### PR TITLE
D5/SW#127: fail-fast on missing S3 credentials at module-load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
       CENSUS_YEAR: "2023"
       CENSUS_CONGRESSIONAL_SESSION: "118"
       CENSUS_STATE_FIPS: all
+      # delta/config.py validates S3 creds at import when WAREHOUSE_ROOT
+      # is s3a://. CI has no S3; point it at a local path so the
+      # validator's file:// carve-out applies. (D5 / SW#127)
+      SW_WAREHOUSE_ROOT: file:///tmp/sw-warehouse-ci
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/entities/delta_config.md
+++ b/docs/entities/delta_config.md
@@ -19,8 +19,8 @@ Spark + Delta Lake configuration. Two public functions:
 |---|---|---|---|
 | `WAREHOUSE_ROOT` | `SW_WAREHOUSE_ROOT` | `"s3a://socialwarehouse"` | Root path for tier directories. |
 | `S3_ENDPOINT` | `S3_ENDPOINT` | `"http://10.10.0.10:9000"` | S3 / MinIO endpoint URL. |
-| `S3_ACCESS_KEY` | `S3_ACCESS_KEY` | `""` | **Empty default — D5/#127 open** (silent misconfig). |
-| `S3_SECRET_KEY` | `S3_SECRET_KEY` | `""` | **Empty default — D5/#127 open** (silent misconfig). |
+| `S3_ACCESS_KEY` | `S3_ACCESS_KEY` | `""` | Empty default; validated at module-load (D5 fix). |
+| `S3_SECRET_KEY` | `S3_SECRET_KEY` | `""` | Empty default; validated at module-load (D5 fix). |
 
 ## Singleton semantics (post-D4 fix)
 
@@ -46,10 +46,11 @@ Spark + Delta Lake configuration. Two public functions:
 ## Known assumptions / gotchas
 
 - **`getOrCreate()` is the singleton mechanism.** Post-D4 fix (SW#126): `@lru_cache(maxsize=1)` was removed. Adding it back would re-introduce the eviction-without-stop leak. Don't.
-- **`S3_ACCESS_KEY` / `S3_SECRET_KEY` default to empty string.** D5/#127 open. When unset, Spark gets `""` credentials and the failure surfaces as opaque AWS SDK errors mid-query rather than a clear ConfigError at startup. Fix: validate at module-load if `WAREHOUSE_ROOT` is `s3a://`.
+- **`S3_ACCESS_KEY` / `S3_SECRET_KEY` are validated at module-load.** Post-D5/SW#127 fix: `_validate_s3_credentials()` runs at import time. If `WAREHOUSE_ROOT` starts with `s3a://` / `s3://` / `s3n://` AND either credential env var is empty, raises `RuntimeError` naming the missing env vars. Carve-out: a non-S3 warehouse root (e.g. `file:///tmp/sw-warehouse` for local dev) skips validation. Pre-fix the empty strings were silently passed to Spark's hadoop config and surfaced as opaque AWS SDK errors mid-query (often hours into a job). Same anti-pattern as the Django `POSTGRES_PASSWORD` empty-string default in `settings/base.py` (ST4); separate scope.
 - **First-call wins for `app_name`.** Calling `get_spark_session(app_name="X")` then `get_spark_session(app_name="Y")` returns the X-named session both times. Standard Spark behavior. Subsequent renaming requires stopping the existing session first.
 - **`enable_sedona=False` followed by `enable_sedona=True` DOES register Sedona** on the existing session (since Sedona registration is idempotent at runtime). Useful for notebooks that start non-spatial and add spatial later.
 
 ## Survey log
 
 - 2026-05-18: Seeded via survey-context NO-DOC path during D4 / SW#126 fix. `@lru_cache(maxsize=1)` decorator removed; docstring expanded to name why `getOrCreate()` is the singleton mechanism and what the lru_cache anti-pattern was. D5/#127 (empty-string S3 credential defaults) remains open.
+- 2026-05-19: D5 / SW#127 fixed. `_validate_s3_credentials()` runs at module-load and raises `RuntimeError` if `WAREHOUSE_ROOT` is `s3a://` / `s3://` / `s3n://` while `S3_ACCESS_KEY` or `S3_SECRET_KEY` is empty. Non-S3 roots (e.g. `file://` for local dev) skip validation. Failure mode moves from opaque mid-query AWS SDK errors to a clear startup-time RuntimeError naming the missing env vars.

--- a/socialwarehouse/delta/config.py
+++ b/socialwarehouse/delta/config.py
@@ -23,6 +23,37 @@ S3_ACCESS_KEY = os.environ.get("S3_ACCESS_KEY", "")
 S3_SECRET_KEY = os.environ.get("S3_SECRET_KEY", "")
 
 
+def _validate_s3_credentials():
+    """Fail-fast at module-load when WAREHOUSE_ROOT requires S3 credentials.
+
+    Pre-D5/SW#127: empty S3_ACCESS_KEY / S3_SECRET_KEY were silently passed
+    through to Spark's hadoop config; first read/write surfaced as an
+    opaque AWS SDK error mid-query (often hours into a job). Now: if the
+    warehouse root looks like s3a:// AND credentials are empty, raise a
+    clear RuntimeError at import time naming the env vars to set.
+
+    Carve-out: a non-s3a:// warehouse root (e.g. local file:// for dev)
+    does not require S3 creds; validation is skipped.
+    """
+    if not WAREHOUSE_ROOT.startswith(("s3a://", "s3://", "s3n://")):
+        return  # local filesystem or other; no S3 creds needed
+    missing = []
+    if not S3_ACCESS_KEY:
+        missing.append("S3_ACCESS_KEY")
+    if not S3_SECRET_KEY:
+        missing.append("S3_SECRET_KEY")
+    if missing:
+        raise RuntimeError(
+            f"WAREHOUSE_ROOT={WAREHOUSE_ROOT!r} requires S3 credentials but "
+            f"{', '.join(missing)} env var(s) are unset. Set them in the "
+            f"environment or point SW_WAREHOUSE_ROOT at a non-S3 path "
+            f"(e.g. 'file:///tmp/sw-warehouse' for local dev). (D5 / SW#127)"
+        )
+
+
+_validate_s3_credentials()
+
+
 def get_spark_session(app_name="socialwarehouse", enable_sedona=False):
     """Get or create a SparkSession configured for Delta Lake.
 

--- a/tests/unit/delta/test_config_d5_credential_validation.py
+++ b/tests/unit/delta/test_config_d5_credential_validation.py
@@ -1,0 +1,91 @@
+"""Regression test for D5 (SW#127): delta/config.py validates S3
+credentials at module-load time when WAREHOUSE_ROOT requires S3.
+
+Behavior tests: re-import the module under different env var
+combinations and assert it raises (or doesn't) as designed.
+"""
+
+import importlib
+import os
+import sys
+
+from django.test import SimpleTestCase
+
+
+def _reimport_config(env):
+    """Reload socialwarehouse.delta.config under the given env dict."""
+    saved = {k: os.environ.get(k) for k in
+             ("SW_WAREHOUSE_ROOT", "S3_ACCESS_KEY", "S3_SECRET_KEY")}
+    try:
+        for k, v in env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        sys.modules.pop("socialwarehouse.delta.config", None)
+        return importlib.import_module("socialwarehouse.delta.config")
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        sys.modules.pop("socialwarehouse.delta.config", None)
+
+
+class TestD5CredentialValidation(SimpleTestCase):
+
+    def test_s3a_root_missing_both_creds_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            _reimport_config({
+                "SW_WAREHOUSE_ROOT": "s3a://bucket",
+                "S3_ACCESS_KEY": "",
+                "S3_SECRET_KEY": "",
+            })
+        msg = str(cm.exception)
+        assert "S3_ACCESS_KEY" in msg
+        assert "S3_SECRET_KEY" in msg
+        assert "D5" in msg or "SW#127" in msg
+
+    def test_s3a_root_missing_only_secret_raises(self):
+        with self.assertRaises(RuntimeError) as cm:
+            _reimport_config({
+                "SW_WAREHOUSE_ROOT": "s3a://bucket",
+                "S3_ACCESS_KEY": "key",
+                "S3_SECRET_KEY": "",
+            })
+        assert "S3_SECRET_KEY" in str(cm.exception)
+        assert "S3_ACCESS_KEY" not in str(cm.exception)
+
+    def test_s3_scheme_also_validated(self):
+        with self.assertRaises(RuntimeError):
+            _reimport_config({
+                "SW_WAREHOUSE_ROOT": "s3://bucket",
+                "S3_ACCESS_KEY": "",
+                "S3_SECRET_KEY": "",
+            })
+
+    def test_s3n_scheme_also_validated(self):
+        with self.assertRaises(RuntimeError):
+            _reimport_config({
+                "SW_WAREHOUSE_ROOT": "s3n://bucket",
+                "S3_ACCESS_KEY": "",
+                "S3_SECRET_KEY": "",
+            })
+
+    def test_file_root_skips_validation(self):
+        mod = _reimport_config({
+            "SW_WAREHOUSE_ROOT": "file:///tmp/sw-warehouse",
+            "S3_ACCESS_KEY": "",
+            "S3_SECRET_KEY": "",
+        })
+        assert mod.WAREHOUSE_ROOT == "file:///tmp/sw-warehouse"
+
+    def test_s3a_root_with_both_creds_succeeds(self):
+        mod = _reimport_config({
+            "SW_WAREHOUSE_ROOT": "s3a://bucket",
+            "S3_ACCESS_KEY": "k",
+            "S3_SECRET_KEY": "s",
+        })
+        assert mod.S3_ACCESS_KEY == "k"
+        assert mod.S3_SECRET_KEY == "s"


### PR DESCRIPTION
## Summary

Closes #127. `socialwarehouse/delta/config.py` now validates `S3_ACCESS_KEY` / `S3_SECRET_KEY` at module-load and raises `RuntimeError` when `WAREHOUSE_ROOT` requires S3 (`s3a://` / `s3://` / `s3n://`) but either credential env var is empty. Non-S3 roots (e.g. `file:///tmp/sw-warehouse` for local dev) skip validation.

## Why

Pre-fix the empty-string defaults were silently passed into Spark's hadoop config. First read/write surfaced as an opaque AWS SDK error — sometimes hours into a job. Now: clear startup error naming the missing env vars.

Same anti-pattern as the Django `POSTGRES_PASSWORD` empty-default in `settings/base.py` (ST4); separate scope.

## Test plan

- [x] Behavior-not-inspection regression test added at `tests/unit/delta/test_config_d5_credential_validation.py`:
  - `s3a://` no-creds → RuntimeError (both missing)
  - `s3a://` only secret missing → RuntimeError (only S3_SECRET_KEY named)
  - `s3://` and `s3n://` schemes also validated
  - `file://` root skips validation
  - `s3a://` with both creds succeeds
- [x] Manually exercised all three paths under env-stripped subprocess before commit
- [x] Doc updated: `docs/entities/delta_config.md` (constants table, gotchas, survey log)
- [ ] CI run

## Self-review

See trailer in commit message.