### PR TITLE
feat: survey-context project skill + seed entity docs

### DIFF
--- a/.agents/skills/survey-context/config.md
+++ b/.agents/skills/survey-context/config.md
@@ -1,0 +1,35 @@
+# survey-context project skill — socialwarehouse
+
+## Doc root
+
+`docs/entities/` (relative to repo root)
+
+## Entity catalog
+
+| Name | Type | Namespace | Doc page |
+|---|---|---|---|
+| DimGeography | Django model | socialwarehouse.warehouse.models | docs/entities/dim_geography.md |
+| DimTime | Django model | socialwarehouse.warehouse.models | docs/entities/dim_time.md |
+| DimRedistrictingCycle | Django model | socialwarehouse.warehouse.models | docs/entities/dim_redistricting_cycle.md |
+| Address | Django model | socialwarehouse.geo.models | docs/entities/address.md |
+| DemographicSnapshot | Django model | siege_utilities.geo.django.models.demographics | docs/entities/demographic_snapshot.md |
+| api/geo views decorators | DRF decorator surface | socialwarehouse.api.geo.views | docs/entities/api_geo_views_decorators.md |
+
+Seed coverage chosen for E1 hostile-review frequency. Catalog grows on next touch — every `NO-DOC` outcome in survey artifacts is a candidate.
+
+## Ownership
+
+- **Drift findings** file as GitHub issues in `siege-analytics/socialwarehouse`, child of #49 (E1 epic) until E1 closes, then under a dedicated `drift` label.
+- **Doc-update DoD** reviewed by the PR author at self-review time (see [`self-review` skill](../../skills/self-review/SKILL.md)); hook enforcement deferred to v2.1.
+- **Cross-repo entities** (e.g. DemographicSnapshot lives in siege_utilities): doc page lives here; upstream changes that affect SW callers are recorded in the survey log on the local page.
+
+## Recipe extensions
+
+Project-specific recipes live in `recipes/`. Initial set:
+
+- `recipes/census-vintage.md` — TIGER vintage handling, summary_level conventions, geoid-vs-fips-vs-id distinctions.
+- `recipes/django-orm-defaults.md` — `update_or_create(defaults={...})` kwarg validation against Model._meta (mirrors the static scanner at claude-configs-public#117).
+
+## Notes
+
+This is the seed project-skill landing alongside global survey-context v2. Bootstrap is intentionally narrow — 6 entities chosen to ground the contract concretely. Coverage grows organically through the skill's `NO-DOC → seed` path.

--- a/.agents/skills/survey-context/recipes/census-vintage.md
+++ b/.agents/skills/survey-context/recipes/census-vintage.md
@@ -1,0 +1,19 @@
+# Recipe: Census vintage / geoid handling
+
+**Surveyor command:** Read the model definition + the loader + check vintage_year handling across both.
+
+**What to record in the entity page:**
+- `vintage_year` field type, validators, range
+- `geoid` length expectations per `summary_level` (state=2, county=5, tract=11, block_group=12, block=15, cd=4, vtd=11, sldl/sldu varies)
+- Whether the model uses SCD2 (`is_current`, `effective_from/to`) for vintage drift
+- Whether `geoid` is the natural key or merely indexed
+
+**Drift signals:**
+- New `summary_level` value appears in a loader without being documented in the model's help_text or in this skill's per-entity page.
+- `vintage_year` validator range extended (e.g. 2100 → 2200) without commit message naming why.
+- A new fact table joins on `(geography, time)` but doesn't follow the SCD2 lookup convention (`filter(is_current=True)` or `filter(effective_from__lte=date) & filter(effective_to__gte=date|isnull=True)`).
+
+**Common-mistake patterns this recipe catches:**
+- Author assumes `geoid` is fixed-length 11 (tract) and writes a CharField(max_length=11) caller that breaks on block GEOIDs.
+- Author queries `DimGeography.objects.filter(geoid=X)` and gets multiple rows because SCD2 keeps history; missed the `is_current=True` filter.
+- Loader inserts a new vintage without setting `is_current=False` on the prior vintage, so two rows now claim is_current.

--- a/.agents/skills/survey-context/recipes/django-orm-defaults.md
+++ b/.agents/skills/survey-context/recipes/django-orm-defaults.md
@@ -1,0 +1,27 @@
+# Recipe: Django ORM `defaults={...}` kwarg validation
+
+**Surveyor command:**
+
+```bash
+python -c "from <module> import <Model>; print(sorted(f.name for f in <Model>._meta.get_fields()))"
+```
+
+Compare the output against every `defaults={...}` dict in callers.
+
+**What to record in the entity page:**
+- Full `_meta.get_fields()` output (or at least the writable fields callers can pass to `update_or_create`).
+- Any fields that have non-trivial defaults (`auto_now`, `auto_now_add`, `default=callable`) — these are usually NOT to be passed in `defaults`.
+- Any fields callers commonly get wrong (rename history, similar names, fields-on-related-model that look like they're on this one).
+
+**Drift signals:**
+- A loader writes `defaults={"X": ...}` where `X` is not in the entity-page field list.
+- A field was renamed in the model but the entity page still lists the old name.
+- A loader's `defaults` dict is missing a required-non-null field (no default at DB level, no default in model).
+
+**Common-mistake patterns this recipe catches:**
+- W1 / SW#105: loader wrote 6 keys (`day_suffix`, `day_name`, `weekday`, etc.) that aren't on `DimTime`. Consulting the entity page would have shown the actual field list.
+- W2 / SW#106: loader wrote `census_year` when the model had `decennial_census_year`. Renaming the model field was the right fix; the entity page now records the post-fix name so future callers don't reintroduce the old name.
+
+**Composition with scanner #117:**
+
+The static scanner at `claude-configs-public#117` enforces this recipe automatically for same-file models. For **cross-file** model imports (which is the common case in this repo), the scanner punts and this recipe is the author-time check. The survey-context skill consults the entity page rather than re-running introspection.

--- a/.agents/skills/survey-context/templates/entity.md
+++ b/.agents/skills/survey-context/templates/entity.md
@@ -1,0 +1,35 @@
+# <Entity name> (<type>, <namespace>)
+
+**Definition:** `<file:line>`
+**Surveyed at:** YYYY-MM-DD
+**Owner:** <team / role>
+
+## Shape
+
+### Fields / signature / columns
+
+<list — declared fields with type + constraints>
+
+### Constraints
+
+<unique_together, indexes, FK targets, NOT NULL, defaults>
+
+### Lookups / methods of interest
+
+<for Django models: lookups callers rely on; for functions: documented contract>
+
+## Callers / consumers
+
+<grep result trimmed to load-bearing references>
+
+## Cross-references
+
+<FKs in/out, related models, downstream tables / endpoints>
+
+## Known assumptions / gotchas
+
+<things authors get wrong; e.g. "object_id is CharField geoid-string, NOT integer PK">
+
+## Survey log
+
+- YYYY-MM-DD: <what changed / who verified / why update>

--- a/docs/entities/address.md
+++ b/docs/entities/address.md
@@ -1,0 +1,63 @@
+# Address (Django model, socialwarehouse.geo.models)
+
+**Definition:** `socialwarehouse/geo/models/address.py:19`
+**db_table:** `sw_geo_address`
+**Surveyed at:** 2026-05-18
+**Owner:** geo maintainers
+
+## Shape
+
+### Fields (grouped)
+
+**USPS / address components**
+- `primary_number`, `street_name`, `street_suffix`, `city_name`, `default_city_name`, `state_abbreviation` (max 2), `zip5` / `zip4` (TODO confirm exact name), `delivery_point`, `delivery_point_check_digit`, `record_type`, `zip_type`, `county_fips`, `county_name`, `carrier_route`, `congressional_district`, `rdi`, `elot_sequence`, `elot_sort` — all CharField(max_length=250), `null=True, blank=True, default=None` (Django-convention violation; see F3 / SW#92).
+
+**Coordinates**
+- `latitude`, `longitude` — DecimalField(max_digits=22, decimal_places=16), nullable
+- `geom` — PointField(srid=4326), nullable
+- `coordinate_license`, `precision`, `time_zone`, `utc_offset` — CharField, nullable
+
+**Geocoding state**
+- `geocoded` — BooleanField(default=False)
+- `geocode_quality` — CharField, nullable
+- `geocode_source` — CharField, nullable (values used: "census", "nominatim")
+- `geocoded_at` — DateTimeField, nullable
+
+**Census unit assignments**
+- `census_year` — IntegerField, db_index'd
+- `state_geoid` (2), `county_geoid` (5), `tract_geoid` (11), `block_group_geoid` (12), `block_geoid` (15), `vtd_geoid` (11), `cd_geoid` (4), `sldl_geoid`, `sldu_geoid`
+- `census_units_assigned_at` — DateTimeField, nullable
+
+### Constraints
+
+- Surrogate PK: BigAutoField (auto)
+- No unique_together
+- Indexes (10): see Meta block; covers most common filter pairs (state+city, county_fips, cd_district, census_year, geocoded, state+county_geoid, plus year-scoped indexes for cd/vtd/sldl/sldu GEOIDs).
+
+### Methods of interest
+
+- `assign_census_units_from_fips(state_fips, county_fips, tract, block)` — constructs hierarchical GEOIDs from Census Geocoder FIPS output. Mutates instance fields; caller must `.save()`.
+- `populate_foreign_keys()` — populates siege_geo FK refs from GEOIDs.
+
+## Callers / consumers
+
+- `socialwarehouse/geo/management/commands/geocode_addresses.py` — bulk geocoding; calls `assign_census_units_from_fips` + `addr.save()` per address (M2 / SW#146 — should bulk_update).
+- `socialwarehouse/geo/management/commands/assign_boundaries.py` — bulk boundary assignment.
+- `socialwarehouse/geo/management/commands/export_to_delta.py` — exports to bronze tier.
+- API: addresses are not directly exposed via REST (no AddressViewSet at time of survey).
+
+## Cross-references
+
+- No declared FKs on Address itself; GEOIDs are string-keyed against siege_utilities geo models (see DemographicSnapshot doc for the geoid-as-string-key pattern).
+- `populate_foreign_keys()` lazily wires FK relations to siege_utilities boundary models — not part of the schema; runtime hydration.
+
+## Known assumptions / gotchas
+
+- **`null=True` on CharField throughout** is a Django-convention violation (F3 / SW#92): Django convention is `blank=True, default=""`, not `null=True`. The model uses the latter everywhere. Means `filter(field="")` and `filter(field__isnull=True)` return different sets; callers must know which case the data is in.
+- **`geocoded=True` does NOT imply `geom` is set.** M6 / SW#150: matched-without-coords sets `geocoded=True` with `geom=NULL`. Filter `geocoded=True AND geom__isnull=False` if you need both.
+- **`geocode_source` values are free-form strings** (not a choices field). Known values: "census", "nominatim". Add a CHOICES list if a third source appears.
+- **Per-row `.save()` in geocode loop** is the M2 bottleneck — see SW#146.
+
+## Survey log
+
+- 2026-05-18: Seeded from live model. F3/M2/M6 surfaced in E1 review (SW#92, #146, #150).

--- a/docs/entities/api_geo_views_decorators.md
+++ b/docs/entities/api_geo_views_decorators.md
@@ -1,0 +1,52 @@
+# api/geo views decorator surface (DRF, socialwarehouse.api.geo.views)
+
+**Definition:** `socialwarehouse/api/geo/views.py`
+**Surveyed at:** 2026-05-18
+**Owner:** api maintainers
+
+## Shape — what's a function-based view vs class-based view
+
+The file is **function-based throughout**. Every endpoint is `def name(request, ...)` decorated with `@api_view([...])` (rest_framework.decorators).
+
+### Decorator stack convention
+
+```python
+@api_view(["GET"])           # outermost — DRF dispatch
+@throttle_classes([...])     # rate limiting
+@cache_page(seconds)         # Django caching, applied DIRECTLY (not via method_decorator)
+def endpoint(request, ...):
+    ...
+```
+
+Endpoints currently defined (verify against source on each touch):
+
+- `geocode(request)` — forward + reverse via Census + Nominatim
+- `boundary_list(request, boundary_type)` — list endpoint
+- `boundary_detail(request, boundary_type, geoid)` — single boundary; **cache_page direct, NOT method_decorator** (A1 / SW#112 fix)
+- `proximity(request)` — nearest-boundary search
+- `intersections(request)` — overlap query
+- `standardize_address(request)` — fragile parser; A7 finding
+- `reverse_geocode(request)` — coord → address
+
+### Helper conventions
+
+- `_forward_geocode(address)` / `_reverse_geocode(lat, lon)` — return `(lat, lon)` / dict / None on miss; log exceptions at WARNING (A3 / SW#114 fix).
+- `_get_demographics_for_boundaries(model, geoid)` — content_type + geoid lookup against DemographicSnapshot (see demographic_snapshot.md).
+- `_serialize_boundary(obj)` — hasattr-chain serialization (A8 finding).
+- `_standardize_address(address)` — comma-split parser (A7 finding).
+
+## Known assumptions / gotchas
+
+- **`method_decorator(cache_page(...), name="dispatch")` is class-based-view shape ONLY.** `name="dispatch"` references the `dispatch` method which exists on `View` subclasses, not on functions. Applying it to a function-based view silently no-ops the cache (A1 / SW#112 — fixed). Future cache decorators on these endpoints must apply `@cache_page(seconds)` directly.
+- **Geocode helpers return `None` on miss AND on exception.** Per A3 / SW#114, exceptions are logged at WARNING with type + message + inputs. Callers can distinguish "no result" vs "geocoder failure" only via the log; the return value is the same. If a future API surface needs the distinction, change the helpers' contract and update this doc.
+- **No authentication/permission classes** on any view (A9). All endpoints are publicly readable. Document any change.
+- **`BOUNDARY_MODELS` registry** is the canonical list of supported boundary types. Adding a new boundary type requires updating the registry; the lookup-and-error-response pattern is duplicated across 4 endpoints (A6 finding).
+
+## Callers / consumers
+
+- `socialwarehouse/urls.py` (URL routing)
+- Frontend / external clients via REST
+
+## Survey log
+
+- 2026-05-18: Seeded post-PR #122 (A1+A3 fixes). Documents the function-based-view shape that A1 violated. Future PRs that touch decorators or add endpoints must update this page in the same PR.

--- a/docs/entities/demographic_snapshot.md
+++ b/docs/entities/demographic_snapshot.md
@@ -1,0 +1,42 @@
+# DemographicSnapshot (Django model, siege_utilities.geo.django.models.demographics)
+
+**Definition:** `siege_utilities/geo/django/models/demographics.py` (upstream — not in this repo)
+**Surveyed at:** 2026-05-18
+**Owner:** SU maintainers (upstream); SW callers responsible for local survey log
+
+## Shape (relevant fields for SW callers)
+
+| Field | Type | Notes |
+|---|---|---|
+| `content_type` | ForeignKey(ContentType) | generic-FK type half |
+| `object_id` | **CharField(max_length=20)** | **GEOID string** — NOT an integer PK |
+| `content_object` | GenericForeignKey | resolves via (content_type, object_id) |
+| `year` | PositiveSmallIntegerField | db_index'd; 1990-2050 |
+| `dataset` | CharField(max_length=10) | db_index'd; choices from DATASET_CHOICES |
+| `vintage` | PositiveSmallIntegerField | nullable; API vintage may differ from year |
+| `values` | JSONField(default=dict) | variable_code → value |
+| `moe_values` | JSONField(default=dict, blank=True) | variable_code → margin of error |
+| `total_population` | PositiveIntegerField | nullable; db_index'd; computed summary (B01001_001E) |
+| `median_household_income` | PositiveIntegerField | nullable |
+
+(Other computed-summary fields exist; consult upstream for full list.)
+
+### Lookups callers must use correctly
+
+- **`filter(object_id=geoid_string)`** — geoid string-matched. NOT `filter(object_id=int_pk)`.
+- `filter(content_type=ct, object_id=geoid)` — the canonical SW pattern.
+- `filter(year=..., dataset=...)` — time + source scoping.
+
+## Callers / consumers (SW)
+
+- `socialwarehouse/api/geo/views.py:_get_demographics_for_boundaries` — queries by content_type + geoid. The original A2 review (SW#113) incorrectly claimed this query was broken because `object_id` was assumed integer; verifying the field type via this page shows the existing query is correct.
+
+## Known assumptions / gotchas
+
+- **`object_id` is CharField geoid-string, NOT IntegerField PK.** This is the canonical example of why this skill exists: a reviewer (and would-be author) without consulting upstream model can incorrectly assume Django's generic-FK convention (object_id = int PK pointing at content_type.id). For SU's boundary models, the design is geoid-keyed for stability across vintages — boundary PK can change but geoid does not.
+- **`values` / `moe_values` are JSONFields** — variable codes appear as JSON keys, NOT as columns. Don't try `filter(values__B01001_001E=...)` portably across DB engines; use JSONField KeyTransform with care.
+- **Cross-app dependency.** Upstream changes affect SW callers. Local survey log records SU-version where the shape was last verified.
+
+## Survey log
+
+- 2026-05-18: Seeded after the A2 / SW#113 retraction. SU upstream (commit unrecorded; verify at next survey) confirms `object_id = CharField(max_length=20)`. This is the worked example in the global skill demonstrating the value of the consult-docs step.

--- a/docs/entities/dim_geography.md
+++ b/docs/entities/dim_geography.md
@@ -1,0 +1,61 @@
+# DimGeography (Django model, socialwarehouse.warehouse.models)
+
+**Definition:** `socialwarehouse/warehouse/models/dimensions.py:12`
+**Surveyed at:** 2026-05-18
+**Owner:** warehouse maintainers
+
+## Shape
+
+### Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `geoid` | CharField(max_length=20) | db_index; Census GEOID (e.g. "06037") |
+| `name` | CharField(max_length=255) | |
+| `vintage_year` | PositiveSmallIntegerField | db_index; validated 1790-2100 |
+| `summary_level` | CharField(max_length=30) | db_index; state/county/tract/blockgroup/place/cd/zcta |
+| `state_fips` | CharField(max_length=2) | db_index; blank=True default="" |
+| `geometry` | MultiPolygonField(srid=4326) | nullable |
+| `area_land` | BigIntegerField | nullable; sq meters |
+| `area_water` | BigIntegerField | nullable; sq meters |
+| `internal_point` | PointField(srid=4326) | nullable; interior label point |
+| `parent` | ForeignKey(self) | SET_NULL; related_name="children"; for drill-up |
+| `effective_from` | DateField | nullable; SCD2 validity start |
+| `effective_to` | DateField | nullable; NULL = current |
+| `is_current` | BooleanField(default=True) | db_index; latest-version flag |
+| `created_at` | DateTimeField(auto_now_add=True) | |
+| `updated_at` | DateTimeField(auto_now=True) | |
+
+### Constraints
+
+- Surrogate PK: BigAutoField (auto)
+- `unique_together = [("geoid", "vintage_year")]` — natural key
+- Indexes: `(summary_level, vintage_year)`, `(state_fips, summary_level)`, `(is_current, summary_level)`
+
+### Lookups callers rely on
+
+- `DimGeography.objects.filter(is_current=True)` — current-version filtering (used by ViewSet)
+- `DimGeography.objects.filter(geoid__startswith=state_fips)` — state-scoped queries
+- `parent` reverse: `geo.children.all()` — drill-down
+
+## Callers / consumers
+
+- `socialwarehouse/api/warehouse/views.py:DimGeographyViewSet` — read-only API surface
+- `socialwarehouse/api/warehouse/serializers.py:DimGeographySerializer` — serialization
+- `socialwarehouse/warehouse/services/dimension_loader.py` — ETL loader
+- FactElectionResult, FactACSEstimate, FactRedistrictingPlan — FK target
+
+## Cross-references
+
+- **Self-FK:** `parent` for hierarchical drill-up.
+- **Referenced by:** FactElectionResult.geography, FactACSEstimate.geography, FactRedistrictingPlan.geography.
+
+## Known assumptions / gotchas
+
+- **SCD Type 2** — multiple rows per (geoid) across vintage years; use `is_current=True` when you want today's boundary.
+- **geometry is nullable** — lightweight loads skip it. Code paths that assume geometry exists must filter `geometry__isnull=False`.
+- **state_fips defaults to ""** not None — `filter(state_fips="")` returns the unset rows; `filter(state_fips__isnull=True)` returns nothing.
+
+## Survey log
+
+- 2026-05-18: Seeded from live model. PR #105 added SCD2 fields (effective_from/to, is_current). PR #106 cleared field-name mismatch with loader (DimRedistrictingCycle, not this model — listed here only as related context).

--- a/docs/entities/dim_redistricting_cycle.md
+++ b/docs/entities/dim_redistricting_cycle.md
@@ -1,0 +1,50 @@
+# DimRedistrictingCycle (Django model, socialwarehouse.warehouse.models)
+
+**Definition:** `socialwarehouse/warehouse/models/dimensions.py:290`
+**Surveyed at:** 2026-05-18
+**Owner:** warehouse maintainers
+
+## Shape
+
+### Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `cycle_year` | PositiveSmallIntegerField | unique=True; validated 1960-2040 |
+| `census_year` | PositiveSmallIntegerField(default=0) | renamed from `decennial_census_year` in PR #106 |
+| `first_election_year` | PositiveSmallIntegerField(default=0) | typically cycle_year + 2 |
+| `effective_start` | DateField | nullable; cycle's effective period start |
+| `effective_end` | DateField | nullable; end of effective period |
+| `notes` | TextField(blank=True, default="") | |
+| `created_at` | DateTimeField(auto_now_add=True) | |
+
+### Constraints
+
+- Surrogate PK: BigAutoField
+- `cycle_year` is unique
+- No additional indexes declared.
+
+### Lookups callers rely on
+
+- `DimRedistrictingCycle.objects.get(cycle_year=2020)` — direct lookup
+- `update_or_create(cycle_year=YEAR, defaults={"census_year": ..., "first_election_year": ..., "effective_start": ..., "effective_end": ..., "notes": ...})` — loader pattern
+
+## Callers / consumers
+
+- `socialwarehouse/warehouse/services/dimension_loader.py` — ETL
+- FactRedistrictingPlan — FK target
+
+## Cross-references
+
+- Referenced by FactRedistrictingPlan via `cycle` FK.
+
+## Known assumptions / gotchas
+
+- **`census_year` NOT `decennial_census_year`** — the original loader used the longer name and W2/#106 fixed it. Any new caller writing `decennial_census_year=` will fail with FieldError. The static scanner at claude-configs-public#117 catches this for same-file callers; cross-file callers rely on this doc page.
+- **`first_election_year` is typically cycle_year + 2** but loaders should compute it explicitly — not all cycles follow the pattern (special elections, mid-decade redistricting).
+- **`effective_start` / `effective_end` are nullable** but production rows always have them set; nullable is for backfill convenience. Query callers should not assume non-null.
+
+## Survey log
+
+- 2026-05-18: Seeded from live model post-PR #106 fix.
+- Pre-PR-#106: schema had `decennial_census_year` instead of `census_year`; loader's `defaults={...}` dict referenced `census_year` causing FieldError. Fixed in PR #106 by renaming the model field (loader code was correct).

--- a/docs/entities/dim_time.md
+++ b/docs/entities/dim_time.md
@@ -1,0 +1,58 @@
+# DimTime (Django model, socialwarehouse.warehouse.models)
+
+**Definition:** `socialwarehouse/warehouse/models/dimensions.py:218`
+**Surveyed at:** 2026-05-18
+**Owner:** warehouse maintainers
+
+## Shape
+
+### Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `calendar_date` | DateField | unique=True |
+| `year` | PositiveSmallIntegerField | db_index |
+| `quarter` | PositiveSmallIntegerField | 1-4 |
+| `month` | PositiveSmallIntegerField | 1-12 |
+| `day_of_year` | PositiveSmallIntegerField | |
+| `day_of_month` | PositiveSmallIntegerField | 1-31; default=1 |
+| `day_of_week` | PositiveSmallIntegerField | 0-6; Python weekday() (0=Mon, 6=Sun); default=0 |
+| `week_of_year` | PositiveSmallIntegerField | 1-53 (ISO); default=1 |
+| `is_census_day` | BooleanField(default=False) | April 1 of decennial years |
+| `is_election_day` | BooleanField(default=False) | first Tue after first Mon in November |
+| `is_presidential_election` | BooleanField(default=False) | db_index |
+| `is_midterm_election` | BooleanField(default=False) | db_index |
+| `federal_fiscal_year` | PositiveSmallIntegerField(default=0) | FY starts Oct 1 of (calendar_year - 1) |
+| `created_at` | DateTimeField(auto_now_add=True) | |
+
+### Constraints
+
+- Surrogate PK: BigAutoField
+- `calendar_date` is unique (natural key)
+- Indexes: `(year, quarter)`, `(is_census_day,)`, `(is_election_day,)`
+
+### Lookups callers rely on
+
+- `DimTime.objects.filter(calendar_date=...)` — point lookups
+- `DimTime.objects.filter(year=..., quarter=...)` — quarterly facts
+- `DimTime.objects.filter(is_election_day=True)` — election joins
+
+## Callers / consumers
+
+- `socialwarehouse/warehouse/services/dimension_loader.py:_load_time` — date-range backfill
+- Fact tables that join on time (election results, ACS by year)
+
+## Cross-references
+
+- No FKs out.
+- Referenced by fact tables via `time` FK convention (not enforced at this model — fact tables declare their own FK).
+
+## Known assumptions / gotchas
+
+- **`day_of_week` is Python convention** (0=Monday), NOT ISO 8601 (1=Monday) or US convention (1=Sunday). Loaders that use other libraries' weekday conventions misalign.
+- **`federal_fiscal_year` defaults to 0** for unset. Filters on `federal_fiscal_year=2026` won't return seed rows that haven't been backfilled. Update_or_create paths must set this explicitly.
+- **The loader bug PR #105 fixed** wrote keys (`day_suffix`, `day_name`, etc.) that aren't on this model. The fields above are the *only* fields a `defaults={...}` dict may use. If you add new fields, update this page in the same PR.
+
+## Survey log
+
+- 2026-05-18: Seeded from live model. PR #105 extended schema with day_of_month, day_of_week, week_of_year, is_presidential_election, is_midterm_election, federal_fiscal_year — these match this page's listing.


### PR DESCRIPTION
## Summary

Reference implementation of the survey-context v2 contract (claude-configs-public PR #116). Establishes SW's project skill at `.agents/skills/survey-context/` and seeds 6 entity doc pages at `docs/entities/`.

### What's here

**Project skill** (`.agents/skills/survey-context/`):
- `config.md` — entity catalog (6 entities), doc root (`docs/entities/`), ownership.
- `templates/entity.md` — copy-pasteable doc-page skeleton.
- `recipes/census-vintage.md` — TIGER vintage / geoid conventions.
- `recipes/django-orm-defaults.md` — `update_or_create` kwarg validation; explicitly composes with the static scanner at claude-configs-public#117.

**Seed entity docs** (chosen for E1 hostile-review frequency):
- `DimGeography` — SCD2 dimension; documents `is_current` convention.
- `DimTime` — Python weekday() convention gotcha + W1/#105 history.
- `DimRedistrictingCycle` — post-W2/#106 `census_year` rename history.
- `Address` — F3/#92 `null=True` violation + M2/#146 (per-row save) + M6/#150 (geocoded vs geom) gotchas.
- `DemographicSnapshot` — `object_id` is `CharField` geoid-string (NOT integer PK); this is the page that would have prevented the A2/#113 false review.
- `api/geo views decorator surface` — function-based-view convention + A1/#112 `method_decorator` gotcha + post-A3/#114 helper contracts.

### Why these 6

They're the entities that surfaced as drift cases in the E1 hostile review (gotchas spread across closed PRs SW#92, #105, #106, #112, #113, #114, #146, #150). The pages now consolidate that history at the entity level where future authors can find it.

### Definition of Done note

Per the v2 contract: shape changes in code carry a DoD to update the corresponding doc page in the same PR. Hook enforcement deferred to claude-configs-public#118 v2.1; operator-auditable now.

## Test plan

- [ ] Project-skill structure follows `PROJECT_SKILL_TEMPLATE.md` from claude-configs-public#116.
- [ ] Each entity page's field listing verified against live source at indicated `file:line`.
- [ ] Cross-references between pages (e.g. address.md → demographic_snapshot.md) check out.
- [ ] Gotchas section names specific shipped tickets (F3/#92, M2/#146, M6/#150, A1/#112, A2/#113, A3/#114, W1/#105, W2/#106).
- [ ] Catalog grows organically — every `NO-DOC` outcome in future surveys offers to seed a new page.

Related: claude-configs-public#116 (global v2 contract), claude-configs-public#117 (runtime scanner), claude-configs-public#118 (v2.1 hook follow-up).