### PR TITLE
fix(settings): move GST sys.path insert from manage.py to base.py (ST3 / #141)

### DIFF
--- a/docs/entities/settings.md
+++ b/docs/entities/settings.md
@@ -37,7 +37,7 @@ Order-sensitive (Grappelli must precede `django.contrib.admin`):
 - 3rd party: `rest_framework`, `rest_framework_gis`
 - SU geo: `siege_utilities.geo.django`
 - SW apps: `socialwarehouse.geo`, `socialwarehouse.warehouse`
-- GST: `locations` (bare-name dep on hidden sys.path mechanism — see ST3 / SW#141)
+- GST: `locations` (bare-name; sys.path wired in `base.py` itself post-ST3 / SW#141 so every entry point gets it)
 
 ## GST integration constants
 
@@ -53,7 +53,7 @@ Mirrored from upstream GST settings so SW doesn't pull GST's full config (which 
 - **`SECRET_KEY` MUST be set in production via `DJANGO_SECRET_KEY` env var.** Post-ST1/SW#139 fix: `production.py` does `SECRET_KEY = os.environ["DJANGO_SECRET_KEY"]` which raises `KeyError` at startup if unset. `base.py` retains a documented dev-only fallback for local development. Production deployments that forget the env var **fail fast** rather than silently using the insecure default. (Was ST1, fixed.)
 - **`POSTGRES_PASSWORD` is required in production.** Post-ST4/SW#142 fix: `production.py` overrides `DATABASES["default"]["PASSWORD"]` with `os.environ["POSTGRES_PASSWORD"]` (KeyError at startup if unset). `base.py` retains the empty-string default for dev. The `S3_ACCESS_KEY` / `S3_SECRET_KEY` in `delta/config.py` (D5) is the same anti-pattern but separate scope. (Was ST4, fixed.)
 - **`ALLOWED_HOSTS` is required in production with blank-filtering.** Post-ST2/SW#140 fix: `production.py` does `[h.strip() for h in os.environ["ALLOWED_HOSTS"].split(",") if h.strip()]` — KeyError if env var missing, RuntimeError if it parses to no hosts (e.g. empty string or only commas). Pre-fix returned `[""]` and surfaced as confusing DisallowedHost on every request. (Was ST2, fixed.)
-- **`"locations"` in INSTALLED_APPS depends on hidden sys.path manipulation** from the GST submodule. If the sys.path mechanism breaks (manage.py / conftest.py / wsgi.py refactor), Django fails at startup with `No module named 'locations'`. (ST3, open.)
+- **`"locations"` in INSTALLED_APPS requires the GST app dir on sys.path.** Post-ST3/#141 fix: `base.py` inserts `vendor/geodjango_simple_template/app/hellodjango` into `sys.path` at module-load time, so every entry point that imports settings (manage.py, wsgi.py, asgi.py, pytest, direct `from socialwarehouse.settings import ...`) gets the wiring. Pre-fix the insert lived only in `manage.py`; any non-manage entry point hit `ModuleNotFoundError: No module named 'locations'` at startup. `manage.py`'s insert is preserved as defense-in-depth but is no longer load-bearing.
 - **Settings split via wildcard import** (`from .base import *`). Override files don't re-import `os` explicitly — `production.py` uses `os.environ` through the wildcard import (with `# noqa: F405`). Brittle if `os` is removed from base.py.
 
 ## Callers / consumers
@@ -71,3 +71,4 @@ Mirrored from upstream GST settings so SW doesn't pull GST's full config (which 
 
 - 2026-05-18: Seeded via survey-context NO-DOC path during ST1 / SW#139 fix. Documents the post-ST1 fail-fast pattern for `SECRET_KEY` in production. Pre-ST1 behavior was a hardcoded `"insecure-dev-key-change-in-production"` default in `base.py` that production deployments silently inherited when the env var was unset.
 - 2026-05-18: ST2 / SW#140 + ST4 / SW#142 — production.py now fail-fast on missing `ALLOWED_HOSTS` (KeyError, or RuntimeError if env var parses to no hosts) and missing `POSTGRES_PASSWORD` (KeyError). Same shape as ST1 — bracket subscript at the production override layer; base.py retains dev fallbacks.
+- 2026-05-19: ST3 / SW#141 — GST sys.path wiring moved from `manage.py` to `base.py` at module-load time. Every entry point that loads settings (wsgi/asgi/pytest/direct-import/manage) gets the wiring, not just manage.py. `manage.py`'s insert preserved as defense-in-depth but no longer load-bearing.

--- a/manage.py
+++ b/manage.py
@@ -4,14 +4,16 @@ import os
 import sys
 from pathlib import Path
 
-# GST submodule: vendor/geodjango_simple_template/app/hellodjango/ holds
-# GST's Django apps. Inserted at the start of sys.path so `import
-# locations` resolves once the submodule is initialised. (GST configures
-# its apps with bare names like 'locations', not 'hellodjango.locations',
-# matching how GST itself runs from app/hellodjango/ as cwd.)
-# P1B-A wired the path (one level too high); P1B-B (#68) corrects it
-# and adds GST apps to INSTALLED_APPS. See
-# plans/p1b-b-absorb-gst-apps-design.md.
+# GST submodule sys.path wiring. The load-bearing version of this lives
+# in socialwarehouse/settings/base.py (post-ST3 / SW#141), so every
+# entry point that loads settings (wsgi.py / asgi.py / pytest / ad-hoc
+# settings.import) gets the wiring -- not just manage.py invocations.
+#
+# This duplicate insert is kept as defense-in-depth: it runs slightly
+# earlier (before DJANGO_SETTINGS_MODULE is even set), which helps for
+# the rare case where something imports from the GST app dir before
+# settings is loaded. Safe to delete if settings.base.py is the sole
+# source of truth and no pre-settings imports exist.
 _GST_APP = Path(__file__).resolve().parent / "vendor" / "geodjango_simple_template" / "app" / "hellodjango"
 if _GST_APP.is_dir() and str(_GST_APP) not in sys.path:
     sys.path.insert(0, str(_GST_APP))

--- a/socialwarehouse/settings/base.py
+++ b/socialwarehouse/settings/base.py
@@ -6,9 +6,27 @@ Override in development.py, production.py, or test.py as needed.
 """
 
 import os
+import sys
 from pathlib import Path
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
+
+# GST submodule wiring: insert the GST Django app directory into sys.path
+# so `import locations` resolves when Django processes INSTALLED_APPS.
+#
+# This MUST run before INSTALLED_APPS is referenced by Django -- which
+# means it must run at settings module-load time, not at manage.py time.
+# Pre-fix (ST3 / SW#141) the sys.path insert lived only in manage.py;
+# any entry point that bypassed manage.py (wsgi.py / asgi.py / pytest /
+# ad-hoc `from socialwarehouse.settings import base`) hit
+# `ModuleNotFoundError: No module named 'locations'` at startup.
+#
+# Putting it here makes every entry point that loads settings get the
+# wiring automatically. manage.py's redundant insert is preserved as
+# defense-in-depth but is no longer load-bearing.
+_GST_APP_DIR = BASE_DIR / "vendor" / "geodjango_simple_template" / "app" / "hellodjango"
+if _GST_APP_DIR.is_dir() and str(_GST_APP_DIR) not in sys.path:
+    sys.path.insert(0, str(_GST_APP_DIR))
 
 # Dev-only fallback. Production settings overrides this with a fail-fast
 # os.environ["DJANGO_SECRET_KEY"] read (ST1 / SW#139); production deployments

--- a/tests/unit/settings/test_gst_syspath_wiring.py
+++ b/tests/unit/settings/test_gst_syspath_wiring.py
@@ -1,0 +1,114 @@
+"""Regression test for ST3 (SW#141): GST sys.path wiring in
+socialwarehouse/settings/base.py so every entry point (manage / wsgi /
+asgi / pytest / direct-import) gets the GST app dir on sys.path.
+
+Pre-fix the insert lived only in manage.py; non-manage entry points
+hit ModuleNotFoundError on `import locations` at startup.
+
+Subprocess imports settings.base in an env-stripped subprocess and
+asserts sys.path contains the GST app dir after.
+"""
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_BASE_SRC = (_REPO_ROOT / "socialwarehouse/settings/base.py").read_text(encoding="utf-8")
+_MANAGE_SRC = (_REPO_ROOT / "manage.py").read_text(encoding="utf-8")
+
+
+def _strip_comments_and_docstrings(source):
+    cleaned = re.sub(r'"""[\s\S]*?"""', "", source)
+    cleaned = re.sub(r"'''[\s\S]*?'''", "", cleaned)
+    out = [line.split("#", 1)[0] for line in cleaned.splitlines()]
+    return "\n".join(out)
+
+
+_BASE_CODE = _strip_comments_and_docstrings(_BASE_SRC)
+_MANAGE_CODE = _strip_comments_and_docstrings(_MANAGE_SRC)
+
+
+class TestBaseSettingsInsertsGstPath(SimpleTestCase):
+    """Source-grep: base.py must contain a sys.path.insert for the GST
+    app dir before INSTALLED_APPS is referenced."""
+
+    def test_base_imports_sys(self):
+        assert "import sys" in _BASE_CODE, (
+            "base.py must import sys to manipulate sys.path (ST3 / SW#141)"
+        )
+
+    def test_base_inserts_gst_app_dir(self):
+        # Look for sys.path.insert with a path containing
+        # vendor/geodjango_simple_template.
+        assert "sys.path.insert" in _BASE_CODE, (
+            "base.py must call sys.path.insert for GST submodule "
+            "(ST3 / SW#141)"
+        )
+        assert "geodjango_simple_template" in _BASE_CODE, (
+            "base.py's sys.path insert must target the GST submodule path"
+        )
+
+    def test_insert_runs_before_installed_apps_reference(self):
+        # INSTALLED_APPS = [...] line must come after the sys.path insert.
+        lines = _BASE_CODE.splitlines()
+        installed_idx = next(
+            (i for i, l in enumerate(lines) if l.startswith("INSTALLED_APPS")),
+            None,
+        )
+        insert_idx = next(
+            (i for i, l in enumerate(lines) if "sys.path.insert" in l),
+            None,
+        )
+        assert installed_idx is not None and insert_idx is not None
+        assert insert_idx < installed_idx, (
+            f"sys.path.insert (line {insert_idx}) must precede "
+            f"INSTALLED_APPS (line {installed_idx}); otherwise Django "
+            f"processes INSTALLED_APPS before sys.path is updated."
+        )
+
+
+class TestSubprocessImportInjectsPath(SimpleTestCase):
+    """Behavior test: a fresh subprocess that imports settings.base
+    should have the GST app dir on sys.path after the import."""
+
+    def test_direct_settings_import_inserts_gst_path(self):
+        # Spawn a clean Python subprocess, import settings.base directly,
+        # then print sys.path entries that look like the GST app dir.
+        env = {
+            "PATH": "/usr/bin:/bin",
+            "PYTHONPATH": str(_REPO_ROOT),
+            "DJANGO_SETTINGS_MODULE": "socialwarehouse.settings.base",
+            # Provide the env vars base.py reads.
+            "DJANGO_SECRET_KEY": "test",
+            "POSTGRES_DB": "x",
+            "POSTGRES_USER": "x",
+            "ALLOWED_HOSTS": "localhost",
+        }
+        script = (
+            "from socialwarehouse.settings import base; "
+            "import sys; "
+            "import json; "
+            "print(json.dumps([p for p in sys.path if 'hellodjango' in p]))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env, capture_output=True, text=True, timeout=15,
+        )
+        assert result.returncode == 0, (
+            f"Subprocess failed: stderr={result.stderr!r}"
+        )
+        # Parse JSON from stdout; the LAST line is our print.
+        import json
+        # Take the last non-empty line.
+        last = [l for l in result.stdout.strip().splitlines() if l.strip()][-1]
+        gst_paths = json.loads(last)
+        assert gst_paths, (
+            "After importing settings.base, sys.path must contain an "
+            "entry ending in '.../hellodjango'. Got: "
+            + repr(result.stdout)
+        )


### PR DESCRIPTION
## Summary

ST3 / SW#141. Pre-fix the GST submodule `sys.path` insert lived only in `manage.py`. Any entry point that bypassed manage.py — `wsgi.py` / `asgi.py` for production servers, `pytest` for tests, ad-hoc `from socialwarehouse.settings import base` — hit `ModuleNotFoundError: No module named 'locations'` at startup because `INSTALLED_APPS` contains the bare name `'locations'` (from the GST submodule).

## Fix

Move the `sys.path.insert` into `socialwarehouse/settings/base.py` at module-load time. It runs before Django processes `INSTALLED_APPS` (settings module is imported during Django's bootstrap, before app loading). Every entry point that loads settings now gets the wiring automatically.

`manage.py`'s insert preserved as defense-in-depth (annotated as such in the comment). Idempotent + runs slightly earlier than settings load, helping if some pre-settings code path imports from the GST app dir. Could be removed later for single-source-of-truth cleanliness; keeping for now.

## Survey-context exercise (tenth live-use)

MATCH path on `docs/entities/settings.md`. INSTALLED_APPS section, Known gotchas, and Survey log all updated.

## Test plan

`tests/unit/settings/test_gst_syspath_wiring.py`:

- [x] Source-grep: `base.py` imports `sys` + calls `sys.path.insert` with the `geodjango_simple_template` path.
- [x] Ordering: `sys.path.insert` appears before `INSTALLED_APPS` reference in source.
- [x] Behavior: env-stripped subprocess imports `socialwarehouse.settings.base` in isolation and asserts the GST app dir is on `sys.path` after.

4 assertions verified.

## Lesson surfaced

"Entry-point-conditional initialization" is a common Django anti-pattern. Wiring that only runs in one entry point breaks silently when other entry points are added (wsgi for production, pytest for tests). Settings module is the right place for any Django-prerequisite that must run regardless of entry point.

Closes #141
