### PR TITLE
warehouse bundle: W4 (#108) + W5 (#109) + W6 (#110)

### DIFF
--- a/socialwarehouse/warehouse/models/dimensions.py
+++ b/socialwarehouse/warehouse/models/dimensions.py
@@ -103,6 +103,18 @@ class DimSurvey(models.Model):
     One row per (survey_type, vintage_year) combination.
     """
 
+    # Scope is intentionally narrow: only Census programs SW has an
+    # active loader path for today. Adding a choice here requires a
+    # Django migration AND a corresponding loader; adding it without
+    # the loader puts a non-functional option in the admin dropdown
+    # that confuses operators. Programs SW does NOT yet handle (add
+    # in lockstep with their loader):
+    #   - PEP (Population Estimates Program)
+    #   - Economic Census (5-year)
+    #   - ACS Subject Tables
+    #   - CHAS (Comprehensive Housing Affordability Strategy)
+    #   - American Housing Survey
+    # See W5 / SW#109 for the original gap-discovery context.
     SURVEY_TYPES = [
         ("acs5", "ACS 5-Year Estimates"),
         ("acs1", "ACS 1-Year Estimates"),

--- a/socialwarehouse/warehouse/models/facts.py
+++ b/socialwarehouse/warehouse/models/facts.py
@@ -21,13 +21,23 @@ from .dimensions import (
 )
 
 
+# Census Bureau coefficient-of-variation reliability thresholds. Drawn
+# from Census's published guidance for ACS estimate reliability: CV < 12%
+# = high reliability, 12-40% = medium, > 40% = low. Hoisted to module
+# scope so the RELIABILITY_CHOICES strings, the compute_reliability
+# implementation, and any downstream analytics that want to mirror these
+# bands share one source of truth. (W4 / SW#108)
+CV_HIGH_THRESHOLD = 12
+CV_MEDIUM_THRESHOLD = 40
+
+
 class FactACSEstimate(models.Model):
     """ACS estimate fact — one row per (geography, variable, survey)."""
 
     RELIABILITY_CHOICES = [
-        ("high", "High (CV < 12%)"),
-        ("medium", "Medium (CV 12-40%)"),
-        ("low", "Low (CV > 40%)"),
+        ("high", f"High (CV < {CV_HIGH_THRESHOLD}%)"),
+        ("medium", f"Medium (CV {CV_HIGH_THRESHOLD}-{CV_MEDIUM_THRESHOLD}%)"),
+        ("low", f"Low (CV > {CV_MEDIUM_THRESHOLD}%)"),
         ("suppressed", "Suppressed by Census Bureau"),
     ]
 
@@ -57,9 +67,9 @@ class FactACSEstimate(models.Model):
         if self.coefficient_of_variation is None:
             return "suppressed"
         cv = abs(self.coefficient_of_variation)
-        if cv < 12:
+        if cv < CV_HIGH_THRESHOLD:
             return "high"
-        if cv < 40:
+        if cv < CV_MEDIUM_THRESHOLD:
             return "medium"
         return "low"
 

--- a/socialwarehouse/warehouse/services/dimension_loader.py
+++ b/socialwarehouse/warehouse/services/dimension_loader.py
@@ -68,6 +68,18 @@ class DimensionLoaderService:
                             geoid=parent_geoid, vintage_year=vintage_year
                         ).first()
 
+                # The hasattr/getattr defenses below are intentional:
+                # MODEL_MAP covers Census + political boundary models
+                # with genuinely different field sets. Census-derived
+                # models (State, County, Tract, BlockGroup, Place,
+                # CongressionalDistrict) carry the full TIGER metadata
+                # (area_land, area_water, internal_point, geometry).
+                # Political models (StateLegislativeLower/Upper) carry
+                # geometry but not always the TIGER area fields. A
+                # per-model field map would be more code than the
+                # defensive lookups for the same end state. Mirrors the
+                # A8 (#119) pattern in api/geo/views.py:_serialize_boundary.
+                # (W6 / SW#110)
                 dim, created = DimGeography.objects.update_or_create(
                     geoid=boundary.geoid,
                     vintage_year=vintage_year,

--- a/tests/unit/warehouse/test_facts_w4_cv_thresholds.py
+++ b/tests/unit/warehouse/test_facts_w4_cv_thresholds.py
@@ -1,0 +1,60 @@
+"""Regression test for W4 (SW#108): CV reliability thresholds are
+hoisted to module-scope constants and the RELIABILITY_CHOICES strings
+mirror the constant values.
+
+Behavior tests: instantiate FactACSEstimate with CVs around the
+thresholds and assert compute_reliability returns the documented band.
+"""
+
+from django.test import SimpleTestCase
+
+from socialwarehouse.warehouse.models.facts import (
+    CV_HIGH_THRESHOLD,
+    CV_MEDIUM_THRESHOLD,
+    FactACSEstimate,
+)
+
+
+class TestCVThresholds(SimpleTestCase):
+
+    def test_module_constants_match_census_published_bands(self):
+        # Census Bureau guidance: high reliability < 12%, medium 12-40%,
+        # low > 40%. If these constants change, downstream analytics
+        # using the same bands must be aware.
+        assert CV_HIGH_THRESHOLD == 12
+        assert CV_MEDIUM_THRESHOLD == 40
+
+    def test_choices_strings_mirror_constants(self):
+        # The display strings are derived from the constants, so a
+        # change to the constants flows through to the admin labels.
+        choices_dict = dict(FactACSEstimate.RELIABILITY_CHOICES)
+        assert f"< {CV_HIGH_THRESHOLD}%" in choices_dict["high"]
+        assert f"{CV_HIGH_THRESHOLD}-{CV_MEDIUM_THRESHOLD}%" in choices_dict["medium"]
+        assert f"> {CV_MEDIUM_THRESHOLD}%" in choices_dict["low"]
+
+    def test_compute_reliability_below_high_threshold(self):
+        f = FactACSEstimate(estimate=100, coefficient_of_variation=CV_HIGH_THRESHOLD - 1)
+        assert f.compute_reliability() == "high"
+
+    def test_compute_reliability_at_high_threshold_is_medium(self):
+        # Threshold semantics: < CV_HIGH_THRESHOLD is high; == is medium.
+        f = FactACSEstimate(estimate=100, coefficient_of_variation=CV_HIGH_THRESHOLD)
+        assert f.compute_reliability() == "medium"
+
+    def test_compute_reliability_between_thresholds_is_medium(self):
+        f = FactACSEstimate(estimate=100, coefficient_of_variation=25)
+        assert f.compute_reliability() == "medium"
+
+    def test_compute_reliability_at_medium_threshold_is_low(self):
+        f = FactACSEstimate(estimate=100, coefficient_of_variation=CV_MEDIUM_THRESHOLD)
+        assert f.compute_reliability() == "low"
+
+    def test_compute_reliability_suppressed_when_cv_none(self):
+        f = FactACSEstimate(estimate=100, coefficient_of_variation=None)
+        assert f.compute_reliability() == "suppressed"
+
+    def test_compute_reliability_uses_absolute_value(self):
+        # Negative CV is degenerate but defensible — treat magnitude as
+        # the bin selector.
+        f = FactACSEstimate(estimate=100, coefficient_of_variation=-5)
+        assert f.compute_reliability() == "high"


### PR DESCRIPTION
## Summary

Three warehouse-subsystem findings:

- **W4 / #108**: hoist FactACSEstimate CV reliability thresholds to module constants (`CV_HIGH_THRESHOLD=12`, `CV_MEDIUM_THRESHOLD=40`). Display strings derive from constants via f-string so admin labels stay in sync.
- **W5 / #109**: documentation-only. Inline comment above `SURVEY_TYPES` names candidate programs (PEP, Economic Census, ACS Subject, CHAS, AHS) and the rule — add the choice in lockstep with the loader, never alone.
- **W6 / #110**: keep the `dimension_loader.py` hasattr/getattr chain; add a comment explaining the MODEL_MAP field heterogeneity (Census + political boundary models). Mirrors A8 (#119) in `api/geo/views.py:_serialize_boundary`.

## Test plan

- [x] `tests/unit/warehouse/test_facts_w4_cv_thresholds.py` covers `compute_reliability` band boundaries + display-string mirroring.
- [x] W5 / W6 are documentation-only; no test (would be testing a comment).
- [x] No DB migration needed for W4: choice tuple structure is identical (f-string interpolation produces the same labels).
- [ ] CI run.

## Closes

#108, #109, #110.

## Self-review

See trailer in commit message.