### PR TITLE
M6/SW#150: enforce geocoded=True implies geom IS NOT NULL

### DIFF
--- a/docs/entities/geocode_addresses_command.md
+++ b/docs/entities/geocode_addresses_command.md
@@ -1,0 +1,60 @@
+# geocode_addresses management command (Django command, socialwarehouse.geo)
+
+**Definition:** `socialwarehouse/geo/management/commands/geocode_addresses.py`
+**Surveyed at:** 2026-05-19 (seeded via survey-context NO-DOC path during M6 fix)
+**Owner:** geo / address-loading maintainers
+
+## Shape
+
+Django management command that geocodes `Address` rows where `geocoded=False`. Two-phase pipeline:
+
+1. **Phase 1 — Census batch geocoder.** Streams addresses in chunks of `batch_size` through the Census Bureau batch API. Per-chunk `bulk_update` with `ADDRESS_BULK_UPDATE_FIELDS`.
+2. **Phase 2 — Nominatim fallback.** Receives the `census_unmatched` list from Phase 1 (in `dual` mode) or its own queryset (in `nominatim-only` mode). Same streaming + bulk_update shape.
+
+## CLI flags
+
+| Flag | Effect |
+|---|---|
+| `--source {dual,census-only,nominatim-only}` | Which phases to run. |
+| `--batch-size N` | Chunk size for Census batch API + bulk_update flushes. |
+| `--limit N` | Cap total addresses processed. |
+| `--force` | Re-geocode rows where `geocoded=True`. |
+| `--dry-run` | Print what would be processed; no DB writes. |
+| `--nominatim-url URL` | Override Nominatim endpoint. |
+
+## State invariants (post-M6 fix)
+
+**`geocoded=True` implies `geom IS NOT NULL`.** Both phases enforce: the address is only marked `geocoded=True` AFTER `lat` and `lon` are non-falsy AND `geom` is populated as a `Point(lon, lat, srid=4326)`.
+
+**Pre-M6/SW#150:** Census's `matched=True` was the gate. Census occasionally returns `matched=True` with `lat=None`/`lon=None` (street + city resolved but no coords); those rows flipped `geocoded=True` while leaving `geom=NULL`. Downstream filters on `geocoded=True` alone returned ghost rows that spatial joins silently dropped.
+
+**Post-fix:** matched-without-coords is demoted to `census_unmatched` and Phase 2 (Nominatim) gets a real try at it.
+
+## Bulk-update pattern (post-M1+M2+M3 fix)
+
+- `ADDRESS_BULK_UPDATE_FIELDS` is an explicit module constant listing every field that `bulk_update` is allowed to write. Adding a new write requires adding the field to the constant in the same diff.
+- `DB_BULK_CHUNK = 500` controls per-flush write size.
+- `_yield_chunks(iterable, chunk_size)` is a stand-alone generator (testable in isolation).
+- Phase 1's `chunk_map` is local to a single batch (no cross-phase shared state).
+- Phase 2's source is either `iter(census_unmatched)` (dual mode) or `queryset.iterator()` (nominatim-only).
+
+## Callers / consumers
+
+- `python manage.py geocode_addresses ...` (operator-invoked)
+- Cron / Celery scheduled tasks
+
+## Cross-references
+
+- `socialwarehouse.warehouse.fact.Address` — the model written to.
+- `socialwarehouse.geo.census_geocoder.geocode_batch_chunked` — Census API client.
+- `siege_utilities.geo.nominatim.use_nominatim_geocoder` — Nominatim wrapper.
+
+## Known assumptions / gotchas
+
+- **`geocoded=True` implies `geom IS NOT NULL`** (M6 post-fix; see above).
+- **Census `matched=True` is not coordinate-bearing on its own** — the upstream API can mark a row matched without populating lat/lon. Phase 1's filter respects this.
+- **Phase 2 in dual mode iterates the in-memory list** (`census_unmatched`). For very large geocoding runs (millions of rows) the memory cost grows with the Phase-1 unmatched count. Acceptable today (typical unmatched fraction is <5% of input).
+
+## Survey log
+
+- 2026-05-19: Seeded via survey-context NO-DOC path during M6 / SW#150 fix. Documents the post-M6 invariant and the existing post-M1/M2/M3 bulk-update + chunking shape. M4 (#148) closed as obsolete (no `address_map` exists post-refactor). M5 (#149 — PostGIS-side intersection rewrite) and M7 (#151 — export_to_delta advisory inconsistency) remain open.

--- a/socialwarehouse/geo/management/commands/geocode_addresses.py
+++ b/socialwarehouse/geo/management/commands/geocode_addresses.py
@@ -143,11 +143,19 @@ class Command(BaseCommand):
                     addr = chunk_map.get(result.input_id)
                     if addr is None:
                         continue
-                    if result.matched:
+                    # Census's `matched=True` does not guarantee coordinates:
+                    # the batch geocoder can return a non-Match (street + city
+                    # resolved) without populating lat/lon. Treating those as
+                    # geocoded=True with geom=NULL breaks the downstream
+                    # invariant "geocoded == True implies geom is not None"
+                    # — filters on `geocoded=True` alone return rows that
+                    # spatial joins then drop silently. Demote matched-without-
+                    # coords to the unmatched bucket so Phase 2 (Nominatim)
+                    # gets a real try. (M6 / SW#150)
+                    if result.matched and result.lat and result.lon:
                         addr.latitude = result.lat
                         addr.longitude = result.lon
-                        if result.lat and result.lon:
-                            addr.geom = Point(result.lon, result.lat, srid=4326)
+                        addr.geom = Point(result.lon, result.lat, srid=4326)
                         addr.geocoded = True
                         addr.geocode_source = "census"
                         addr.geocode_quality = result.match_type

--- a/tests/unit/geo/test_geocode_addresses_m6_invariant.py
+++ b/tests/unit/geo/test_geocode_addresses_m6_invariant.py
@@ -1,0 +1,64 @@
+"""Regression test for M6 (SW#150): geocode_addresses Phase-1 enforces
+the invariant `geocoded=True implies geom IS NOT NULL`.
+
+Pre-fix: Census `matched=True` flipped `geocoded=True` regardless of
+whether lat/lon were populated. Post-fix: matched-without-coords is
+demoted to the unmatched bucket.
+
+Source-grep regression (writing-tests:6 carve-out): the actual control
+flow lives inside a management-command handle() with heavy DB/HTTP
+fixtures; we assert the structural property that the matched branch
+requires lat AND lon at the condition.
+"""
+
+import re
+from pathlib import Path
+
+from django.test import SimpleTestCase
+
+from socialwarehouse.geo.management.commands import geocode_addresses as _mod
+
+
+_SRC = Path(_mod.__file__).read_text(encoding="utf-8")
+
+
+def _strip_comments_and_docstrings(source):
+    cleaned = re.sub(r'"""[\s\S]*?"""', "", source)
+    cleaned = re.sub(r"'''[\s\S]*?'''", "", cleaned)
+    out = []
+    for line in cleaned.splitlines():
+        out.append(line.split("#", 1)[0])
+    return "\n".join(out)
+
+
+_CODE = _strip_comments_and_docstrings(_SRC)
+
+
+class TestM6CoordsRequiredForGeocoded(SimpleTestCase):
+
+    def test_matched_branch_requires_lat_and_lon(self):
+        # Post-M6: the condition for entering the "mark geocoded=True"
+        # branch must include result.lat AND result.lon, not just
+        # result.matched.
+        assert re.search(
+            r"if\s+result\.matched\s+and\s+result\.lat\s+and\s+result\.lon\s*:",
+            _CODE,
+        ), (
+            "Post-M6/SW#150 condition not found: expected "
+            "'if result.matched and result.lat and result.lon:' guard"
+        )
+
+    def test_no_bare_matched_only_branch(self):
+        # The pre-fix shape was `if result.matched:` followed by a
+        # nested `if result.lat and result.lon:` only on the geom
+        # assignment. The post-fix removes that pattern by moving the
+        # coord check up to the outer condition.
+        # Match: any line that is exactly `if result.matched:` (no AND).
+        assert not re.search(
+            r"^\s*if\s+result\.matched\s*:\s*$",
+            _CODE,
+            flags=re.MULTILINE,
+        ), (
+            "Pre-M6 bare `if result.matched:` branch is back. "
+            "matched=True without coords must be demoted to unmatched."
+        )


### PR DESCRIPTION
## Summary

Closes #150. Tightens the Phase-1 condition in `geocode_addresses` so a row is only marked `geocoded=True` when Census returns `matched=True` AND `lat` AND `lon` are all truthy. Matched-without-coords gets demoted to `census_unmatched` so Phase 2 (Nominatim) gets a real try.

Establishes the invariant **`geocoded=True implies geom IS NOT NULL`** that downstream spatial-join filters already assume.

Also closes #148 (M4) as obsolete: the `address_map` symbol no longer exists post-M1/M2/M3 refactor.

## Why

Census's batch geocoder occasionally returns `matched=True` with `lat=None`/`lon=None`. Pre-fix those rows flipped `geocoded=True` with `geom=NULL`. Downstream filters on `geocoded=True` alone returned ghost rows that spatial joins silently dropped — invisible loss.

## Test plan

- [x] Structural regression test at `tests/unit/geo/test_geocode_addresses_m6_invariant.py` (writing-tests:6 source-grep carve-out for management-command handle()).
- [x] Manually verified Phase 2 already enforces the invariant (geocoded flip is inside `if location:`).
- [x] Entity doc seeded: `docs/entities/geocode_addresses_command.md`.
- [ ] CI run.

## Self-review

See trailer in commit message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Addresses receiving incomplete geocoding results from the Census service are now correctly marked for retry, improving overall address matching coverage and accuracy.

* **Tests**
  * Added regression test to maintain geocoding state consistency and prevent future data integrity issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->