### PR TITLE
feat(infra): add SedonaDB JupyterLab service to docker-compose (#64)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,12 @@ NEO4J_HEAP=512m
 NEO4J_PAGECACHE=512m
 NEO4J_PASSWORD=CHANGEME
 
+# --- SedonaDB (opt-in: --profile sedonadb or --profile full) ---
+# JupyterLab-wrapped Apache SedonaDB analytical engine for interactive
+# exploration. Local-dev only (no auth on JupyterLab). Port bound to
+# 127.0.0.1 to avoid LAN exposure.
+SEDONADB_PORT=8889
+
 # --- Census data (used by swh CLI) ---
 CENSUS_YEAR=2023
 CENSUS_CONGRESS_NUMBER=118

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,10 @@ up:  ## Start PostGIS + Python (default profile)
 up-spark:  ## Start with Spark cluster
 	$(DKC) --profile spark up -d
 
-up-full:  ## Start everything (Spark + Zeppelin + Maven)
+up-sedonadb:  ## Start with SedonaDB JupyterLab service
+	$(DKC) --profile sedonadb up -d
+
+up-full:  ## Start everything (Spark + Zeppelin + Maven + SedonaDB)
 	$(DKC) --profile full up -d
 
 down:  ## Stop all services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -250,7 +250,29 @@ services:
       timeout: 10s
       retries: 5
 
+  # ---------------------------------------------------------------------------
+  # SedonaDB -- single-node analytical database (Apache Sedona team).
+  # Distributed as a Python library; this container wraps it in JupyterLab
+  # for interactive exploration. Local-dev only (no auth). Opt-in profile.
+  # ---------------------------------------------------------------------------
+  sedonadb:
+    build:
+      context: docker/sedonadb
+      args:
+        - UBUNTU_BASE_IMAGE=${UBUNTU_BASE_IMAGE:-ubuntu:24.04}
+        - PYTHON_VENV_PATH=${PYTHON_VENV_PATH:-/opt/venv}
+    image: swh-sedonadb-image
+    ports:
+      - "127.0.0.1:${SEDONADB_PORT:-8889}:${SEDONADB_PORT:-8889}"
+    environment:
+      - SEDONADB_PORT=${SEDONADB_PORT:-8889}
+    volumes:
+      - swh_sedonadb_data:/home/sedonadb/work
+    restart: unless-stopped
+    profiles: [sedonadb, full]
+
 volumes:
   swh_pg_data:
   swh_neo4j_data:
   swh_neo4j_logs:
+  swh_sedonadb_data:

--- a/docker/sedonadb/Dockerfile
+++ b/docker/sedonadb/Dockerfile
@@ -1,0 +1,50 @@
+# Social Warehouse -- SedonaDB JupyterLab Image
+#
+# Apache SedonaDB is a single-node analytical database engine with
+# geospatial as a first-class citizen. It's distributed as a Python
+# library (apache-sedona[db]); there's no official server image. This
+# Dockerfile wraps SedonaDB in a JupyterLab notebook environment so it
+# can be explored interactively in a browser.
+#
+# Local-dev only: no Jupyter token, no TLS. Production hardening is a
+# followup if SedonaDB graduates from "immature" to "keep" (#64).
+
+ARG UBUNTU_BASE_IMAGE=ubuntu:24.04
+FROM ${UBUNTU_BASE_IMAGE}
+
+ARG PYTHON_VENV_PATH=/opt/venv
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ---- OS packages ----
+# GDAL is for geopandas + shapely interop (SedonaDB consumes/produces
+# GeoParquet, geopandas DataFrames). build-essential supports any wheel
+# fallbacks.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        tzdata build-essential ca-certificates curl \
+        python3-pip python3-venv \
+        gdal-bin libgdal-dev \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# ---- Python venv ----
+RUN python3 -m venv ${PYTHON_VENV_PATH}
+ENV PATH="${PYTHON_VENV_PATH}/bin:${PATH}"
+
+# ---- GDAL (must match system version) ----
+RUN pip install --upgrade pip \
+    && pip install GDAL=="$(gdal-config --version).*"
+
+# ---- Python dependencies ----
+COPY requirements.txt /tmp/
+RUN pip install -r /tmp/requirements.txt
+
+# ---- Working directory + persistent volume target ----
+RUN mkdir -p /home/sedonadb/work
+WORKDIR /home/sedonadb/work
+
+# ---- Default port: JupyterLab ----
+EXPOSE 8889
+
+# ---- Entrypoint ----
+COPY entrypoint.sh /usr/local/bin/sedonadb-entrypoint.sh
+RUN chmod +x /usr/local/bin/sedonadb-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/sedonadb-entrypoint.sh"]

--- a/docker/sedonadb/entrypoint.sh
+++ b/docker/sedonadb/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# SedonaDB JupyterLab entrypoint.
+# Local-dev shape: no token, no password, listens on 0.0.0.0.
+
+set -euo pipefail
+
+PORT="${SEDONADB_PORT:-8889}"
+
+echo "Starting JupyterLab with SedonaDB on port ${PORT}"
+echo "Access at: http://localhost:${PORT}"
+echo ""
+echo "Quickstart in a notebook:"
+echo "  import sedona.db"
+echo "  con = sedona.db.connect()"
+echo "  con.sql(\"SELECT ST_Point(1, 2)\").show()"
+echo ""
+
+exec jupyter lab \
+    --ip=0.0.0.0 \
+    --port="${PORT}" \
+    --no-browser \
+    --allow-root \
+    --ServerApp.token='' \
+    --ServerApp.password='' \
+    --ServerApp.disable_check_xsrf=True

--- a/docker/sedonadb/requirements.txt
+++ b/docker/sedonadb/requirements.txt
@@ -1,0 +1,9 @@
+# SedonaDB JupyterLab container Python dependencies.
+
+apache-sedona[db]>=0.3.0
+jupyterlab>=4.2
+geopandas>=1.1
+pandas>=2.2
+pyarrow>=15.0
+shapely>=2.1
+pyproj>=3.7


### PR DESCRIPTION
Closes #64.

## Summary

Per operator (2026-05-15): "Let's add the container for SedonaDB, we can drop it later. It is a little immature but I think it's cool."

Apache SedonaDB is the Sedona team's single-node analytical database engine (Rust-based, geospatial as a first-class citizen). Latest 0.3.0 (March 2026). Distributed as a Python library (`pip install "apache-sedona[db]"`); there is no official Docker server image. This PR wraps SedonaDB in a JupyterLab notebook environment so it can be explored interactively in a browser.

## Files

- **`docker/sedonadb/Dockerfile`** (new): ubuntu:24.04 base, Python venv, GDAL, installs `apache-sedona[db]>=0.3.0` + JupyterLab + geo deps. Mirrors the `docker/python-computation/` structure.
- **`docker/sedonadb/requirements.txt`** (new): `apache-sedona[db]>=0.3.0`, `jupyterlab>=4.2`, geopandas, pandas, pyarrow, shapely, pyproj.
- **`docker/sedonadb/entrypoint.sh`** (new): starts JupyterLab on `${SEDONADB_PORT:-8889}`, no token, no password (local-dev only).
- **`docker-compose.yml`**: new `sedonadb` service. `profiles: [sedonadb, full]` so it does NOT start in default `make up`. Port bound to `127.0.0.1` to avoid LAN exposure. Persistent volume `swh_sedonadb_data` mounted at `/home/sedonadb/work` for notebook state.
- **`.env.example`**: `SEDONADB_PORT` (default 8889) with documentation comment.
- **`Makefile`**: new `up-sedonadb` target. `up-full` updated to mention SedonaDB (already covered via the `full` profile).

## Verification

```
$ docker compose --profile sedonadb config --services
sedonadb
redis
postgis
web
neo4j
celery-worker
python-computation

$ docker compose config --services        # default profile (no sedonadb)
redis
postgis
web
neo4j
celery-worker
python-computation
# (sedonadb correctly absent -- opt-in confirmed)

$ bash -n docker/sedonadb/entrypoint.sh
shell syntax OK

$ python3 -c "import re; ..."             # non-ASCII scan
docker/sedonadb/Dockerfile: CLEAN
docker/sedonadb/requirements.txt: CLEAN
docker/sedonadb/entrypoint.sh: CLEAN
```

## Test plan (operator-side, after merge)

- [ ] `cp .env.example .env` (set NEO4J_PASSWORD + POSTGRES_PASSWORD).
- [ ] `make up-sedonadb` (or `docker compose --profile sedonadb up -d`).
- [ ] Browser to `http://localhost:8889` -- JupyterLab loads.
- [ ] In a notebook: `import sedona.db; con = sedona.db.connect(); con.sql("SELECT ST_Point(1, 2)").show()`.

## Out of scope (followups if SedonaDB graduates from "immature" to "keep")

- JupyterLab auth (token / password / TLS).
- CI smoke test that the service comes up.
- Wiki template update mentioning the new service -- deferred until PR #63 (the wiki generator port) merges. Will add a SedonaDB section to `scripts/wiki-templates/Configuration.md` in a follow-up PR.

## References

- https://github.com/apache/sedona-db
- https://sedona.apache.org/sedonadb/latest/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SedonaDB service with JupyterLab interface for interactive geospatial and data analysis
  * New command available to start SedonaDB service (accessible via port 8889 by default)
  * Includes Apache Sedona database with geospatial and data analysis libraries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->