### PR TITLE
chore: sync python3-dev fix from main to develop

### DIFF
--- a/docker/python-computation/Dockerfile
+++ b/docker/python-computation/Dockerfile
@@ -12,7 +12,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # ---- OS packages ----
 RUN apt-get update && apt-get install -y --no-install-recommends \
         tzdata build-essential wget ca-certificates \
-        python3-pip python3-venv python3-pyproj \
+        python3-pip python3-venv python3-dev python3-pyproj \
         gdal-bin libgdal-dev \
         postgresql-client \
         vim \

--- a/docker/sedonadb/Dockerfile
+++ b/docker/sedonadb/Dockerfile
@@ -21,7 +21,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 # fallbacks.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         tzdata build-essential ca-certificates curl \
-        python3-pip python3-venv \
+        python3-pip python3-venv python3-dev \
         gdal-bin libgdal-dev \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/docker/spark/Dockerfile
+++ b/docker/spark/Dockerfile
@@ -19,7 +19,7 @@ ARG SCALA_VERSION=2.13.14
 RUN apt-get update && apt-get install -y --no-install-recommends \
         tzdata sudo curl vim unzip zip rsync wget \
         build-essential software-properties-common ssh \
-        python3-pip python3-venv python3-pyproj \
+        python3-pip python3-venv python3-dev python3-pyproj \
         gdal-bin libgdal-dev \
         postgresql-client \
     && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Cherry-picks 78a99d5 (originally #73) from main onto develop. #73 was accidentally targeted at main instead of develop; this sync unblocks #76 (entrypoint fix) and #74 (submodule bump) which both target develop and need python3-dev underneath them.

sedonadb Dockerfile had a trivial conflict (develop's version differed by formatting in the same hunk); resolved to include python3-dev. python-computation and spark Dockerfiles applied cleanly.

The larger main/develop divergence (main is +2, develop is +19) is left for separate reconciliation.