### PR TITLE
delta bundle: D7 (#129 SCD-decision doc) + D8 (#130 typo-validation)

### DIFF
--- a/docs/entities/delta_enrichment.md
+++ b/docs/entities/delta_enrichment.md
@@ -18,7 +18,7 @@ Spark + Sedona enrichment surface for warehouse-scale geographic operations. Two
 
 **Inputs:**
 - `spark` — `SparkSession` with Sedona registered (caller responsible; failure to register surfaces as `AnalysisException: Undefined function: ST_Contains`).
-- `addresses_table` — either a key from `delta/tables.py:TABLES` (resolved via the registry) OR a raw Delta path. Brittle to typos — invalid registry-shaped strings fall through to raw-path interpretation (D8 finding).
+- `addresses_table` — either a key from `delta/tables.py:TABLES` (resolved via the registry) OR a raw Delta path (containing `/` or a scheme like `s3a://`). Post-D8/SW#130: anything else (no `/`, no scheme, not a registry key) raises `ValueError` at the function boundary naming the known keys. Pre-fix typos fell through to `spark.read.load()` and surfaced as confusing "path does not exist" errors deep in the Spark stack.
 - `year` — Census vintage year. Used to filter boundaries before joins. Defaults to 2020.
 - `boundaries_path` — optional Delta path for boundaries. Defaults to `get_table_path("silver", "boundaries")`.
 
@@ -60,3 +60,4 @@ JDBC read from `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_DB` env vars; write
 ## Survey log
 
 - 2026-05-18: Seeded via survey-context NO-DOC path during D1+D2+D3 bundled fix (PR pending). Documents the post-fix function contract; pre-fix gotchas captured in Known gotchas section above.
+- 2026-05-19: D8 / SW#130 fix — `addresses_table` resolution now distinguishes "raw path" (has `/` or scheme) from "typo'd registry key" (neither). Typos raise `ValueError` at the function boundary listing the available keys. Pre-fix Spark surfaced a confusing path-not-found mid-job.

--- a/docs/entities/delta_tables.md
+++ b/docs/entities/delta_tables.md
@@ -1,0 +1,44 @@
+# delta/tables.py (Python module, socialwarehouse.delta.tables)
+
+**Definition:** `socialwarehouse/delta/tables.py`
+**Surveyed at:** 2026-05-19 (seeded via survey-context NO-DOC path during D7 SCD-decision write-up)
+**Owner:** delta / warehouse-scale maintainers
+
+## Shape
+
+Centralized registry of Spark `StructType` schemas + a `TABLES` dict mapping registry keys (`bronze.*`, `silver.*`, `gold.*`) to `{schema, path, partition_by, description}` records. Resolved paths come from `delta/config.py:get_table_path`.
+
+## Tiers
+
+| Tier | Purpose | Tables defined |
+|---|---|---|
+| Bronze | Raw ingested data, untransformed | `bronze.addresses`, `bronze.boundaries` |
+| Silver | Cleaned / typed / partitioned | `silver.addresses`, `silver.demographics`, `silver.boundaries` (path-only) |
+| Gold | Analytics-ready, joined | `gold.enriched_addresses` |
+
+## SCD2 vs point-in-time keying
+
+**`SILVER_DEMOGRAPHICS` is intentionally NOT SCD2.** Census demographic estimates are point-in-time snapshots with a natural composite key: `(geoid, vintage_year, summary_level, variable_code, survey_type)`. Revisions are published as a NEW `vintage_year` or `survey_type`, never as in-place edits to the same composite key — the version IS the natural key. Adding `is_current` / `effective_from` / `effective_to` would duplicate version-tracking the composite key already provides.
+
+By contrast, the warehouse-side `DimGeography` IS SCD2: geographies do get revised within a vintage (TIGER/Line corrections, redistricting amendments, boundary mergers) and the same `(geoid, vintage_year)` key can have multiple effective spans. SCD2 fields are load-bearing there. (D7 / SW#129 — intentional asymmetry, documented.)
+
+## Callers / consumers
+
+- `socialwarehouse/delta/enrichment.py` — resolves `addresses_table` arg against `TABLES`.
+- `socialwarehouse/delta/io.py` (if present) — uses schemas for `spark.read.schema(...)`.
+- Future Spark jobs should resolve via this registry rather than re-typing paths.
+
+## Cross-references
+
+- `delta/config.py:get_table_path` — provides the tier path prefix.
+- `delta/enrichment.py` — primary `TABLES` consumer.
+- Warehouse `DimGeography` (siege_utilities.geo / SW warehouse) — the SCD2 counterpart documented above.
+
+## Known assumptions / gotchas
+
+- **Registry keys are flat strings** (e.g. `"silver.addresses"`). Typos route through `enrichment.py`'s `addresses_table` validation, which post-D8 raises `ValueError` rather than falling through to a raw-path read.
+- **`SILVER_DEMOGRAPHICS` lacks SCD2 fields by design** — see SCD2 vs point-in-time keying above. Don't add `is_current` / `effective_from` / `effective_to` without first updating that section.
+
+## Survey log
+
+- 2026-05-19: Seeded via survey-context NO-DOC path during D7 / SW#129 fix. Documents the intentional SCD2 asymmetry: `DimGeography` is SCD2 because geographies revise within a vintage; `SILVER_DEMOGRAPHICS` is not because Census revisions ship as new vintages, not edits. Inline comment added above `SILVER_DEMOGRAPHICS` capturing the same rationale at the call site.

--- a/socialwarehouse/delta/enrichment.py
+++ b/socialwarehouse/delta/enrichment.py
@@ -51,8 +51,21 @@ def enrich_addresses_with_boundaries(spark, addresses_table, year=2020, boundari
 
     if addresses_table in TABLES:
         addr_path = TABLES[addresses_table]["path"]
-    else:
+    elif "/" in addresses_table or "://" in addresses_table:
+        # Explicit raw path — has a separator or scheme. Pass through.
         addr_path = addresses_table
+    else:
+        # No separator AND not a registry key — almost certainly a typo'd
+        # registry key (e.g. "silver.address" instead of "silver.addresses").
+        # Pre-D8/SW#130 the value fell through to spark.read.load() which
+        # surfaced as a confusing "path does not exist" deep in the Spark
+        # stack. Fail fast at the API boundary with the available keys.
+        raise ValueError(
+            f"Unknown addresses_table {addresses_table!r}. Must be a key "
+            f"in delta/tables.py:TABLES or a raw Delta path "
+            f"(containing '/' or a scheme like 's3a://'). "
+            f"Known keys: {sorted(TABLES.keys())}. (D8 / SW#130)"
+        )
 
     addresses = (
         spark.read.format("delta").load(addr_path)

--- a/socialwarehouse/delta/tables.py
+++ b/socialwarehouse/delta/tables.py
@@ -84,6 +84,17 @@ SILVER_ADDRESSES = StructType([
     StructField("census_units_assigned_at", TimestampType(), True),
 ])
 
+# Intentionally NOT SCD2: the warehouse-side DimGeography tracks
+# is_current / effective_from / effective_to because geographies are
+# revised within a vintage (TIGER/Line corrections, redistricting
+# revisions). Census demographic estimates, by contrast, are
+# point-in-time snapshots keyed by the composite
+# (geoid, vintage_year, summary_level, variable_code, survey_type).
+# Revisions are published as a NEW vintage_year or survey_type — never
+# as an in-place edit of the same key. The natural key is the version,
+# so SCD2 effective_from/to would be redundant tracking.
+# Re-loads of the same key upsert by primary key.
+# (D7 / SW#129 — intentional simplification, documented per ticket.)
 SILVER_DEMOGRAPHICS = StructType([
     StructField("geoid", StringType(), False),
     StructField("vintage_year", IntegerType(), False),

--- a/tests/unit/delta/test_enrichment_d8_addresses_table_validation.py
+++ b/tests/unit/delta/test_enrichment_d8_addresses_table_validation.py
@@ -9,6 +9,14 @@ runs before any Spark API is touched.
 
 from unittest.mock import MagicMock
 
+import pytest
+
+# delta/tables.py imports pyspark at module load; CI without pyspark
+# would otherwise fail at test collection. The D8 validator behavior
+# itself doesn't need a real Spark — but the TABLES registry import
+# chain does. Skip cleanly when pyspark is absent.
+pytest.importorskip("pyspark")
+
 from django.test import SimpleTestCase
 
 from socialwarehouse.delta import enrichment as _enr

--- a/tests/unit/delta/test_enrichment_d8_addresses_table_validation.py
+++ b/tests/unit/delta/test_enrichment_d8_addresses_table_validation.py
@@ -1,0 +1,63 @@
+"""Regression test for D8 (SW#130): enrich_addresses_with_boundaries
+validates addresses_table against the TABLES registry, and only accepts
+unknown values that look like raw paths (contain '/' or a scheme).
+
+Behavior test — call the function with a bad addresses_table; assert
+ValueError. We don't need a real SparkSession because the validation
+runs before any Spark API is touched.
+"""
+
+from unittest.mock import MagicMock
+
+from django.test import SimpleTestCase
+
+from socialwarehouse.delta import enrichment as _enr
+from socialwarehouse.delta.tables import TABLES
+
+
+class TestD8AddressesTableValidation(SimpleTestCase):
+
+    def test_typo_registry_key_raises_valueerror(self):
+        # "silver.address" is a one-char typo of "silver.addresses".
+        # Pre-fix this fell through to spark.read.load("silver.address").
+        # Post-fix it raises ValueError naming the known keys.
+        spark = MagicMock()
+        with self.assertRaises(ValueError) as cm:
+            _enr.enrich_addresses_with_boundaries(spark, "silver.address")
+        msg = str(cm.exception)
+        assert "silver.address" in msg
+        assert "D8" in msg or "SW#130" in msg
+        # Should mention at least one known key in the error.
+        assert "silver.addresses" in msg or any(k in msg for k in TABLES.keys())
+
+    def test_path_with_slash_passes_validation(self):
+        # Raw filesystem-style path — should not raise from the
+        # validator. (It will fail later in Spark — that's fine; we
+        # only assert the validator doesn't reject the raw path.)
+        spark = MagicMock()
+        spark.read.format.return_value.load.return_value.filter.return_value = MagicMock()
+        try:
+            _enr.enrich_addresses_with_boundaries(spark, "/tmp/some/raw/path")
+        except ValueError as e:
+            if "D8" in str(e) or "SW#130" in str(e):
+                self.fail(f"raw filesystem path incorrectly rejected by D8 validator: {e}")
+
+    def test_path_with_scheme_passes_validation(self):
+        spark = MagicMock()
+        spark.read.format.return_value.load.return_value.filter.return_value = MagicMock()
+        try:
+            _enr.enrich_addresses_with_boundaries(spark, "s3a://bucket/path")
+        except ValueError as e:
+            if "D8" in str(e) or "SW#130" in str(e):
+                self.fail(f"s3a:// path incorrectly rejected by D8 validator: {e}")
+
+    def test_known_registry_key_passes_validation(self):
+        spark = MagicMock()
+        spark.read.format.return_value.load.return_value.filter.return_value = MagicMock()
+        # Use whatever key is in TABLES.
+        known_key = next(iter(TABLES.keys()))
+        try:
+            _enr.enrich_addresses_with_boundaries(spark, known_key)
+        except ValueError as e:
+            if "D8" in str(e) or "SW#130" in str(e):
+                self.fail(f"known registry key incorrectly rejected by D8 validator: {e}")


### PR DESCRIPTION
## Summary

Two-finding bundle in `socialwarehouse/delta/`:

- **D7 / #129**: document `SILVER_DEMOGRAPHICS`'s intentional lack of SCD2 fields. Inline comment + new entity doc `docs/entities/delta_tables.md` captures the rationale and the asymmetry with `DimGeography`.
- **D8 / #130**: `enrich_addresses_with_boundaries` validates `addresses_table` at function entry. Typos no longer fall through to `spark.read.load()`; they raise `ValueError` naming the known keys.

## Test plan

- [x] Behavior test at `tests/unit/delta/test_enrichment_d8_addresses_table_validation.py`: covers typo → ValueError, raw path → pass, scheme → pass, known key → pass. Uses MagicMock spark since the validator runs before any Spark I/O.
- [x] Entity docs updated: `delta_enrichment.md` (D8) + new `delta_tables.md` (D7).
- [x] D7 is documentation-only — no test needed (no behavior change).
- [ ] CI run.

## Closes

#129, #130.

## Self-review

See trailer in commit message.