### PR TITLE
fix(security): swap hardcoded sample creds for .env in load_psql.sh (#60)

### DIFF
--- a/code/bash_scripts/load_psql.sh
+++ b/code/bash_scripts/load_psql.sh
@@ -1,11 +1,29 @@
-export PGHOST="localhost"
-export PGUSER="dheerajchand"
-export PGPASSWORD="dessert"
-export PGPORT="54321"
-export PGDATABASE="gis"
+#!/usr/bin/env bash
+#
+# Load TIGER shapefiles into PostGIS.
+#
+# Reads connection settings from .env -- mirrors the dev/sw.zsh and
+# Makefile conventions used elsewhere in the repo. Sample defaults that
+# were previously hardcoded here have been removed (#60).
+#
+# Usage:
+#   source <(grep -v '^#' .env | xargs -I {} echo export {})
+#   bash code/bash_scripts/load_psql.sh
+#
+# Or run via Makefile / docker compose where .env is already loaded.
 
-schema="public"
-tabblock_projection=4269
+set -euo pipefail
+
+# Connection settings from environment. Fallbacks match docker-compose
+# service names so the script also works inside a running container.
+export PGHOST="${POSTGRES_HOST:-postgis}"
+export PGUSER="${POSTGRES_USER:?POSTGRES_USER must be set (in .env)}"
+export PGPASSWORD="${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (in .env)}"
+export PGPORT="${POSTGRES_PORT:-54324}"
+export PGDATABASE="${POSTGRES_DB:-gis}"
+
+schema="${LOAD_PSQL_SCHEMA:-public}"
+tabblock_projection="${LOAD_PSQL_SRID:-4269}"
 
 SOURCE_DIR='./downloads'
 ZIP_DIR="./unzipped"
@@ -16,5 +34,5 @@ for shapefile in $(find downloads/ -type f -name '*.shp');
  do
    tablename="$(basename "$shapefile" .shp)"
    echo $tablename
-   shp2pgsql -d -I -s $tabblock_projection $shapefile $schema.$tablename| psql
+   shp2pgsql -d -I -s $tabblock_projection $shapefile $schema.$tablename | psql
  done


### PR DESCRIPTION
Closes #60.

## Summary

\`code/bash_scripts/load_psql.sh\` previously had hardcoded sample credential values (\`PGUSER=\"dheerajchand\"\`, \`PGPASSWORD=\"dessert\"\`, etc.) at the top of the file. Operator confirmed the values were never real credentials -- just early-dev sample defaults -- but the hardcoded shape pattern-matches as a credential leak to scanning bots and to anyone reading the public repo cold.

This PR replaces the hardcoded values with .env sourcing that mirrors the existing convention in \`dev/sw.zsh\` and the Makefile.

## Changes

- Reads \`POSTGRES_HOST / USER / PASSWORD / PORT / DB\` from .env (matches \`.env.example\`).
- \`POSTGRES_USER\` and \`POSTGRES_PASSWORD\` use \`\${VAR:?msg}\` syntax so the script fails fast with a clear error if .env was not loaded.
- \`POSTGRES_HOST\` defaults to \`postgis\` (the docker-compose service name) so the script works inside a running container.
- Added shebang, \`set -euo pipefail\`, usage comment.
- Cosmetic: space before \`| psql\` for readability.

## Test plan

- [ ] Source .env, run \`bash code/bash_scripts/load_psql.sh\` against a directory containing TIGER zips; confirm tables load into PostGIS.
- [ ] Run without sourcing .env: confirm the script exits non-zero with a clear message about POSTGRES_USER / POSTGRES_PASSWORD.

## Context

Surfaced during phase 1 E4.6 (#59) audit of variant flat shell scripts; the same file (with same hardcoded values) existed in both target and variant. Cross-references in security finding #60.

## Verified-by

- \`grep -E 'PGPASSWORD|dessert|dheerajchand' code/bash_scripts/load_psql.sh\` -- only match is the env-var reference \`\${POSTGRES_PASSWORD:?...}\`; no hardcoded literals remain.
- \`bash -n code/bash_scripts/load_psql.sh\` -- syntax OK.
- Non-ASCII scan: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Database connection settings are now configurable through environment variables with built-in defaults
  * Improved error handling during data loading operations
  * Schema and spatial projection parameters are now customizable via environment variables

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->