### PR TITLE
fix(settings): production fail-fast on missing DJANGO_SECRET_KEY (ST1 / #139)

### DIFF
--- a/.agents/skills/survey-context/config.md
+++ b/.agents/skills/survey-context/config.md
@@ -15,6 +15,7 @@
 | DemographicSnapshot | Django model | siege_utilities.geo.django.models.demographics | docs/entities/demographic_snapshot.md |
 | api/geo views decorators | DRF decorator surface | socialwarehouse.api.geo.views | docs/entities/api_geo_views_decorators.md |
 | delta/enrichment.py | Spark module | socialwarehouse.delta.enrichment | docs/entities/delta_enrichment.md |
+| settings | Django settings module | socialwarehouse.settings | docs/entities/settings.md |
 
 Seed coverage chosen for E1 hostile-review frequency. Catalog grows on next touch — every `NO-DOC` outcome in survey artifacts is a candidate.
 

--- a/docs/entities/settings.md
+++ b/docs/entities/settings.md
@@ -1,0 +1,72 @@
+# socialwarehouse.settings (Django settings module)
+
+**Definition:** `socialwarehouse/settings/base.py` (+ `development.py`, `production.py`, `test.py`)
+**Surveyed at:** 2026-05-18 (seeded via survey-context NO-DOC path during ST1 SECRET_KEY hardening)
+**Owner:** ops / infra maintainers
+
+## Shape
+
+Per-environment Django settings split. `base.py` declares the shared defaults; `development.py`, `production.py`, `test.py` import-everything from base and override the environment-specific knobs.
+
+| File | Purpose | Notable overrides |
+|---|---|---|
+| `base.py` | shared defaults | `INSTALLED_APPS`, `MIDDLEWARE`, `DATABASES["default"]` from env vars, GST integration constants |
+| `development.py` | dev | `DEBUG = True`, `ALLOWED_HOSTS = ["*"]` |
+| `production.py` | prod | `DEBUG = False`, `ALLOWED_HOSTS` from env var |
+| `test.py` | CI / local test | override `DATABASES` to `test_socialwarehouse` |
+
+## Required environment variables
+
+| Variable | Used by | Default if unset | Fail-fast? |
+|---|---|---|---|
+| `DJANGO_SECRET_KEY` | base.py | None — **required in production** (ST1 fix) | **YES (production only)** — KeyError at startup |
+| `POSTGRES_DB` | base.py, test.py | `"socialwarehouse"` (base) / `"test_socialwarehouse"` (test) | No |
+| `POSTGRES_USER` | base.py | `"socialwarehouse"` | No |
+| `POSTGRES_PASSWORD` | base.py | `""` (anti-pattern, see ST4) | No |
+| `POSTGRES_HOST` | base.py | `"localhost"` | No |
+| `POSTGRES_PORT` | base.py | `"5432"` | No |
+| `ALLOWED_HOSTS` | production.py | `""` parsed to `[""]` (anti-pattern, see ST2) | No |
+| `CELERY_BROKER_URL` | base.py | `"redis://localhost:6379/0"` | No |
+| `CELERY_RESULT_BACKEND` | base.py | `"redis://localhost:6379/0"` | No |
+
+## INSTALLED_APPS
+
+Order-sensitive (Grappelli must precede `django.contrib.admin`):
+- `grappelli`
+- Django core: `admin`, `auth`, `contenttypes`, `sessions`, `messages`, `staticfiles`, `gis`
+- 3rd party: `rest_framework`, `rest_framework_gis`
+- SU geo: `siege_utilities.geo.django`
+- SW apps: `socialwarehouse.geo`, `socialwarehouse.warehouse`
+- GST: `locations` (bare-name dep on hidden sys.path mechanism — see ST3 / SW#141)
+
+## GST integration constants
+
+Mirrored from upstream GST settings so SW doesn't pull GST's full config (which conflicts):
+- `_GST_DATA_DIR`, `SPATIAL_DATA_SUBDIRECTORY`, ..., `NECESSARY_PATHS`
+- `DEFAULT_PROJECTION_NUMBER = 4326`
+- `PREFERRED_PROJECTION_FOR_US_DISTANCE_SEARCH = 5070`
+- `NOMINATIM_API_BASE_URL`, `NOMINATIM_USER_AGENT`, etc.
+- `VALID_VECTOR_FILE_EXTENSIONS`
+
+## Known assumptions / gotchas
+
+- **`SECRET_KEY` MUST be set in production via `DJANGO_SECRET_KEY` env var.** Post-ST1/SW#139 fix: `production.py` does `SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]` which raises `KeyError` at startup if unset. `base.py` retains a documented dev-only fallback for local development. Production deployments that forget the env var **fail fast** rather than silently using the insecure default. (Was ST1, fixed.)
+- **`POSTGRES_PASSWORD` defaults to empty string.** Connection-time failure surfaces as opaque PG error rather than clear ConfigError at startup. Same anti-pattern as `S3_ACCESS_KEY` in `delta/config.py` (D5). (ST4, open.)
+- **`ALLOWED_HOSTS` parses to `[""]` on missing env var in production.py.** `os.environ.get("ALLOWED_HOSTS", "").split(",")` returns `[""]` not `[]`. Truthy + matches no hosts; Django rejects all requests with confusing DisallowedHost. (ST2, open.)
+- **`"locations"` in INSTALLED_APPS depends on hidden sys.path manipulation** from the GST submodule. If the sys.path mechanism breaks (manage.py / conftest.py / wsgi.py refactor), Django fails at startup with `No module named 'locations'`. (ST3, open.)
+- **Settings split via wildcard import** (`from .base import *`). Override files don't re-import `os` explicitly — `production.py` uses `os.environ` through the wildcard import (with `# noqa: F405`). Brittle if `os` is removed from base.py.
+
+## Callers / consumers
+
+- Django process startup reads via `DJANGO_SETTINGS_MODULE` env var (defaults: `development`, `production`, `test`).
+- `manage.py` selects the module at command time.
+- GST modules (`vendor/geodjango_simple_template/...`) read the GST-mirrored constants directly.
+
+## Cross-references
+
+- `delta/config.py` — Spark settings; separate from Django settings but shares the empty-string-default-for-credentials anti-pattern (D5).
+- GST submodule under `vendor/geodjango_simple_template/` — sources the GST integration constants.
+
+## Survey log
+
+- 2026-05-18: Seeded via survey-context NO-DOC path during ST1 / SW#139 fix. Documents the post-ST1 fail-fast pattern for `SECRET_KEY` in production. Pre-ST1 behavior was a hardcoded `"insecure-dev-key-change-in-production"` default in `base.py` that production deployments silently inherited when the env var was unset.

--- a/socialwarehouse/settings/base.py
+++ b/socialwarehouse/settings/base.py
@@ -10,6 +10,10 @@ from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
+# Dev-only fallback. Production settings overrides this with a fail-fast
+# os.environ["DJANGO_SECRET_KEY"] read (ST1 / SW#139); production deployments
+# that forget the env var get a KeyError at startup rather than silently
+# running with the insecure default below.
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "insecure-dev-key-change-in-production")
 DEBUG = False
 ALLOWED_HOSTS = []

--- a/socialwarehouse/settings/production.py
+++ b/socialwarehouse/settings/production.py
@@ -1,4 +1,9 @@
 from .base import *  # noqa: F401,F403
 
+# Fail-fast: production must define DJANGO_SECRET_KEY explicitly. A missing
+# env var raises KeyError at startup rather than silently inheriting the
+# insecure dev fallback from base.py. (ST1 / SW#139)
+SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]  # noqa: F405
+
 DEBUG = False
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(",")  # noqa: F405

--- a/tests/unit/settings/test_production_secret_key.py
+++ b/tests/unit/settings/test_production_secret_key.py
@@ -1,0 +1,84 @@
+"""Regression test for ST1 (SW#139): production.py fails fast on missing DJANGO_SECRET_KEY.
+
+Pre-fix: base.py's SECRET_KEY default was 'insecure-dev-key-change-in-production'
+and production.py inherited it via wildcard import. A production deployment
+that forgot to set DJANGO_SECRET_KEY silently ran with the insecure key.
+
+Post-fix: production.py does SECRET_KEY = os.environ["DJANGO_SECRET_KEY"],
+which raises KeyError at module-load if the env var is unset.
+
+Test strategy: import production.py in a subprocess with DJANGO_SECRET_KEY
+unset and assert KeyError. base.py's dev fallback is preserved (separate
+test confirms it).
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_PRODUCTION_SRC = (_REPO_ROOT / "socialwarehouse/settings/production.py").read_text(encoding="utf-8")
+_BASE_SRC = (_REPO_ROOT / "socialwarehouse/settings/base.py").read_text(encoding="utf-8")
+
+
+class TestProductionFailFastOnMissingSecretKey(SimpleTestCase):
+    """ST1 fix: production.py raises KeyError when DJANGO_SECRET_KEY is unset."""
+
+    def test_production_imports_fail_on_missing_secret_key(self):
+        """Spawn a subprocess that imports production settings with the env
+        var unset and assert KeyError.
+
+        Uses subprocess (not pytest's monkeypatch) so Django's settings cache
+        and any other process-level state stays clean. Stripping the env var
+        in-process and re-importing is fragile.
+        """
+        env = {k: v for k, v in os.environ.items() if k != "DJANGO_SECRET_KEY"}
+        env["DJANGO_SETTINGS_MODULE"] = "socialwarehouse.settings.production"
+        env["PYTHONPATH"] = str(_REPO_ROOT)
+        # Force-set a few env vars that base.py reads so failure is isolated
+        # to SECRET_KEY's KeyError (not e.g. POSTGRES_DB being missing).
+        env.setdefault("POSTGRES_DB", "x")
+        env.setdefault("POSTGRES_USER", "x")
+        env.setdefault("ALLOWED_HOSTS", "localhost")
+
+        result = subprocess.run(
+            [sys.executable, "-c", "from socialwarehouse.settings import production"],
+            env=env, capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode != 0, (
+            "production.py must fail when DJANGO_SECRET_KEY is unset "
+            "(ST1 / SW#139). Got returncode 0."
+        )
+        assert "KeyError" in result.stderr and "DJANGO_SECRET_KEY" in result.stderr, (
+            f"Expected KeyError mentioning DJANGO_SECRET_KEY in stderr; got:\n"
+            f"{result.stderr}"
+        )
+
+
+class TestProductionSourceShape(SimpleTestCase):
+    """Source-grep regressions: red on revert of the fail-fast pattern."""
+
+    def test_production_uses_bracket_subscript(self):
+        """Post-fix production.py must use os.environ['DJANGO_SECRET_KEY']
+        (raises KeyError) NOT os.environ.get(...) (silently returns None or
+        a default)."""
+        assert 'os.environ["DJANGO_SECRET_KEY"]' in _PRODUCTION_SRC, (
+            "production.py must set SECRET_KEY via os.environ['DJANGO_SECRET_KEY'] "
+            "for fail-fast (ST1 / SW#139)"
+        )
+        # The buggy shape -- silent default -- is the regression target.
+        assert 'os.environ.get("DJANGO_SECRET_KEY"' not in _PRODUCTION_SRC, (
+            "production.py must NOT use os.environ.get('DJANGO_SECRET_KEY', ...) "
+            "-- that silently inherits the insecure base.py default"
+        )
+
+    def test_base_dev_fallback_preserved(self):
+        """base.py still has a dev-only fallback so local development works
+        without setting the env var. Production overrides it."""
+        assert 'os.environ.get("DJANGO_SECRET_KEY"' in _BASE_SRC, (
+            "base.py should retain the dev-only fallback for local development; "
+            "production.py overrides it with fail-fast bracket access"
+        )


### PR DESCRIPTION
## Summary

**Security-relevant MAJOR fix.** Pre-fix: `base.py`'s `SECRET_KEY` default was `'insecure-dev-key-change-in-production'`. `production.py` inherited it via wildcard import. A production deployment that forgot to set `DJANGO_SECRET_KEY` silently ran with the insecure key — compromising session signing, password-reset tokens, CSRF tokens.

**Fix:** `production.py` now reads `SECRET_KEY` via `os.environ["DJANGO_SECRET_KEY"]` (bracket subscript) — raises `KeyError` at module-load if unset. `base.py` retains the dev fallback (with explanatory comment) so local dev continues to work without env-var setup.

## Deployment note

Production deployments that have NOT been setting `DJANGO_SECRET_KEY` will crash at startup after this lands. That's the intended consequence — the silent insecure default was the bug. Ops should preempt by confirming the env var is set wherever production settings load.

## Survey-context exercise (third live-use)

This is the third PR exercising survey-context. NO-DOC → seed path for the settings module:

- Seeded `docs/entities/settings.md` from live introspection. Documents required env vars, INSTALLED_APPS shape, GST integration constants, and named open issues (ST2 / ST3 / ST4 — separate tickets).
- Added catalog entry in `.agents/skills/survey-context/config.md`.

Coverage of survey-context paths now:
- PR #154 — MATCH path (existing entity doc).
- PR #155 — NO-DOC → seed (delta/enrichment.py).
- This PR — NO-DOC → seed (settings module).

## Test plan

`tests/unit/settings/test_production_secret_key.py`:

- [ ] Subprocess imports `socialwarehouse.settings.production` with `DJANGO_SECRET_KEY` unset → asserts non-zero exit AND `KeyError: 'DJANGO_SECRET_KEY'` in stderr. Verified manually via `env -i ... python -c 'from ... import production'`.
- [ ] Source-grep: `production.py` uses `os.environ["DJANGO_SECRET_KEY"]` (fail-fast shape).
- [ ] Source-grep: `production.py` does NOT use `os.environ.get("DJANGO_SECRET_KEY"` (the buggy shape).
- [ ] Source-grep: `base.py` retains `os.environ.get("DJANGO_SECRET_KEY"` (dev fallback preserved).

Closes #139