### PR TITLE
fix(swh/voters): explicit LOCK before DROP+RENAME in atomic-swap (S3 / #133)

### DIFF
--- a/.agents/skills/survey-context/config.md
+++ b/.agents/skills/survey-context/config.md
@@ -16,6 +16,7 @@
 | api/geo views decorators | DRF decorator surface | socialwarehouse.api.geo.views | docs/entities/api_geo_views_decorators.md |
 | delta/enrichment.py | Spark module | socialwarehouse.delta.enrichment | docs/entities/delta_enrichment.md |
 | settings | Django settings module | socialwarehouse.settings | docs/entities/settings.md |
+| swh/voters.py | Python module | swh.voters | docs/entities/swh_voters.md |
 
 Seed coverage chosen for E1 hostile-review frequency. Catalog grows on next touch — every `NO-DOC` outcome in survey artifacts is a candidate.
 

--- a/docs/entities/swh_voters.md
+++ b/docs/entities/swh_voters.md
@@ -1,0 +1,65 @@
+# swh/voters.py (Python module, swh.voters)
+
+**Definition:** `swh/voters.py`
+**Surveyed at:** 2026-05-18 (seeded via survey-context NO-DOC path during S3 lock fix)
+**Owner:** swh / data-loading maintainers
+
+## Shape
+
+Voter-file CSV loader. Reads chunked pandas, builds Point geometries from lon/lat columns, uploads to PostGIS via `siege_utilities.geo.spatial_transformations.PostGISConnector`.
+
+Public functions:
+
+| Function | Purpose |
+|---|---|
+| `load_voter_file(filepath, table_name, ...)` | Stream-load a voter CSV into a PostGIS table. Stages first, atomic-swaps on completion. |
+| `voter_file_to_geodataframe(filepath, ...)` | Read into an in-memory GeoDataFrame for Tier-3 (GeoPandas-only) processing. |
+| `_coerce_and_build_geometry(df, ...)` | Internal helper. Coerces lon/lat to numeric, drops invalid rows, builds GeoDataFrame. |
+
+## DEFAULT_COLUMNS
+
+TargetSmart voter file convention:
+
+| Logical | CSV column |
+|---|---|
+| longitude | `vb_tsmart_longitude` |
+| latitude | `vb_tsmart_latitude` |
+| precinct | `vb_vf_national_precinct_code` |
+| county | `vb_tsmart_county_name` |
+| cd | `vb_vf_cd` |
+| sd | `vb_vf_sd` |
+| hd | `vb_vf_hd` |
+
+Override per-call via the `longitude_col` / `latitude_col` parameters or via CLI flags from `swh/cli.py`.
+
+## Staging-table + atomic-swap pattern (post-S3 fix)
+
+1. Generate uniquely-named staging table: `_staging_{table_name}_{uuid8}`.
+2. For each chunk: build GeoDataFrame, upload via `connector.upload_spatial_data(gdf, staging_table, ..., if_exists="replace" on first chunk / "append" thereafter)`.
+3. On all-chunks-success, run the swap inside one transaction:
+   - `inspect(connector.engine).has_table(table_name, schema=schema)` — pre-check existence.
+   - If target exists: `LOCK TABLE <schema>.<table_name> IN ACCESS EXCLUSIVE MODE` (post-S3/#133 fix — explicit lock acquisition before DDL).
+   - `DROP TABLE IF EXISTS <schema>.<table_name>`.
+   - `ALTER TABLE <schema>.<staging_table> RENAME TO <table_name>`.
+4. On any chunk failure: drop the staging table; raise.
+
+## Callers / consumers
+
+- `swh/cli.py:load_voters` — Click command `swh load-voters <filepath> --table <name> [...]`.
+
+## Cross-references
+
+- `siege_utilities.geo.spatial_transformations.PostGISConnector` — handles the actual upload + engine.
+- `swh/config.py:settings.database.connection_string` — default connection target.
+
+## Known assumptions / gotchas
+
+- **`LOCK TABLE` requires the table to exist.** Post-fix: an `inspect.has_table` pre-check guards against `relation does not exist` on first-ever loads. Without this check, naive `LOCK TABLE` would fail on the first run.
+- **`pd.read_csv` is called with default encoding/quoting/dtype.** S2 / SW#132 (open): TargetSmart files have BOM markers, mixed quoting, and ID columns that pandas auto-types as float. Without `encoding="utf-8-sig"`, `dtype={precinct: str, county_fips: str}`, etc., loaded data is silently corrupted.
+- **Chunk-append assumes chunk-1's column shape.** S4 / SW#134 (open): `if_exists="replace"` on chunk 1 then `"append"` on chunk 2+; if chunk 2 has different columns from chunk 1 (schema drift mid-file, late-added columns, etc.), the append silently misaligns. Verify `upload_spatial_data`'s `if_exists="append"` semantics.
+- **`{schema}.{table_name}` interpolated into raw SQL.** S6 / SW#136 (open MINOR): schema name comes from `--schema` CLI option; weird chars would open injection. Should use `psycopg2.sql.Identifier` or SQLAlchemy `quoted_name`. Operator-trust boundary; low risk in practice.
+- **Cleanup-exception warning lacks remediation hint.** S8 / SW#138 (open NIT): if staging-table cleanup fails after a load failure, the warning names the table but not how to clean it up manually.
+
+## Survey log
+
+- 2026-05-18: Seeded via survey-context NO-DOC path during S3 / SW#133 fix. Pattern documented covers post-S3 shape; S2 / S4 / S6 / S8 listed as open gotchas to fix in subsequent PRs.

--- a/swh/voters.py
+++ b/swh/voters.py
@@ -136,7 +136,7 @@ def load_voter_file(
         Loaded 15234567 voters
     """
     from siege_utilities.geo.spatial_transformations import PostGISConnector
-    from sqlalchemy import text
+    from sqlalchemy import inspect as sa_inspect, text
 
     filepath = Path(filepath)
     conn_str = connection_string or settings.database.connection_string
@@ -163,8 +163,17 @@ def load_voter_file(
             first_chunk = False
             logger.info("Loaded chunk: %d rows (total: %d)", len(gdf), total_rows)
 
-        # Atomic swap: drop target, rename staging -> target
+        # Atomic swap: drop target, rename staging -> target.
+        # Acquire ACCESS EXCLUSIVE lock on the target table BEFORE the DROP
+        # so concurrent readers complete or block here (cleaner than relying
+        # on implicit DDL-acquired locks). LOCK requires the table to exist;
+        # the inspect.has_table pre-check guards first-ever loads where no
+        # target exists yet. (S3 / SW#133)
+        inspector = sa_inspect(connector.engine)
+        target_exists = inspector.has_table(table_name, schema=schema)
         with connector.engine.begin() as conn:
+            if target_exists:
+                conn.execute(text(f"LOCK TABLE {schema}.{table_name} IN ACCESS EXCLUSIVE MODE"))
             conn.execute(text(f"DROP TABLE IF EXISTS {schema}.{table_name}"))
             conn.execute(text(f"ALTER TABLE {schema}.{staging_table} RENAME TO {table_name}"))
 

--- a/tests/unit/swh/test_voters_lock_swap.py
+++ b/tests/unit/swh/test_voters_lock_swap.py
@@ -1,0 +1,89 @@
+"""Regression test for S3 (SW#133): load_voter_file uses explicit
+ACCESS EXCLUSIVE LOCK before DROP+RENAME during atomic table swap.
+
+File-text source-grep (writing-tests:6 / claude-configs-public#123).
+A live concurrency test against a real Postgres would need a fixture
+that exercises a concurrent reader during the swap; out of session
+scope. The source-grep regression goes red if anyone removes the LOCK
+or moves it after the DROP.
+"""
+
+import re
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+import swh.voters as _voters_mod
+
+_SRC = Path(_voters_mod.__file__).read_text(encoding="utf-8")
+
+
+def _strip_comments_and_docstrings(source):
+    cleaned = re.sub(r'"""[\s\S]*?"""', "", source)
+    cleaned = re.sub(r"'''[\s\S]*?'''", "", cleaned)
+    out = []
+    for line in cleaned.splitlines():
+        out.append(line.split("#", 1)[0])
+    return "\n".join(out)
+
+
+_CODE = _strip_comments_and_docstrings(_SRC)
+
+
+class TestLockBeforeDropRename(SimpleTestCase):
+
+    def test_lock_table_in_code(self):
+        assert "LOCK TABLE" in _CODE, (
+            "Post-S3 fix expected `LOCK TABLE ... IN ACCESS EXCLUSIVE MODE` "
+            "before DROP+RENAME. (SW#133)"
+        )
+
+    def test_access_exclusive_mode(self):
+        assert "ACCESS EXCLUSIVE MODE" in _CODE, (
+            "Post-S3 fix expected explicit ACCESS EXCLUSIVE MODE lock "
+            "qualifier. (SW#133)"
+        )
+
+    def test_lock_appears_before_drop_in_swap_block(self):
+        # Find the LOCK occurrence and the swap-block's DROP TABLE IF EXISTS.
+        lock_idx = _CODE.find("LOCK TABLE")
+        drop_idx = _CODE.find("DROP TABLE IF EXISTS")
+        rename_idx = _CODE.find("ALTER TABLE")
+        assert -1 < lock_idx < drop_idx < rename_idx, (
+            f"Order must be LOCK -> DROP -> RENAME within the swap block. "
+            f"Got LOCK@{lock_idx} DROP@{drop_idx} RENAME@{rename_idx}."
+        )
+
+    def test_has_table_check_before_lock(self):
+        # has_table check guards first-ever loads where target does not exist.
+        # Without this, LOCK would error.
+        assert "has_table(" in _CODE, (
+            "Post-S3 fix expected inspect(engine).has_table(...) pre-check "
+            "to guard first-ever-load case where target doesn't exist yet. "
+            "(SW#133)"
+        )
+        has_table_idx = _CODE.find("has_table(")
+        lock_idx = _CODE.find("LOCK TABLE")
+        assert -1 < has_table_idx < lock_idx, (
+            "has_table check must precede the LOCK TABLE statement."
+        )
+
+    def test_lock_is_conditional_on_target_exists(self):
+        # The LOCK must be guarded by a conditional referencing the
+        # target-existence check; otherwise first-ever loads fail.
+        # Heuristic: the line preceding LOCK TABLE should contain "if " and
+        # a variable referencing the existence check.
+        lines = _CODE.splitlines()
+        for i, line in enumerate(lines):
+            if "LOCK TABLE" in line:
+                # Look at the preceding non-blank line for an `if` guard.
+                for j in range(i - 1, max(-1, i - 5), -1):
+                    if lines[j].strip():
+                        assert "if " in lines[j], (
+                            f"LOCK TABLE on line {i} must be guarded by an "
+                            f"`if target_exists`-style conditional; "
+                            f"preceding line was: {lines[j]!r}"
+                        )
+                        return
+        # If we got here, no LOCK TABLE was found -- already covered by
+        # test_lock_table_in_code.


### PR DESCRIPTION
## Summary

S3 / SW#133. Adds explicit `LOCK TABLE ... IN ACCESS EXCLUSIVE MODE` before the DROP+RENAME atomic swap in `load_voter_file`, guarded by an `inspect.has_table` pre-check so first-ever loads (where the target table doesn't exist yet) don't fail on the LOCK.

## Why

Pre-fix relied on Postgres's implicit DDL-acquired lock during DROP. Correct under READ COMMITTED + default DDL behavior, but the lock-acquisition timing was implicit and hard to audit. Production-class loaders should make the acquisition explicit.

## Survey-context exercise (sixth live-use)

NO-DOC -> seed path. `swh/voters.py` was not in the SW project skill catalog; seeded `docs/entities/swh_voters.md` covering both public functions, the DEFAULT_COLUMNS TargetSmart convention, the post-fix staging-swap pattern, and the known-open S2/S4/S6/S8 gotchas. Catalog entry added.

## Test plan

`tests/unit/swh/test_voters_lock_swap.py` (file-text + comment-stripped grep per writing-tests:6 / claude-configs-public#123):

- [x] `LOCK TABLE` present in code (not just in comments).
- [x] `ACCESS EXCLUSIVE MODE` qualifier present.
- [x] `inspect.has_table` check present and precedes the LOCK.
- [x] Ordering: LOCK -> DROP -> RENAME.
- [x] LOCK guarded by an `if`-block (conditional on target existence).

All 6 assertions pass.

## Out of scope (same file, separate PRs)

- S2 (#132): `pd.read_csv` encoding/quoting/dtype hints
- S4 (#134): chunk-append column-shape drift
- S6 (#136): SQL identifier interpolation without quoting
- S8 (#138): cleanup-exception warning lacks remediation hint

Each gets its own PR to keep review surface narrow.

## Operator note on lock-wait timing

Default Postgres `statement_timeout` is unlimited. If a long-running reader holds an `ACCESS SHARE` lock on the target table, the loader's LOCK acquisition will block until the reader releases. Intended; operators wanting fast-fail can set `lock_timeout` on the connection. Out of scope for this PR.

Closes #133
