### PR TITLE
fix(docker): entrypoint.sh execs command args (#75)

### DIFF
--- a/docker/python-computation/entrypoint.sh
+++ b/docker/python-computation/entrypoint.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-# Install the swh package in editable mode from the mounted volume,
-# then keep the container running for interactive use.
+# Install the swh package in editable mode from the mounted volume.
+# With args: exec the requested command (one-shot use, e.g. CI).
+# Without args: keep the container running for interactive use.
 
 if [ -f /opt/social_warehouse/pyproject.toml ]; then
     pip install -e /opt/social_warehouse/ --quiet 2>/dev/null
 fi
 
 trap : TERM INT
-tail -f /dev/null & wait
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+else
+    tail -f /dev/null & wait
+fi


### PR DESCRIPTION
Closes #75.

`docker compose run --rm python-computation python manage.py check` hung in CI on PR #73 for ~3 hours because the entrypoint ignored CMD args and ran `tail -f /dev/null` forever. Adds standard `exec "$@"` pattern with tail-loop fallback when no args are supplied.

untested locally; first exercise is CI.

## Test plan
- [ ] CI's `Django check inside container` step completes
- [ ] Interactive dev workflow (`docker compose up python-computation`) still keeps container alive
- [ ] Once #73 (python3-dev) lands, sequence: #73 first, then #75 to validate full chain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Python computation container startup with flexible command execution support and improved keep-alive mode
  * Maintained signal handling for graceful shutdown during container lifecycle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->