### PR TITLE
fix(delta/enrichment): bundle D1 + D2 + D3 in enrich_addresses_with_boundaries (#123, #124, #125)

### DIFF
--- a/.agents/skills/survey-context/config.md
+++ b/.agents/skills/survey-context/config.md
@@ -14,6 +14,7 @@
 | Address | Django model | socialwarehouse.geo.models | docs/entities/address.md |
 | DemographicSnapshot | Django model | siege_utilities.geo.django.models.demographics | docs/entities/demographic_snapshot.md |
 | api/geo views decorators | DRF decorator surface | socialwarehouse.api.geo.views | docs/entities/api_geo_views_decorators.md |
+| delta/enrichment.py | Spark module | socialwarehouse.delta.enrichment | docs/entities/delta_enrichment.md |
 
 Seed coverage chosen for E1 hostile-review frequency. Catalog grows on next touch — every `NO-DOC` outcome in survey artifacts is a candidate.
 

--- a/docs/entities/delta_enrichment.md
+++ b/docs/entities/delta_enrichment.md
@@ -1,0 +1,62 @@
+# delta/enrichment.py (Spark module, socialwarehouse.delta.enrichment)
+
+**Definition:** `socialwarehouse/delta/enrichment.py`
+**Surveyed at:** 2026-05-18 (seeded via survey-context NO-DOC path during D1+D2+D3 fix)
+**Owner:** delta / warehouse-scale maintainers
+
+## Shape
+
+Spark + Sedona enrichment surface for warehouse-scale geographic operations. Two functions:
+
+- `enrich_addresses_with_boundaries(spark, addresses_table, year=2020, boundaries_path=None)` — spatial enrichment of addresses with state / county / congressional-district boundary attributes via Sedona `ST_Contains`. Returns a DataFrame with the address columns plus `state_name`, `county_geoid`, `county_name`, `cd_geoid`, `cd_name`.
+- `load_postgis_addresses_to_delta(spark, batch_size=100_000)` — JDBC ETL from PostGIS `sw_geo_address` table to the Delta `bronze.addresses` tier.
+- `estimate_scale(row_count)` — Returns advisory `(engine, reason)` recommendation (`postgis` vs `spark`) based on a 1M-row threshold.
+
+## Function contracts
+
+### `enrich_addresses_with_boundaries`
+
+**Inputs:**
+- `spark` — `SparkSession` with Sedona registered (caller responsible; failure to register surfaces as `AnalysisException: Undefined function: ST_Contains`).
+- `addresses_table` — either a key from `delta/tables.py:TABLES` (resolved via the registry) OR a raw Delta path. Brittle to typos — invalid registry-shaped strings fall through to raw-path interpretation (D8 finding).
+- `year` — Census vintage year. Used to filter boundaries before joins. Defaults to 2020.
+- `boundaries_path` — optional Delta path for boundaries. Defaults to `get_table_path("silver", "boundaries")`.
+
+**Output:**
+- DataFrame whose schema is the input addresses schema plus columns: `state_name`, `county_geoid`, `county_name`, `cd_geoid`, `cd_name`. All boundary-derived columns are nullable — addresses that don't intersect a polygon for a given summary level get NULLs (LEFT JOIN semantics, consistent across the three enrichment passes).
+
+**Side effects:**
+- Creates Spark temporary views: `addresses`, `boundaries`, `with_state`, `with_state_county`. Temp views are session-scoped; callers running multiple enrichments in the same session see the latest temp views.
+
+### `load_postgis_addresses_to_delta`
+
+JDBC read from `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_DB` env vars; writes to `bronze.addresses`. Partitioned by `state_abbreviation` on overwrite.
+
+## Constraints / known assumptions
+
+- **Sedona-required.** Both spatial-join functions assume Sedona's `ST_*` UDFs are registered on the SparkSession. Caller must `get_spark_session(enable_sedona=True)` from `delta/config.py`.
+- **Boundary intersection on edges produces row duplication.** An address that geometrically lies on the boundary between two polygons of the same summary level (rare but possible at coastline / national-boundary edges) joins to both and produces duplicate rows. Not currently de-duplicated.
+- **`year` is filtered server-side via DataFrame API** (`F.col("vintage_year") == year`) — not interpolated into SQL strings (was D1 / SW#123, fixed in this entity's first survey log entry).
+- **All three boundary enrichments use LEFT JOIN** — addresses without a matching boundary at a given level retain NULL for that level's columns rather than being dropped. Consistent across state / county / cd (was D6's inconsistency before D2's bundled fix).
+- **Spatial joins are computed left-to-right** — `with_state` → `with_state_county` → `with_state_county_cd` (returned). Each step's temp view carries the address's `geom_point` through to the next join.
+
+## Callers / consumers
+
+- `socialwarehouse/geo/management/commands/export_to_delta.py` — Django mgmt command calling `load_postgis_addresses_to_delta`.
+- Future warehouse-scale enrichment jobs (no current callers of `enrich_addresses_with_boundaries` outside ad-hoc Spark sessions).
+
+## Cross-references
+
+- Reads via `delta/tables.py:TABLES` registry (silver.boundaries path).
+- Reads via `delta/config.py:get_table_path` for default paths.
+- Writes to `bronze.addresses` Delta path (schema in `delta/tables.py:BRONZE_ADDRESSES`).
+
+## Known gotchas
+
+- **`.count()` is a Spark action.** Earlier versions of `enrich_addresses_with_boundaries` called `addresses.count()` inside a `logger.info` — forced a full plan execution just for the log message. Don't add `.count()` calls to logs in pipeline code. (D3 / SW#125, fixed.)
+- **String interpolation of parameters into Spark SQL** is the wrong shape even when the parameter is int-typed — type safety is enforced at the signature level, not at the SQL boundary. Use DataFrame API filters before the SQL, or parameter binding (Spark 3.4+). (D1 / SW#123, fixed.)
+- **Unused computed DataFrames are not free.** Building a Spark plan without returning the DataFrame still costs planner work; if a follow-up action (like `.count()` for a log) is then called on a sibling DataFrame, the unused plans may still get partially evaluated depending on cache state. Don't compute DataFrames you don't use. (D2 / SW#124, fixed.)
+
+## Survey log
+
+- 2026-05-18: Seeded via survey-context NO-DOC path during D1+D2+D3 bundled fix (PR pending). Documents the post-fix function contract; pre-fix gotchas captured in Known gotchas section above.

--- a/socialwarehouse/delta/enrichment.py
+++ b/socialwarehouse/delta/enrichment.py
@@ -19,22 +19,36 @@ logger = logging.getLogger("socialwarehouse.delta")
 
 
 def enrich_addresses_with_boundaries(spark, addresses_table, year=2020, boundaries_path=None):
-    """Join geocoded addresses with boundary names via Sedona spatial join.
+    """Spatial-enrich addresses with state, county, and CD boundary attributes.
+
+    Performs three sequential Sedona LEFT JOINs (state -> county -> cd). The
+    returned DataFrame has the input address columns plus:
+        state_name, county_geoid, county_name, cd_geoid, cd_name
+    Addresses that don't intersect a polygon at a given summary level get
+    NULL for that level's columns (LEFT JOIN semantics, consistent across
+    the three passes).
 
     Args:
-        spark: SparkSession with Sedona registered.
-        addresses_table: Delta path or table name for silver addresses.
-        year: Census vintage year for boundaries.
-        boundaries_path: Delta path for boundaries. If None, reads from
-            silver.boundaries in the registry.
+        spark: SparkSession with Sedona registered. Caller is responsible
+            for registration; absence surfaces as ``AnalysisException:
+            Undefined function: ST_Contains``.
+        addresses_table: Either a key in ``delta/tables.py:TABLES`` or a
+            raw Delta path.
+        year: Census vintage year for boundaries (default 2020).
+        boundaries_path: Optional Delta path for boundaries. Defaults to
+            ``get_table_path("silver", "boundaries")``.
 
     Returns:
-        DataFrame with address fields + boundary names.
+        Spark DataFrame with address columns + boundary attributes.
+
+    See docs/entities/delta_enrichment.md for the canonical entity contract,
+    constraints, and survey log.
     """
+    from pyspark.sql import functions as F
+
     from .config import get_table_path
     from .tables import TABLES
 
-    # Read addresses
     if addresses_table in TABLES:
         addr_path = TABLES[addresses_table]["path"]
     else:
@@ -42,24 +56,24 @@ def enrich_addresses_with_boundaries(spark, addresses_table, year=2020, boundari
 
     addresses = (
         spark.read.format("delta").load(addr_path)
-        .filter("latitude IS NOT NULL AND longitude IS NOT NULL")
+        .filter(F.col("latitude").isNotNull() & F.col("longitude").isNotNull())
     )
-
-    # Create point geometry column
     addresses = addresses.selectExpr(
         "*",
         "ST_Point(CAST(longitude AS DOUBLE), CAST(latitude AS DOUBLE)) AS geom_point",
     )
     addresses.createOrReplaceTempView("addresses")
 
-    # Read boundaries
     if boundaries_path is None:
         boundaries_path = get_table_path("silver", "boundaries")
 
+    # Pre-filter boundaries by year via DataFrame API (no SQL string
+    # interpolation of `year` -- D1 / SW#123). The downstream SQL joins
+    # therefore drop the redundant `b.vintage_year = {year}` predicate.
     boundaries = (
         spark.read.format("delta").load(boundaries_path)
-        .filter(f"vintage_year = {year}")
-        .filter("wkt IS NOT NULL")
+        .filter(F.col("vintage_year") == year)
+        .filter(F.col("wkt").isNotNull())
     )
     boundaries = boundaries.selectExpr(
         "*",
@@ -67,42 +81,42 @@ def enrich_addresses_with_boundaries(spark, addresses_table, year=2020, boundari
     )
     boundaries.createOrReplaceTempView("boundaries")
 
-    # Spatial join — state
-    state_join = spark.sql("""
-        SELECT a.*, b.name AS state_name
+    # Three sequential LEFT JOINs. Each step's temp view carries
+    # `a.geom_point` through to the next join. All three contribute to the
+    # returned DataFrame (D2 / SW#124).
+    enriched = spark.sql("""
+        SELECT a.*, s.name AS state_name
         FROM addresses a
-        LEFT JOIN boundaries b
-            ON ST_Contains(b.geom_boundary, a.geom_point)
-            AND b.summary_level = 'state'
-            AND b.vintage_year = {year}
-    """.format(year=year))
+        LEFT JOIN boundaries s
+            ON ST_Contains(s.geom_boundary, a.geom_point)
+            AND s.summary_level = 'state'
+    """)
+    enriched.createOrReplaceTempView("with_state")
 
-    # Spatial join — county
-    county_join = spark.sql("""
-        SELECT b.geoid AS county_geoid_joined, b.name AS county_name
-        FROM addresses a
-        JOIN boundaries b
-            ON ST_Contains(b.geom_boundary, a.geom_point)
-            AND b.summary_level = 'county'
-            AND b.vintage_year = {year}
-    """.format(year=year))
+    enriched = spark.sql("""
+        SELECT a.*, c.geoid AS county_geoid, c.name AS county_name
+        FROM with_state a
+        LEFT JOIN boundaries c
+            ON ST_Contains(c.geom_boundary, a.geom_point)
+            AND c.summary_level = 'county'
+    """)
+    enriched.createOrReplaceTempView("with_state_county")
 
-    # Spatial join — congressional district
-    cd_join = spark.sql("""
-        SELECT b.geoid AS cd_geoid_joined, b.name AS cd_name
-        FROM addresses a
-        JOIN boundaries b
-            ON ST_Contains(b.geom_boundary, a.geom_point)
-            AND b.summary_level = 'cd'
-            AND b.vintage_year = {year}
-    """.format(year=year))
+    enriched = spark.sql("""
+        SELECT a.*, d.geoid AS cd_geoid, d.name AS cd_name
+        FROM with_state_county a
+        LEFT JOIN boundaries d
+            ON ST_Contains(d.geom_boundary, a.geom_point)
+            AND d.summary_level = 'cd'
+    """)
 
+    # No .count() in the log (D3 / SW#125 -- .count() is a Spark action
+    # and would force full plan execution for a log message).
     logger.info(
-        "Enrichment complete: %d addresses joined with %d year boundaries",
-        addresses.count(), year,
+        "Enrichment complete: state/county/cd joins for year %d", year,
     )
 
-    return state_join
+    return enriched
 
 
 def load_postgis_addresses_to_delta(spark, batch_size=100_000):

--- a/tests/unit/delta/test_enrichment_d_series.py
+++ b/tests/unit/delta/test_enrichment_d_series.py
@@ -1,0 +1,136 @@
+"""Regression tests for D1+D2+D3 fixes in delta/enrichment.py.
+
+D1 (SW#123): SQL string interpolation of `year` parameter removed.
+D2 (SW#124): county + cd joins now contribute to returned DataFrame.
+D3 (SW#125): `.count()` no longer inside log messages.
+
+Tests are source-grep based (file-text read, not inspect.getsource per
+claude-configs-public#123 inspection-vs-behavior rule-gap). Live Spark
+behavior tests are not in this PR -- Sedona/Spark is not in the unit-test
+matrix, and adding it is a separate scope. The source-grep regressions
+go red on revert of any of the three findings.
+"""
+
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from socialwarehouse.delta import enrichment
+
+_SRC = Path(enrichment.__file__).read_text(encoding="utf-8")
+
+
+def _function_block(name):
+    """Return decorator stack + def + body for a top-level function."""
+    lines = _SRC.splitlines()
+    def_idx = next((i for i, line in enumerate(lines) if line.startswith(f"def {name}(")), None)
+    if def_idx is None:
+        return ""
+    start = def_idx
+    while start > 0 and lines[start - 1].startswith("@"):
+        start -= 1
+    end = def_idx + 1
+    while end < len(lines) and not (
+        lines[end].startswith("def ") or lines[end].startswith("class ")
+    ):
+        end += 1
+    return "\n".join(lines[start:end])
+
+
+class TestD1NoSqlYearInterpolation(SimpleTestCase):
+    """D1: `year` must not be interpolated into Spark SQL strings."""
+
+    def test_no_format_year_in_enrichment_block(self):
+        block = _function_block("enrich_addresses_with_boundaries")
+        assert block, "enrich_addresses_with_boundaries not found in source"
+        # The pre-fix shape: .format(year=year) on a triple-quoted SQL string.
+        assert ".format(year=year)" not in block, (
+            "year must not be interpolated into Spark SQL via .format() "
+            "(D1/SW#123). Pre-filter boundaries via DataFrame API instead."
+        )
+
+    def test_no_fstring_year_in_filter(self):
+        block = _function_block("enrich_addresses_with_boundaries")
+        # The pre-fix shape: f"vintage_year = {year}" inside .filter()
+        assert 'f"vintage_year = {year}"' not in block, (
+            "Pre-filter boundaries by year via F.col equality, not f-string "
+            "filter expression (D1/SW#123)."
+        )
+
+    def test_uses_dataframe_api_for_year_filter(self):
+        block = _function_block("enrich_addresses_with_boundaries")
+        # Post-fix uses F.col("vintage_year") == year
+        assert 'F.col("vintage_year") == year' in block, (
+            "Expected DataFrame-API filter F.col(\"vintage_year\") == year "
+            "after D1/SW#123 fix"
+        )
+
+
+class TestD2EnrichmentReturnsAllJoins(SimpleTestCase):
+    """D2: county and cd joins must contribute to the returned DataFrame."""
+
+    def test_returns_chained_enrichment(self):
+        block = _function_block("enrich_addresses_with_boundaries")
+        # Post-fix returns `enriched` (the chain output), not `state_join`.
+        assert "return enriched" in block, (
+            "Expected `return enriched` (chained state/county/cd DataFrame) "
+            "after D2/SW#124 fix"
+        )
+        assert "return state_join" not in block, (
+            "`return state_join` discards county and cd joins (D2/SW#124)"
+        )
+
+    def test_county_columns_in_select(self):
+        block = _function_block("enrich_addresses_with_boundaries")
+        assert "county_geoid" in block and "county_name" in block, (
+            "Post-D2 enriched DataFrame must surface county_geoid and "
+            "county_name columns"
+        )
+
+    def test_cd_columns_in_select(self):
+        block = _function_block("enrich_addresses_with_boundaries")
+        assert "cd_geoid" in block and "cd_name" in block, (
+            "Post-D2 enriched DataFrame must surface cd_geoid and cd_name"
+        )
+
+    def test_uses_left_join_consistently(self):
+        block = _function_block("enrich_addresses_with_boundaries")
+        # Post-fix: LEFT JOIN for all three. Pre-fix: state was LEFT, county
+        # and cd were INNER. Going red if anyone re-introduces INNER.
+        # Heuristic: counted LEFT JOIN occurrences in the function body
+        # should be at least 3 (state, county, cd). Plain `JOIN` (without LEFT)
+        # against boundaries should not appear.
+        assert block.count("LEFT JOIN boundaries") == 3, (
+            f"Expected 3 LEFT JOIN boundaries in enrichment chain, "
+            f"got {block.count('LEFT JOIN boundaries')} (D2/D6 fix)"
+        )
+
+
+class TestD3NoCountInLog(SimpleTestCase):
+    """D3: `.count()` must not appear inside logger calls.
+
+    Comments mentioning `.count()` (e.g. the post-fix explanatory comment)
+    are allowed; only code-side `.count()` inside a `logger.<level>(...)`
+    argument list is the regression target.
+    """
+
+    def test_no_count_in_logger_args(self):
+        import re
+
+        block = _function_block("enrich_addresses_with_boundaries")
+        # Strip comment-only lines and inline-trailing comments before grep.
+        code_lines = []
+        for line in block.splitlines():
+            stripped = line.split("#", 1)[0]
+            if stripped.strip():
+                code_lines.append(stripped)
+        code = "\n".join(code_lines)
+        # Look for logger.<anything>(...) calls and check their argument
+        # span for `.count(`. Spark `.count()` is the regression target.
+        pattern = re.compile(r"logger\.\w+\s*\((.*?)\)", re.DOTALL)
+        for match in pattern.finditer(code):
+            args = match.group(1)
+            assert ".count(" not in args, (
+                f".count() is a Spark action; do not invoke inside a logger "
+                f"call (D3/SW#125). Offending call args:\n{args!r}"
+            )


### PR DESCRIPTION
## Summary

Three MAJOR findings from the E1 delta review, all in `enrich_addresses_with_boundaries`. Bundled refactor.

- **D1 (#123):** `year` interpolated into Spark SQL via `.format()` and into `.filter()` via f-string. Replaced with `F.col("vintage_year") == year` (DataFrame API, type-safe). Downstream SQL JOIN predicates no longer carry the redundant `b.vintage_year = {year}` clause.
- **D2 (#124):** function returned only `state_join`; `county_join` and `cd_join` were computed but discarded. Rewritten as three sequential LEFT JOINs (state → county → cd). Returned DataFrame now has `state_name`, `county_geoid`, `county_name`, `cd_geoid`, `cd_name`.
- **D3 (#125):** `addresses.count()` removed from `logger.info` — Spark action in log message forced full plan execution.

**In passing:** D6 (LEFT vs INNER inconsistency) is resolved mechanically by the chained-LEFT design. Test asserts exactly 3 LEFT JOIN occurrences.

## Survey-context exercise (second live-use)

This PR exercises the **NO-DOC → seed** path of survey-context that PR #154 did not:
- `delta/enrichment.py` was not in the SW project skill catalog.
- Seeded `docs/entities/delta_enrichment.md` from live introspection.
- Added catalog entry in `.agents/skills/survey-context/config.md`.
- Doc page is the canonical contract going forward.

The v2.1 hook (claude-configs-public#119, merged) would BLOCK a push touching `delta/enrichment.py` without a doc touch. This diff includes the new doc page in the same commit; hook PASSES.

## Test plan

Regression tests at `tests/unit/delta/test_enrichment_d_series.py` (file-text source-greps per claude-configs-public#123 inspection-vs-behavior rule-gap):

- [ ] D1: no `.format(year=year)`, no `f"vintage_year = {year}"`, DOES contain `F.col("vintage_year") == year`.
- [ ] D2: returns `enriched` NOT `state_join`; county_geoid + cd_geoid columns present; exactly 3 LEFT JOIN occurrences in the chain.
- [ ] D3: regex scan of `logger.<level>(...)` calls asserts no `.count(` inside any argument list. Comments stripped before grep (post-fix explanatory comment doesn't false-positive).

Live Spark / Sedona behavior tests acknowledged as a gap — Sedona is not in the unit-test matrix; adding it is a separate scope.

Closes #123
Closes #124
Closes #125

Also closes #128 (D6) — resolved mechanically by the chained-LEFT design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added entity catalog entry for address enrichment with boundary data.

* **Improvements**
  * Enhanced address enrichment pipeline to integrate state, county, and district boundary data through sequential spatial joins.
  * Optimized logging performance.
  * Standardized NULL handling for unmapped boundary data.

* **Tests**
  * Added comprehensive regression tests for enrichment pipeline validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->