### PR TITLE
api/geo bundle: A4+A5+A7+A8+A10 (#115, #116, #118, #119, #121)

### DIFF
--- a/docs/entities/api_geo_views_decorators.md
+++ b/docs/entities/api_geo_views_decorators.md
@@ -25,7 +25,7 @@ Endpoints currently defined (verify against source on each touch):
 - `boundary_detail(request, boundary_type, geoid)` — single boundary; **cache_page direct, NOT method_decorator** (A1 / SW#112 fix)
 - `proximity(request)` — nearest-boundary search
 - `intersections(request)` — overlap query
-- `standardize_address(request)` — fragile parser; A7 finding
+- `standardize_address(request)` — best-effort placeholder, naive comma-split US-only parser (A7 / SW#118 — documented as placeholder, not replaced)
 - `reverse_geocode(request)` — coord → address
 
 ### Helper conventions
@@ -33,14 +33,15 @@ Endpoints currently defined (verify against source on each touch):
 - `_resolve_boundary_model(boundary_type)` — single-type lookup against `BOUNDARY_MODELS`. Returns `(model, None)` on hit, `(None, Response)` with a 400 + `valid_types` list on miss. Used by `boundary_list`, `boundary_detail`, and `proximity` (A6 / SW#117 fix). Loop sites (`geocode`, `_get_demographics_for_boundaries`) iterate types and silently skip unknowns — they do NOT use this helper.
 - `_forward_geocode(address)` / `_reverse_geocode(lat, lon)` — return `(lat, lon)` / dict / None on miss; log exceptions at WARNING (A3 / SW#114 fix).
 - `_get_demographics_for_boundaries(model, geoid)` — content_type + geoid lookup against DemographicSnapshot (see demographic_snapshot.md).
-- `_serialize_boundary(obj)` — hasattr-chain serialization (A8 finding).
-- `_standardize_address(address)` — comma-split parser (A7 finding).
+- `_serialize_boundary(obj)` — hasattr-chain serialization. Post-A8/SW#119: chain is intentional and documented in the function docstring; BOUNDARY_MODELS span Census/political/timezone tables with genuinely different field sets (abbreviation: State only; district/congress fields: CongressionalDistrict only; timezone fields: TimezoneGeometry only; area_land/water: most Census). A per-model field map would be more code than the chain.
+- `_standardize_address(address)` — comma-split placeholder (A7 / SW#118). Post-A10/SW#121: returns `{"components": {...}}` only — the previously-included `input` key was dead (the only caller surfaces the original address as `original`).
 
 ## Known assumptions / gotchas
 
 - **`method_decorator(cache_page(...), name="dispatch")` is class-based-view shape ONLY.** `name="dispatch"` references the `dispatch` method which exists on `View` subclasses, not on functions. Applying it to a function-based view silently no-ops the cache (A1 / SW#112 — fixed). Future cache decorators on these endpoints must apply `@cache_page(seconds)` directly.
 - **Geocode helpers return `None` on miss AND on exception.** Per A3 / SW#114, exceptions are logged at WARNING with type + message + inputs. Callers can distinguish "no result" vs "geocoder failure" only via the log; the return value is the same. If a future API surface needs the distinction, change the helpers' contract and update this doc.
 - **No authentication/permission classes** on any view (A9). All endpoints are publicly readable. Document any change.
+- **`boundary_detail` cache TTL is 1 day** (post-A5/SW#116). Pre-fix was 7 days, which exceeded the actual boundary-update cadence enough to produce week-old stale responses after a re-load. No save-signal-driven invalidation yet; 24h is the blunt-instrument compromise.
 - **`BOUNDARY_MODELS` registry** is the canonical list of supported boundary types. Adding a new boundary type requires updating the registry. Single-type lookups go through `_resolve_boundary_model` (which returns a standardized 400 with `valid_types` on miss); loop-sites iterate the registry directly and silently skip unknowns. Before A6/#117 the single-type pattern was duplicated across 3 endpoints with an inconsistency (`boundary_detail`'s 400 omitted `valid_types`); the helper standardizes the response shape.
 
 ## Callers / consumers
@@ -52,3 +53,4 @@ Endpoints currently defined (verify against source on each touch):
 
 - 2026-05-18: Seeded post-PR #122 (A1+A3 fixes). Documents the function-based-view shape that A1 violated. Future PRs that touch decorators or add endpoints must update this page in the same PR.
 - 2026-05-18: A6/#117 fix — `_resolve_boundary_model` helper extracted; `boundary_detail` 400 response now includes `valid_types` (was inconsistent). Helper-conventions and BOUNDARY_MODELS notes updated.
+- 2026-05-19: api/geo bundle A4+A5+A7+A8+A10 fixes (PRs SW#115, #116, #118, #119, #121). Module docstring corrected (no `BoundaryManager` wrapper exists — A4). `boundary_detail` cache_page TTL reduced 7d → 1d (A5). `_standardize_address` flagged in-source as a US-only naive placeholder; `standardize_address` view docstring marks it best-effort (A7). `_serialize_boundary` hasattr chain kept and explained inline; BOUNDARY_MODELS field-heterogeneity documented (A8). Dead `input` key dropped from `_standardize_address` return (A10).

--- a/socialwarehouse/api/geo/views.py
+++ b/socialwarehouse/api/geo/views.py
@@ -1,8 +1,11 @@
 """Geospatial API views — DSTK replacement.
 
 Provides geocoding, point-in-polygon, boundary retrieval, proximity,
-and intersection endpoints. Wraps siege_utilities BoundaryManager
-spatial queries.
+and intersection endpoints. Uses queryset manager methods
+(`containing_point`, `nearest`, standard Django ORM filters) on
+siege_utilities boundary models. No `BoundaryManager` wrapper class is
+imported or used; the previous wording of this docstring was stale.
+(A4 / SW#115)
 """
 
 import json
@@ -54,7 +57,26 @@ DEFAULT_GEOCODE_TYPES = [
 
 
 def _serialize_boundary(obj, include_geometry=False):
-    """Serialize a boundary object to a dict."""
+    """Serialize a boundary object to a dict.
+
+    The `hasattr` chain below is intentional: BOUNDARY_MODELS span
+    Census/political/timezone tables with genuinely different field
+    sets, and a single endpoint serializes whichever model the caller
+    requested. Per-field heterogeneity (A8 / SW#119):
+
+    - `abbreviation`: State only
+    - `state_fips`: County, Tract, Place, ZCTA, CongressionalDistrict,
+      StateLegislativeUpper/Lower, VTD (any sub-state Census model)
+    - `district_number`, `congress_number`: CongressionalDistrict only
+    - `timezone_id`, `utc_offset_std`: TimezoneGeometry only
+    - `area_land`, `area_water`: most Census boundaries; not on
+      TimezoneGeometry or political models that don't carry TIGER metadata
+
+    Replacing the chain with a per-model field map would be more code
+    than the chain itself for the same behavior, so we keep the chain
+    and document the diversity here. Mirrors the W6 (#110) pattern in
+    `dimension_loader.py`.
+    """
     data = {
         "geoid": getattr(obj, "geoid", getattr(obj, "feature_id", None)),
         "name": obj.name,
@@ -209,7 +231,12 @@ def reverse_geocode(request):
 @api_view(["GET"])
 @throttle_classes([GeocodeThrottle])
 def standardize_address(request):
-    """Standardize an address string without geocoding."""
+    """Standardize an address string without geocoding.
+
+    Best-effort placeholder: backed by `_standardize_address`, a naive
+    comma-split US-only parser. Not suitable for international formats
+    or addresses without commas. (A7 / SW#118)
+    """
     address = request.query_params.get("address")
     if not address:
         return Response({"error": "address parameter is required"}, status=status.HTTP_400_BAD_REQUEST)
@@ -265,8 +292,13 @@ def boundary_list(request, boundary_type):
     return paginator.get_paginated_response(data)
 
 
+# 1-day TTL (was 7 days, A5 / SW#116). Boundary updates from upstream
+# loaders (TIGER, RDH, etc.) ship on the order of weeks-to-months, so a
+# 24h staleness window matches the actual update cadence and keeps
+# operator surprise low after a re-load. Lacking a save-signal-driven
+# invalidation, 1 day is the right blunt instrument.
 @api_view(["GET"])
-@cache_page(60 * 60 * 24 * 7)
+@cache_page(60 * 60 * 24)
 def boundary_detail(request, boundary_type, geoid):
     """Retrieve a single boundary by type and GEOID. Always includes geometry."""
     model, err = _resolve_boundary_model(boundary_type)
@@ -442,9 +474,23 @@ def _reverse_geocode(lat, lon):
 
 
 def _standardize_address(address):
-    """Standardize an address string. Returns dict of parsed components."""
+    """Standardize an address string. Returns dict of parsed components.
+
+    PLACEHOLDER (A7 / SW#118): this is a naive comma-split that assumes
+    a US-style "street, city, state zip" shape. It will misparse
+    international formats, multi-line addresses, and anything without
+    commas. Replace with `usaddress` (US-only) or `libpostal` (heavier,
+    international) when the endpoint moves past placeholder status. The
+    `standardize_address` view that calls this is explicitly documented
+    as best-effort.
+
+    The returned dict's outer `input` key was previously dead — the
+    only caller (`standardize_address` at line 211) already surfaces
+    the original address as the response's `original` key and ignores
+    the inner `input`. Dropping it here. (A10 / SW#121)
+    """
     parts = [p.strip() for p in address.split(",")]
-    result = {"input": address, "components": {}}
+    result = {"components": {}}
     if len(parts) >= 3:
         result["components"]["street"] = parts[0]
         result["components"]["city"] = parts[1]

--- a/tests/unit/api/test_geo_views_a_bundle.py
+++ b/tests/unit/api/test_geo_views_a_bundle.py
@@ -1,0 +1,109 @@
+"""Regression tests for the api/geo bundle: A4+A5+A7+A8+A10.
+
+A4 (#115): module docstring no longer claims BoundaryManager wrapping.
+A5 (#116): boundary_detail cache_page TTL is 1 day, not 7.
+A7 (#118): _standardize_address documents itself as a placeholder.
+A8 (#119): _serialize_boundary hasattr chain documented in-source.
+A10 (#121): _standardize_address return drops the dead "input" key.
+
+A5 verification uses a source-grep on the decorator line (writing-tests:6
+inspection carve-out — decorator inspection from a live api_view is
+unreliable through the DRF wrapper).
+"""
+
+import re
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from socialwarehouse.api.geo import views as _views
+
+
+_SRC = Path(_views.__file__).read_text(encoding="utf-8")
+
+
+def _strip_comments_and_docstrings(source):
+    cleaned = re.sub(r'"""[\s\S]*?"""', "", source)
+    cleaned = re.sub(r"'''[\s\S]*?'''", "", cleaned)
+    out = []
+    for line in cleaned.splitlines():
+        out.append(line.split("#", 1)[0])
+    return "\n".join(out)
+
+
+_CODE = _strip_comments_and_docstrings(_SRC)
+
+
+class TestModuleDocstring(SimpleTestCase):
+    def test_docstring_no_longer_claims_boundarymanager_wrapping(self):
+        # Module docstring should NOT describe a BoundaryManager wrapper
+        # (no such import exists). The new wording mentions queryset
+        # manager methods directly. A4 / SW#115.
+        doc = _views.__doc__ or ""
+        # The literal phrase from the stale docstring must be gone.
+        assert "Wraps siege_utilities BoundaryManager" not in doc
+        # The corrected wording mentions queryset / manager methods.
+        assert "queryset manager methods" in doc
+
+    def test_no_boundarymanager_import(self):
+        assert "BoundaryManager" not in _CODE or "No `BoundaryManager`" in (_views.__doc__ or "")
+
+
+class TestBoundaryDetailCacheTTL(SimpleTestCase):
+    def test_cache_page_is_one_day_not_seven(self):
+        # A5 / SW#116. The decorator line must apply a 1-day TTL on the
+        # boundary_detail view, not 7-day. Source-grep because the
+        # cached function object exposes the wrapper, not the original
+        # decorator args.
+        # Match either `60 * 60 * 24` exactly, OR the literal 86400.
+        # MUST NOT match `60 * 60 * 24 * 7` or 604800 anywhere in views.py.
+        assert re.search(r"@cache_page\(\s*60\s*\*\s*60\s*\*\s*24\s*\)", _CODE), (
+            "expected @cache_page(60*60*24) (1 day) on a view"
+        )
+        assert "60 * 60 * 24 * 7" not in _CODE, (
+            "7-day cache_page TTL still present; A5 fix reverted?"
+        )
+
+
+class TestStandardizeAddressPlaceholder(SimpleTestCase):
+    def test_standardize_drops_dead_input_key(self):
+        # A10 / SW#121. The helper's return dict must no longer carry
+        # an outer "input" key — the caller surfaces the original
+        # address as "original" and never used the inner key.
+        result = _views._standardize_address("123 Main St, Austin, TX 78701")
+        assert "input" not in result
+        assert "components" in result
+        assert result["components"]["street"] == "123 Main St"
+        assert result["components"]["city"] == "Austin"
+        assert result["components"]["state"] == "TX"
+        assert result["components"]["zip"] == "78701"
+
+    def test_two_part_fallback_still_works(self):
+        result = _views._standardize_address("123 Main St, Austin TX 78701")
+        assert "input" not in result
+        assert result["components"]["street"] == "123 Main St"
+        assert result["components"]["city_state_zip"] == "Austin TX 78701"
+
+    def test_no_comma_fallback(self):
+        result = _views._standardize_address("just a string")
+        assert "input" not in result
+        assert result["components"]["raw"] == "just a string"
+
+    def test_docstring_marks_placeholder(self):
+        # A7 / SW#118. The helper's docstring should self-identify as a
+        # placeholder so future maintainers don't mistake it for a
+        # production parser.
+        doc = _views._standardize_address.__doc__ or ""
+        assert "PLACEHOLDER" in doc or "placeholder" in doc
+
+
+class TestSerializeBoundaryHasattrChainDocumented(SimpleTestCase):
+    def test_docstring_explains_field_heterogeneity(self):
+        # A8 / SW#119. The hasattr chain stays; the docstring must
+        # explain WHY (BOUNDARY_MODELS span tables with different
+        # field sets).
+        doc = _views._serialize_boundary.__doc__ or ""
+        # Must mention at least one model-specific field and the
+        # rationale phrase.
+        assert "TimezoneGeometry" in doc
+        assert "CongressionalDistrict" in doc or "district_number" in doc


### PR DESCRIPTION
## Summary

Bundle of five api/geo findings, all in `socialwarehouse/api/geo/views.py` (file-grained bundling per session pattern):

- **A4 / #115**: rewrite stale module docstring (no `BoundaryManager` wrapper exists).
- **A5 / #116**: `boundary_detail` `cache_page` TTL 7d → 1d.
- **A7 / #118**: mark `_standardize_address` as a documented placeholder (naive US-only comma-split, future replacement to use usaddress/libpostal).
- **A8 / #119**: keep `_serialize_boundary` hasattr chain, document the BOUNDARY_MODELS field heterogeneity that makes it necessary.
- **A10 / #121**: drop the dead `input` key from `_standardize_address`'s return.

## Test plan

- [x] `tests/unit/api/test_geo_views_a_bundle.py`: behavior test for A10 (input/output of `_standardize_address`), docstring + source-grep tests for A4, A5, A7, A8.
- [x] Doc updated: `docs/entities/api_geo_views_decorators.md` (endpoint list, helper notes, gotchas, survey log).
- [x] Manually traced the single caller of `_standardize_address` before removing the `input` key.
- [ ] CI run.

## Closes

#115, #116, #118, #119, #121.

## Self-review

See trailer in commit message.