### PR TITLE
fix(api/geo): correct cache decorator + log geocoder failures (#112, #114)

### DIFF
--- a/socialwarehouse/api/geo/views.py
+++ b/socialwarehouse/api/geo/views.py
@@ -6,13 +6,15 @@ spatial queries.
 """
 
 import json
+import logging
 
 from django.contrib.gis.geos import Point
-from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from rest_framework import status
 from rest_framework.decorators import api_view, throttle_classes
 from rest_framework.response import Response
+
+logger = logging.getLogger("socialwarehouse.api.geo")
 
 from socialwarehouse.api.pagination import GeoJSONPagination, StandardPagination
 from socialwarehouse.api.throttling import BulkExportThrottle, GeocodeThrottle
@@ -244,7 +246,7 @@ def boundary_list(request, boundary_type):
 
 
 @api_view(["GET"])
-@method_decorator(cache_page(60 * 60 * 24 * 7), name="dispatch")
+@cache_page(60 * 60 * 24 * 7)
 def boundary_detail(request, boundary_type, geoid):
     """Retrieve a single boundary by type and GEOID. Always includes geometry."""
     model = BOUNDARY_MODELS.get(boundary_type)
@@ -376,19 +378,32 @@ def intersections(request):
 # --- Internal helpers ---
 
 def _forward_geocode(address):
-    """Forward geocode via Nominatim. Returns (lat, lon) or None."""
+    """Forward geocode via Nominatim. Returns (lat, lon) or None.
+
+    Returns None on miss OR on failure; failures are logged at WARNING so
+    operators can distinguish "no result" from "geocoder down / network /
+    malformed query." Per writing-code:7 (no silent error swallowing).
+    """
     try:
         from siege_utilities.geo.geocoding import get_coordinates
         result = get_coordinates(address, country_codes=["us"])
         if result and result.latitude and result.longitude:
             return (result.latitude, result.longitude)
-    except Exception:
-        pass
-    return None
+        return None
+    except Exception as e:
+        logger.warning(
+            "_forward_geocode failed for address=%r: %s: %s",
+            address, type(e).__name__, e,
+        )
+        return None
 
 
 def _reverse_geocode(lat, lon):
-    """Reverse geocode via Nominatim. Returns address dict or None."""
+    """Reverse geocode via Nominatim. Returns address dict or None.
+
+    Returns None on miss OR on failure; failures are logged at WARNING.
+    Per writing-code:7 (no silent error swallowing).
+    """
     try:
         from geopy.geocoders import Nominatim
         geolocator = Nominatim(user_agent="socialwarehouse-api")
@@ -400,9 +415,13 @@ def _reverse_geocode(lat, lon):
                 "lon": location.longitude,
                 "raw": location.raw.get("address", {}),
             }
-    except Exception:
-        pass
-    return None
+        return None
+    except Exception as e:
+        logger.warning(
+            "_reverse_geocode failed for lat=%s lon=%s: %s: %s",
+            lat, lon, type(e).__name__, e,
+        )
+        return None
 
 
 def _standardize_address(address):

--- a/tests/unit/api/test_geo_views_decorators.py
+++ b/tests/unit/api/test_geo_views_decorators.py
@@ -9,13 +9,49 @@ with `except Exception: pass`, hiding geocoder/network failures from operators.
 These tests are designed to GO RED on revert.
 """
 
-import inspect
 import logging
+import re
+from pathlib import Path
 from unittest import mock
 
 from django.test import TestCase
 
 from socialwarehouse.api.geo import views
+
+# Read the module file as text. `inspect.getsource(views.<decorated_fn>)`
+# returns the DRF api_view closure wrapper, not the actual source — so for
+# source-shape regressions we read the file directly. Per writing-tests
+# inspection-vs-behavior note: source-grep tests must inspect text, not
+# decorated function objects.
+_VIEWS_FILE = Path(views.__file__)
+_VIEWS_SOURCE = _VIEWS_FILE.read_text(encoding="utf-8")
+
+
+def _function_block(name):
+    """Return the decorator stack + def header + body for a top-level function.
+
+    Walks the source line-by-line, finds `def <name>(`, walks backwards
+    through immediately-preceding `@`-decorator lines, and walks forward
+    until the next top-level `def `/`class ` or end of file. Sufficient
+    for shape-of-decorators checks.
+    """
+    lines = _VIEWS_SOURCE.splitlines()
+    def_idx = None
+    for i, line in enumerate(lines):
+        if line.startswith(f"def {name}("):
+            def_idx = i
+            break
+    if def_idx is None:
+        return ""
+    start = def_idx
+    while start > 0 and lines[start - 1].startswith("@"):
+        start -= 1
+    end = def_idx + 1
+    while end < len(lines) and not (
+        lines[end].startswith("def ") or lines[end].startswith("class ")
+    ):
+        end += 1
+    return "\n".join(lines[start:end])
 
 
 class TestBoundaryDetailCacheDecorator(TestCase):
@@ -27,17 +63,16 @@ class TestBoundaryDetailCacheDecorator(TestCase):
         Goes red if anyone re-introduces the method_decorator(..., name="dispatch")
         shape on this function-based view.
         """
-        src = inspect.getsource(views.boundary_detail)
-        assert "@cache_page(" in src, "boundary_detail must have @cache_page applied directly"
-        assert 'name="dispatch"' not in src and "name='dispatch'" not in src, (
+        block = _function_block("boundary_detail")
+        assert "@cache_page(" in block, "boundary_detail must have @cache_page applied directly"
+        assert 'name="dispatch"' not in block and "name='dispatch'" not in block, (
             "method_decorator(..., name='dispatch') is class-based-view shape; "
             "function-based DRF views have no dispatch attribute"
         )
 
     def test_boundary_detail_module_does_not_import_method_decorator(self):
         """method_decorator import was removed as part of the A1 fix."""
-        src = inspect.getsource(views)
-        assert "from django.utils.decorators import method_decorator" not in src
+        assert "from django.utils.decorators import method_decorator" not in _VIEWS_SOURCE
 
 
 class TestGeocodeHelpersLogFailures(TestCase):
@@ -66,10 +101,15 @@ class TestGeocodeHelpersLogFailures(TestCase):
         assert any("RuntimeError" in msg for msg in cm.output)
 
     def test_geocode_helper_sources_have_no_bare_except_pass(self):
-        """Goes red if anyone restores `except Exception: pass` in either helper."""
-        for fn in (views._forward_geocode, views._reverse_geocode):
-            src = inspect.getsource(fn)
-            normalized = "\n".join(line.rstrip() for line in src.splitlines())
+        """Goes red if anyone restores `except Exception: pass` in either helper.
+
+        Helpers are non-decorated module-level functions, so reading the file
+        text is the same shape as inspect.getsource — but we use file text
+        for uniformity with the boundary_detail tests above.
+        """
+        for fn_name in ("_forward_geocode", "_reverse_geocode"):
+            block = _function_block(fn_name)
+            normalized = "\n".join(line.rstrip() for line in block.splitlines())
             assert "except Exception:\n        pass" not in normalized, (
-                f"{fn.__name__} must not silently swallow exceptions (writing-code:7)"
+                f"{fn_name} must not silently swallow exceptions (writing-code:7)"
             )

--- a/tests/unit/api/test_geo_views_decorators.py
+++ b/tests/unit/api/test_geo_views_decorators.py
@@ -1,0 +1,75 @@
+"""Regression tests for socialwarehouse.api.geo.views fixes.
+
+A1 (gh #112): boundary_detail used `@method_decorator(cache_page, name="dispatch")`,
+which is class-based-view shape and silently no-ops on function-based DRF views.
+
+A3 (gh #114): `_forward_geocode` / `_reverse_geocode` swallowed all exceptions
+with `except Exception: pass`, hiding geocoder/network failures from operators.
+
+These tests are designed to GO RED on revert.
+"""
+
+import inspect
+import logging
+from unittest import mock
+
+from django.test import TestCase
+
+from socialwarehouse.api.geo import views
+
+
+class TestBoundaryDetailCacheDecorator(TestCase):
+    """A1: boundary_detail must use cache_page directly (not method_decorator)."""
+
+    def test_boundary_detail_source_uses_cache_page_directly(self):
+        """The source must apply @cache_page above the function, not via method_decorator(name='dispatch').
+
+        Goes red if anyone re-introduces the method_decorator(..., name="dispatch")
+        shape on this function-based view.
+        """
+        src = inspect.getsource(views.boundary_detail)
+        assert "@cache_page(" in src, "boundary_detail must have @cache_page applied directly"
+        assert 'name="dispatch"' not in src and "name='dispatch'" not in src, (
+            "method_decorator(..., name='dispatch') is class-based-view shape; "
+            "function-based DRF views have no dispatch attribute"
+        )
+
+    def test_boundary_detail_module_does_not_import_method_decorator(self):
+        """method_decorator import was removed as part of the A1 fix."""
+        src = inspect.getsource(views)
+        assert "from django.utils.decorators import method_decorator" not in src
+
+
+class TestGeocodeHelpersLogFailures(TestCase):
+    """A3: _forward_geocode / _reverse_geocode must log exceptions, not swallow."""
+
+    def test_forward_geocode_logs_on_exception(self):
+        with mock.patch(
+            "siege_utilities.geo.geocoding.get_coordinates",
+            side_effect=RuntimeError("geocoder down"),
+        ):
+            with self.assertLogs("socialwarehouse.api.geo", level="WARNING") as cm:
+                result = views._forward_geocode("123 Main St")
+        assert result is None
+        assert any("_forward_geocode failed" in msg for msg in cm.output)
+        assert any("RuntimeError" in msg for msg in cm.output)
+
+    def test_reverse_geocode_logs_on_exception(self):
+        with mock.patch(
+            "geopy.geocoders.Nominatim",
+            side_effect=RuntimeError("nominatim unreachable"),
+        ):
+            with self.assertLogs("socialwarehouse.api.geo", level="WARNING") as cm:
+                result = views._reverse_geocode(40.0, -74.0)
+        assert result is None
+        assert any("_reverse_geocode failed" in msg for msg in cm.output)
+        assert any("RuntimeError" in msg for msg in cm.output)
+
+    def test_geocode_helper_sources_have_no_bare_except_pass(self):
+        """Goes red if anyone restores `except Exception: pass` in either helper."""
+        for fn in (views._forward_geocode, views._reverse_geocode):
+            src = inspect.getsource(fn)
+            normalized = "\n".join(line.rstrip() for line in src.splitlines())
+            assert "except Exception:\n        pass" not in normalized, (
+                f"{fn.__name__} must not silently swallow exceptions (writing-code:7)"
+            )


### PR DESCRIPTION
## Summary

Bundled fix for two MAJOR findings from the E1 hostile review of `socialwarehouse/api/` (E1 parent: #49).

- **A1 (#112)** — `boundary_detail` had `@method_decorator(cache_page(...), name="dispatch")`, the class-based-view shape. Function-based DRF views have no `dispatch`, so the intended 7-day cache silently no-op'd. Apply `@cache_page` directly.
- **A3 (#114)** — `_forward_geocode` / `_reverse_geocode` used `except Exception: pass`, hiding geocoder / network / malformed-input failures. Log at WARNING with exception type + message + inputs.

### Not in this PR

- **A2 (#113)** — retracted as false positive: `DemographicSnapshot.object_id` IS `CharField`, geoid-keyed (verified at `siege_utilities/geo/django/models/demographics.py:157`). Closed with retraction.
- **A4–A10** — MINOR / NIT, tracked separately.

## Test plan

Regression tests in `tests/unit/api/test_geo_views_decorators.py`:
- [ ] `test_boundary_detail_source_uses_cache_page_directly` — source-grep; red if `name="dispatch"` returns.
- [ ] `test_boundary_detail_module_does_not_import_method_decorator` — defensive.
- [ ] `test_forward_geocode_logs_on_exception` — mocked failure + `assertLogs`.
- [ ] `test_reverse_geocode_logs_on_exception` — same shape, reverse helper.
- [ ] `test_geocode_helper_sources_have_no_bare_except_pass` — source-grep regression.

Closes #112
Closes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and logging for geocoding operations to better capture and report failures.

* **Performance**
  * Improved caching mechanism for the boundary detail endpoint for faster response times.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->