### PR TITLE
feat(infra): wire GST as a git submodule at vendor/geodjango_simple_template/ (#66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5
@@ -98,6 +100,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Set up environment
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "vendor/geodjango_simple_template"]
+	path = vendor/geodjango_simple_template
+	url = git@github.com:siege-analytics/geodjango_simple_template.git
+	branch = main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,14 +12,16 @@ Socialwarehouse is a data warehouse and delta lake for geographic, demographic, 
 
 **siege_utilities** = kitchen equipment — single-serving geographic operations (geocode, boundary lookup, demographics)
 **socialwarehouse** = the restaurant — uses SU's verbs to run geocoding, boundary management, and Census warehousing at massive scale
+**geodjango_simple_template** (GST) = the dining room template — webapp scaffold pulled in as a git submodule at `vendor/geodjango_simple_template/` (pinned). SW uses GST for the web-app side; GST stays independently usable.
 **pure-translation / enterprise** = a franchise — FEC campaign finance application that consumes SW
 
 ## Package Structure
 
-Two packages coexist:
+Three layers coexist:
 
 - `swh/` — CLI tool for Census data downloading and PostGIS loading (pre-existing)
 - `socialwarehouse/` — Django application with geographic warehouse, star schema, DSTK API, Celery tasks
+- `vendor/geodjango_simple_template/` — git submodule (GST), pinned snapshot of [siege-analytics/geodjango_simple_template](https://github.com/siege-analytics/geodjango_simple_template). Provides Django web-app scaffold (locations, dstk_api, fec_loader, utilities, vue-frontend). P1B-A wires the path via `sys.path` in `manage.py`; P1B-B will absorb GST's apps into SW's INSTALLED_APPS.
 
 ```
 socialwarehouse/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ Intended growth:
 - Media markets
 - Officials and jurisdictions
 
+## Cloning
+
+This repo uses a git submodule for the GeoDjango template (GST) at `vendor/geodjango_simple_template/`. Clone with submodules:
+
+```bash
+git clone --recurse-submodules git@github.com:siege-analytics/socialwarehouse.git
+```
+
+If you already have a clone without submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+The GST submodule is a pinned snapshot of [siege-analytics/geodjango_simple_template](https://github.com/siege-analytics/geodjango_simple_template). To bump the pin: `cd vendor/geodjango_simple_template && git fetch && git checkout <new-sha> && cd ../.. && git add vendor/geodjango_simple_template && git commit`.
+
 ## Using
 
 It's recommended to use `make` to run the `docker compose` commands below because we are auto-generating `docker-compose.yml` and `.env` files. Because of the magic of `make`, changes to the source includes will automatically trigger a re-make of the compose files.*See below for more on how to work with the auto-generation*.

--- a/dev/sw.zsh
+++ b/dev/sw.zsh
@@ -15,6 +15,19 @@
 # =================================================================
 
 # -----------------------------------------------------------------
+# GST submodule init check
+# -----------------------------------------------------------------
+# vendor/geodjango_simple_template/ is a git submodule. If the clone
+# was done without --recurse-submodules, the directory exists but is
+# empty -- warn the operator instead of letting Django imports silently
+# resolve to nothing later.
+if [[ -d "vendor/geodjango_simple_template" && ! -e "vendor/geodjango_simple_template/app" ]]; then
+    echo "⚠️  GST submodule not initialised. Run:"
+    echo "      git submodule update --init --recursive"
+    echo "   See README.md \"Cloning\" for details."
+fi
+
+# -----------------------------------------------------------------
 # Load framework modules
 # -----------------------------------------------------------------
 _SW_MODULES="${ZSHRC_CONFIG_DIR:-$HOME/.config/zsh}/modules"

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,16 @@
 """Django's command-line utility for socialwarehouse."""
 import os
 import sys
+from pathlib import Path
+
+# GST submodule: vendor/geodjango_simple_template/app/ holds GST's
+# `hellodjango` Django package. Inserted at the start of sys.path so
+# `import hellodjango.locations` etc. resolves once the submodule is
+# initialised. P1B-A wires the path; P1B-B will add GST apps to
+# INSTALLED_APPS. See plans/p1b-gst-submodule-design.md (#66).
+_GST_APP = Path(__file__).resolve().parent / "vendor" / "geodjango_simple_template" / "app"
+if _GST_APP.is_dir() and str(_GST_APP) not in sys.path:
+    sys.path.insert(0, str(_GST_APP))
 
 
 def main():


### PR DESCRIPTION
Closes #66.

## Summary

First half of P1B (GST submodule integration). Pure mechanism: adds GST as a git submodule at `vendor/geodjango_simple_template/`, wires `manage.py` to add the submodule's `app/` to `sys.path`, updates CI checkout, documents the clone-with-submodules workflow. Does NOT touch `INSTALLED_APPS`, URL routing, or settings — that's P1B-B.

Operator-locked decisions per design note (`plans/p1b-gst-submodule-design.md`, session 260502-vital-channel, approved 2026-05-15 22:34 CT):

- **Mechanism**: git submodule.
- **Architecture target**: one Django process; SW's `manage.py` is the entry point; GST's apps will be absorbed into SW's `INSTALLED_APPS` in P1B-B.
- **Submodule path**: `vendor/geodjango_simple_template/`.
- **Initial pin**: GST canonical HEAD `a607864` (2026-05-15).
- **GST canonical** stays as a standalone repo, independently usable for non-SW projects.

## Files

- **`.gitmodules`** (new): declares the submodule.
- **`vendor/geodjango_simple_template`** (new submodule): pinned to `a607864`.
- **`manage.py`**: inserts `vendor/geodjango_simple_template/app/` at the start of `sys.path` before `django.core.management` import. Conditional on directory existing so a fresh-clone-without-`--recurse-submodules` doesn't break the SW Django bootstrap entirely (GST just won't be visible).
- **`.github/workflows/ci.yml`**: both checkout steps gain `with: submodules: recursive` so the GST submodule is populated in CI.
- **`README.md`**: new "Cloning" section above "Using" — documents `--recurse-submodules` clone and the `git submodule update --init` fallback for existing clones, plus the pin-bump procedure.
- **`dev/sw.zsh`**: warns at source-time if `vendor/geodjango_simple_template/app/` is missing, with the init command. Loud, recoverable.
- **`CLAUDE.md`**: adds GST line to the kitchen/restaurant/franchise framing and updates the Package Structure section to list the submodule.

## Out of scope (P1B-B)

- Adding GST apps (`hellodjango.locations`, `.dstk_api`, `.fec_loader`, `.utilities`) to `INSTALLED_APPS`.
- Including GST URLs from `socialwarehouse/urls.py`.
- Settings changes for templates / static files.
- Reconciling SW `api/` vs GST `dstk_api/` (P1C.1).
- Reconciling SW `geo/Address` vs GST `locations/Place` (P1C.2).

## Verification

```
$ git submodule status
 a607864a5fb98be72eb35a907cf25f00032c2815 vendor/geodjango_simple_template (heads/main)

$ python3 -c "import sys; sys.path.insert(0, 'vendor/geodjango_simple_template/app'); import os; print(os.path.isdir('vendor/geodjango_simple_template/app/hellodjango/locations'))"
True

$ python3 -m py_compile manage.py
# (silent -- compiles OK)

$ zsh -n dev/sw.zsh
# (silent -- syntax OK)

$ bash skills/meta/detect-ai-fingerprints/scan.sh
clean.
```

## Test plan (operator-side, after merge)

- [ ] In a fresh clone (no `--recurse-submodules`): confirm `dev/sw.zsh` warns about missing submodule.
- [ ] Run `git submodule update --init`: confirm the warning goes away.
- [ ] `python manage.py check` -- no errors from the path insertion.
- [ ] CI run: confirm `git submodule status` reports `a607864` in the workflow log.

## Known unrelated CI failures inherited from develop

- **Test suite**: `siege_geo_county` table missing in test DB (#62).
- **Docker build (core)**: GDAL wheel build issue.

This PR does not touch code paths that affect either failure. If both fail the same way as develop's head, admin-merge per the established pattern.

## Followups

- **#67 (will be filed at merge)**: P1B-B — absorb GST apps into SW's Django.
- P1C.1 (api reconciliation), P1C.2 (Address vs Place reconciliation): after P1B-B.
