### PR TITLE
fix(delta/config): remove @lru_cache on get_spark_session (D4 / #126)

### DIFF
--- a/.agents/skills/survey-context/config.md
+++ b/.agents/skills/survey-context/config.md
@@ -15,6 +15,7 @@
 | DemographicSnapshot | Django model | siege_utilities.geo.django.models.demographics | docs/entities/demographic_snapshot.md |
 | api/geo views decorators | DRF decorator surface | socialwarehouse.api.geo.views | docs/entities/api_geo_views_decorators.md |
 | delta/enrichment.py | Spark module | socialwarehouse.delta.enrichment | docs/entities/delta_enrichment.md |
+| delta/config.py | Spark config module | socialwarehouse.delta.config | docs/entities/delta_config.md |
 | settings | Django settings module | socialwarehouse.settings | docs/entities/settings.md |
 
 Seed coverage chosen for E1 hostile-review frequency. Catalog grows on next touch — every `NO-DOC` outcome in survey artifacts is a candidate.

--- a/docs/entities/delta_config.md
+++ b/docs/entities/delta_config.md
@@ -1,0 +1,55 @@
+# delta/config.py (Python module, socialwarehouse.delta.config)
+
+**Definition:** `socialwarehouse/delta/config.py`
+**Surveyed at:** 2026-05-18 (seeded via survey-context NO-DOC path during D4 lru_cache fix)
+**Owner:** delta / warehouse-scale maintainers
+
+## Shape
+
+Spark + Delta Lake configuration. Two public functions:
+
+| Function | Purpose |
+|---|---|
+| `get_spark_session(app_name="socialwarehouse", enable_sedona=False)` | Create or retrieve the JVM's SparkSession configured for Delta Lake (+ optional Sedona spatial extensions). Idempotent via Spark's `getOrCreate()`. |
+| `get_table_path(tier, table_name)` | Build a Delta table path: `{WAREHOUSE_ROOT}/{tier}/{table_name}`. |
+
+## Module constants (env-var-backed)
+
+| Constant | Env var | Default | Notes |
+|---|---|---|---|
+| `WAREHOUSE_ROOT` | `SW_WAREHOUSE_ROOT` | `"s3a://socialwarehouse"` | Root path for tier directories. |
+| `S3_ENDPOINT` | `S3_ENDPOINT` | `"http://10.10.0.10:9000"` | S3 / MinIO endpoint URL. |
+| `S3_ACCESS_KEY` | `S3_ACCESS_KEY` | `""` | **Empty default — D5/#127 open** (silent misconfig). |
+| `S3_SECRET_KEY` | `S3_SECRET_KEY` | `""` | **Empty default — D5/#127 open** (silent misconfig). |
+
+## Singleton semantics (post-D4 fix)
+
+`get_spark_session` is idempotent via Spark's own `SparkSession.builder.getOrCreate()` — the canonical singleton mechanism for a given JVM.
+
+**Pre-D4 (removed in SW#126):** the function was decorated with `@lru_cache(maxsize=1)`. Two arguments (`app_name`, `enable_sedona`) hash into the cache key. Calling with different combinations evicted the prior cached session WITHOUT calling `.stop()`, leaking JVM-side state (SparkContext, scheduler, UI server, broadcast variables). The implicit-cache + explicit-resource-ownership combination is wrong; `getOrCreate()` alone is correct.
+
+**Post-D4:** `@lru_cache` removed. Subsequent calls return the existing session unchanged regardless of `app_name` (standard Spark behavior — first call's `app_name` wins for the JVM lifetime). Sedona registration on an already-running session is idempotent; calling `get_spark_session(enable_sedona=True)` after a non-Sedona session has been created registers Sedona on the existing session.
+
+## Callers / consumers
+
+- `socialwarehouse/delta/enrichment.py` — calls `get_spark_session(enable_sedona=True)` for spatial join workflows.
+- `socialwarehouse/delta/enrichment.py` — uses `get_table_path` to resolve bronze/silver/gold tier paths.
+- `socialwarehouse/delta/tables.py` — uses `get_table_path` for the TABLES registry.
+- Future Spark jobs in this codebase should call `get_spark_session()` rather than building their own `SparkSession.builder` chain — the Delta + S3 configuration is non-trivial and should not be duplicated.
+
+## Cross-references
+
+- `socialwarehouse/delta/tables.py` — TABLES registry references `get_table_path`.
+- `socialwarehouse/delta/enrichment.py` — primary consumer.
+- Sedona registration via `sedona.register.SedonaRegistrator` (optional import; warning logged if missing).
+
+## Known assumptions / gotchas
+
+- **`getOrCreate()` is the singleton mechanism.** Post-D4 fix (SW#126): `@lru_cache(maxsize=1)` was removed. Adding it back would re-introduce the eviction-without-stop leak. Don't.
+- **`S3_ACCESS_KEY` / `S3_SECRET_KEY` default to empty string.** D5/#127 open. When unset, Spark gets `""` credentials and the failure surfaces as opaque AWS SDK errors mid-query rather than a clear ConfigError at startup. Fix: validate at module-load if `WAREHOUSE_ROOT` is `s3a://`.
+- **First-call wins for `app_name`.** Calling `get_spark_session(app_name="X")` then `get_spark_session(app_name="Y")` returns the X-named session both times. Standard Spark behavior. Subsequent renaming requires stopping the existing session first.
+- **`enable_sedona=False` followed by `enable_sedona=True` DOES register Sedona** on the existing session (since Sedona registration is idempotent at runtime). Useful for notebooks that start non-spatial and add spatial later.
+
+## Survey log
+
+- 2026-05-18: Seeded via survey-context NO-DOC path during D4 / SW#126 fix. `@lru_cache(maxsize=1)` decorator removed; docstring expanded to name why `getOrCreate()` is the singleton mechanism and what the lru_cache anti-pattern was. D5/#127 (empty-string S3 credential defaults) remains open.

--- a/socialwarehouse/delta/config.py
+++ b/socialwarehouse/delta/config.py
@@ -13,7 +13,6 @@ Usage:
 
 import logging
 import os
-from functools import lru_cache
 
 logger = logging.getLogger("socialwarehouse.delta")
 
@@ -24,14 +23,26 @@ S3_ACCESS_KEY = os.environ.get("S3_ACCESS_KEY", "")
 S3_SECRET_KEY = os.environ.get("S3_SECRET_KEY", "")
 
 
-@lru_cache(maxsize=1)
 def get_spark_session(app_name="socialwarehouse", enable_sedona=False):
     """Get or create a SparkSession configured for Delta Lake.
 
+    Idempotent via Spark's own `SparkSession.builder.getOrCreate()` — that
+    is the canonical singleton mechanism for a given JVM. An additional
+    @lru_cache layer would be wrong here: a parameterized function with a
+    cache_key based on (app_name, enable_sedona) evicts prior cached
+    sessions WITHOUT calling .stop() when called with different arg
+    combinations, leaking JVM-side state (SparkContext, scheduler, UI
+    server). The @lru_cache decorator was removed in fix for SW#126 (D4).
+
     Args:
-        app_name: Spark application name.
+        app_name: Spark application name. NOTE: only the FIRST call's
+            app_name takes effect for the JVM session; subsequent calls
+            return the existing session regardless of app_name. This is
+            standard Spark behavior, not a bug.
         enable_sedona: If True, register Apache Sedona UDTs and UDFs for
-            spatial operations within Spark.
+            spatial operations within Spark. If the session already
+            exists without Sedona, this call DOES register Sedona on the
+            existing session (registration is idempotent).
 
     Returns:
         SparkSession with Delta Lake extensions.

--- a/tests/unit/delta/test_config_no_lru_cache.py
+++ b/tests/unit/delta/test_config_no_lru_cache.py
@@ -1,0 +1,75 @@
+"""Regression test for D4 (SW#126): get_spark_session is no longer
+decorated with @lru_cache. The Spark singleton mechanism is
+SparkSession.builder.getOrCreate(), not Python-side memoization.
+
+Source-grep + signature inspection. Comment + docstring stripping per
+writing-tests:6 / claude-configs-public#123.
+"""
+
+import re
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from socialwarehouse.delta import config as _cfg
+
+_SRC = Path(_cfg.__file__).read_text(encoding="utf-8")
+
+
+def _strip_comments_and_docstrings(source):
+    cleaned = re.sub(r'"""[\s\S]*?"""', "", source)
+    cleaned = re.sub(r"'''[\s\S]*?'''", "", cleaned)
+    out = []
+    for line in cleaned.splitlines():
+        out.append(line.split("#", 1)[0])
+    return "\n".join(out)
+
+
+_CODE = _strip_comments_and_docstrings(_SRC)
+
+
+class TestNoLruCacheDecorator(SimpleTestCase):
+
+    def test_lru_cache_not_imported(self):
+        assert "from functools import lru_cache" not in _CODE, (
+            "lru_cache import was removed in D4/SW#126 fix; re-adding "
+            "implies someone re-decorated get_spark_session, which "
+            "reintroduces the eviction-without-stop leak."
+        )
+
+    def test_lru_cache_not_applied_to_get_spark_session(self):
+        # Find the def-line and walk backwards through decorators; none
+        # should be @lru_cache.
+        lines = _CODE.splitlines()
+        def_idx = next(
+            (i for i, l in enumerate(lines) if l.startswith("def get_spark_session(")),
+            None,
+        )
+        assert def_idx is not None, "could not find def get_spark_session"
+        decorators = []
+        for i in range(def_idx - 1, -1, -1):
+            stripped = lines[i].strip()
+            if not stripped:
+                break
+            if stripped.startswith("@"):
+                decorators.append(stripped)
+            else:
+                break
+        for dec in decorators:
+            assert "lru_cache" not in dec, (
+                f"get_spark_session must not be @lru_cache decorated "
+                f"(D4/SW#126). Found: {dec}"
+            )
+
+    def test_get_spark_session_function_object_has_no_cache(self):
+        # functools.lru_cache attaches .cache_info() and .cache_clear() to
+        # the wrapped function. If those exist, lru_cache is still applied.
+        fn = _cfg.get_spark_session
+        assert not hasattr(fn, "cache_info"), (
+            "get_spark_session has .cache_info() — implies @lru_cache is "
+            "still applied. Should be a plain function (D4/SW#126)."
+        )
+        assert not hasattr(fn, "cache_clear"), (
+            "get_spark_session has .cache_clear() — implies @lru_cache is "
+            "still applied. Should be a plain function (D4/SW#126)."
+        )


### PR DESCRIPTION
## Summary

D4 / SW#126. Removes `@lru_cache(maxsize=1)` from `get_spark_session`. `SparkSession.builder.getOrCreate()` is the canonical singleton mechanism for the JVM; Python-side memoization on top of it was wrong because eviction semantics don't compose with explicit resource lifecycle (`.stop()`).

Pre-fix: calling with different `(app_name, enable_sedona)` arg combinations evicted the prior cached SparkSession without stopping it, leaking JVM-side state (SparkContext, scheduler, UI server, broadcast variables).

## Survey-context exercise (eighth live-use)

NO-DOC -> seed for `delta/config.py`. New `docs/entities/delta_config.md` covers both public functions, env-var constants (with D5/#127 open-status), the singleton-semantics narrative (pre-fix vs post-fix), callers, and gotchas. Catalog entry added.

## Test plan

`tests/unit/delta/test_config_no_lru_cache.py`:

- [x] Source-grep: no `from functools import lru_cache` import.
- [x] Decorator walk: no `@lru_cache` immediately preceding `def get_spark_session`.
- [x] Function-object: `get_spark_session.cache_info` / `.cache_clear` not present.

3 assertions verified.

## Lesson surfaced

**Don't memoize resource-owning functions.** Memoization's eviction semantics don't compose with explicit `.close()` / `.stop()` / `.disconnect()` semantics. If you need a singleton, use the resource's native mechanism (`getOrCreate`, connection pool, etc.). Banked for the operator-watch rule list pending N>=3 evidence per writing-claims:6.

## Out of scope (same file, separate PR)

- D5 / SW#127: `S3_ACCESS_KEY` / `S3_SECRET_KEY` default to empty string. MINOR.

Closes #126
