### PR TITLE
address.py F-bundle (F4+F5+F6+F9) + export_to_delta M7

### DIFF
--- a/docs/entities/address.md
+++ b/docs/entities/address.md
@@ -36,8 +36,12 @@
 
 ### Methods of interest
 
-- `assign_census_units_from_fips(state_fips, county_fips, tract, block)` — constructs hierarchical GEOIDs from Census Geocoder FIPS output. Mutates instance fields; caller must `.save()`.
-- `populate_foreign_keys()` — populates siege_geo FK refs from GEOIDs.
+- `assign_census_units_from_fips(state_fips, county_fips, tract, block)` — constructs hierarchical GEOIDs from Census Geocoder FIPS output. Mutates instance fields; **caller must `.save()`**.
+- `populate_foreign_keys()` — populates siege_geo FK refs from GEOIDs. Post-F4/F5 (SW#93+#94): mutates instance fields and returns `self`; **caller must `.save()`** (matches `assign_census_units_from_fips`). Pre-fix it called `self.save()` internally — asymmetric with the other instance-mutating method and a hidden per-call write that was suboptimal in bulk-update flows.
+
+### Module constants
+
+- `DEFAULT_CENSUS_YEAR = 2020` — single edit site for the model's `census_year` field default. Bumped manually each decade. Path-of-least-resistance fix for F6 (SW#95) — a `CensusVintageConfig`-driven callable default tangles with F11 (SW#100, still open) and is deferred until that question is settled.
 
 ## Callers / consumers
 
@@ -54,7 +58,7 @@
 ## Known assumptions / gotchas
 
 - **`null=True` on CharField throughout** is a Django-convention violation (F3 / SW#92): Django convention is `blank=True, default=""`, not `null=True`. The model uses the latter everywhere. Means `filter(field="")` and `filter(field__isnull=True)` return different sets; callers must know which case the data is in.
-- **`geocoded=True` does NOT imply `geom` is set.** M6 / SW#150: matched-without-coords sets `geocoded=True` with `geom=NULL`. Filter `geocoded=True AND geom__isnull=False` if you need both.
+- **`geocoded=True` implies `geom IS NOT NULL`** (post-M6/SW#150 fix). Pre-fix Census's `matched=True` flipped `geocoded=True` even when lat/lon were unpopulated, leaving `geom=NULL`; post-fix Phase 1 requires both coords before setting `geocoded=True` and demotes matched-without-coords to the unmatched bucket for Phase 2 (Nominatim) to retry. Downstream filters on `geocoded=True` alone are now safe.
 - **`geocode_source` values are free-form strings** (not a choices field). Known values: "census", "nominatim". Add a CHOICES list if a third source appears.
 - **Per-row `.save()` in geocode loop** was the M2 bottleneck (SW#146). FIXED: `geocode_addresses.py` now uses `Address.objects.bulk_update(pending, ADDRESS_BULK_UPDATE_FIELDS, batch_size=500)`. Future bulk-update callers should mirror this pattern: maintain a `pending_updates` list, flush per chunk, name the field list explicitly so only intended fields are written.
 - **`qs.count()` followed by `.iterator()` re-executes the SELECT.** Was M1 (SW#145), fixed. Don't reintroduce a pre-iteration count in the same flow; for advisory counts use the dry-run code path only.
@@ -64,3 +68,7 @@
 
 - 2026-05-18: Seeded from live model. F3/M2/M6 surfaced in E1 review (SW#92, #146, #150).
 - 2026-05-18: M1+M2+M3 bundled fix shipped — `geocode_addresses.py` rewritten to stream addresses via `qs.iterator(chunk_size=batch_size)`, accumulate per-chunk updates, flush via `Address.objects.bulk_update`. ADDRESS_BULK_UPDATE_FIELDS constant + `_yield_chunks` generator added. Callers wanting the same pattern can reference geocode_addresses.py:handle().
+- 2026-05-19: M6 / SW#150 — Phase 1 now requires `matched AND lat AND lon` before flipping `geocoded=True`; matched-without-coords demoted to Phase 2 (Nominatim) for a real try. The `geocoded=True implies geom IS NOT NULL` invariant downstream code relies on is now load-bearing.
+- 2026-05-19: F4 + F5 / SW#93 + #94 — `populate_foreign_keys()` no longer silently saves. It mutates the instance and returns `self`; caller is responsible for `.save()` (matches `assign_census_units_from_fips`). Updated the only caller (`assign_boundaries.py`) to call `populate_foreign_keys()` BEFORE its existing `.save()` so the geoid changes and the FK assignments share a single UPDATE.
+- 2026-05-19: F6 / SW#95 — Hoisted `census_year` default to module constant `DEFAULT_CENSUS_YEAR = 2020`. Single edit site for the manual-per-decade bump. Callable default (reading `CensusVintageConfig`) deferred until F11 / SW#100 is settled.
+- 2026-05-19: F9 / SW#98 — `assign_boundaries.py` method-local-imports pattern documented at module top: Django AppRegistryNotReady avoidance (management commands import before app loader is ready), GST submodule cost-of-import for unrelated commands, and conditional plan-aware code paths.

--- a/socialwarehouse/geo/management/commands/assign_boundaries.py
+++ b/socialwarehouse/geo/management/commands/assign_boundaries.py
@@ -27,6 +27,32 @@ from django.utils import timezone
 logger = logging.getLogger("socialwarehouse.geo")
 
 
+# Import-discipline note (F9 / SW#98):
+#
+# Heavy domain imports (Address, AddressBoundaryPeriod, CensusVintageConfig,
+# siege_utilities.geo.django.models.*, RedistrictingPlan, etc.) live INSIDE
+# the methods that use them, not at module top. Reasons, in order:
+#
+# 1. Django management commands are imported by manage.py at startup to
+#    discover subcommands. Top-level imports of socialwarehouse.geo.models
+#    would trigger Django's model registration BEFORE Django's app loader
+#    is ready, producing AppRegistryNotReady. Method-local imports defer
+#    until handle() runs (which is post-setup).
+#
+# 2. The siege_utilities boundary models live in a vendor submodule
+#    (vendor/geodjango_simple_template). Top-level imports here pull the
+#    submodule into the import graph of every `python manage.py` invocation,
+#    inflating startup cost for unrelated commands.
+#
+# 3. Some sites (RedistrictingPlan, plan-aware lookups) are conditional —
+#    only the plan-aware code path needs them. Method-local imports keep
+#    the legacy-mode code path independent of the plan-aware dependencies.
+#
+# If you need to add a top-level import, verify the symbol isn't a Django
+# model registered after Django setup, and that adding it doesn't pull in
+# the GST submodule for non-GST-using commands.
+
+
 class Command(BaseCommand):
     help = (
         "Assign census geographic boundaries to geocoded addresses. "
@@ -339,6 +365,14 @@ class Command(BaseCommand):
                     addr.sldu_geoid = sldu_geoid
                     addr.census_year = year
                     addr.census_units_assigned_at = timezone.now()
+
+                    # Populate FKs in memory BEFORE the save so the geoid
+                    # changes and the FK assignments share a single UPDATE.
+                    # Post-F4/F5 (SW#93+#94) populate_foreign_keys() no
+                    # longer saves; callers are responsible for persistence.
+                    if populate_fks:
+                        addr.populate_foreign_keys()
+
                     addr.save()
 
                     # --- Create/update AddressBoundaryPeriod ---
@@ -364,9 +398,6 @@ class Command(BaseCommand):
                                 "assignment_method": method,
                             },
                         )
-
-                    if populate_fks:
-                        addr.populate_foreign_keys()
 
                     assigned += 1
 

--- a/socialwarehouse/geo/management/commands/export_to_delta.py
+++ b/socialwarehouse/geo/management/commands/export_to_delta.py
@@ -40,7 +40,22 @@ class Command(BaseCommand):
         if options["dry_run"]:
             from socialwarehouse.delta.enrichment import estimate_scale
             engine, reason = estimate_scale(total)
+            # Advisory: this command unconditionally uses Spark on the
+            # real run (load_postgis_addresses_to_delta is the only
+            # implementation). The recommendation is informational —
+            # at small scales the PostGIS-direct path is faster, but
+            # this command does not implement it. If the recommendation
+            # is "postgis," consider whether the export is necessary at
+            # all (PostGIS already holds the data) or whether to skip
+            # the Spark hop for this scale. (M7 / SW#151)
             self.stdout.write(f"Recommended engine: {engine} ({reason})")
+            if engine == "postgis":
+                self.stdout.write(
+                    "  Note: this command always uses Spark on the real run; "
+                    "the 'postgis' recommendation suggests an alternative path "
+                    "(direct PostGIS query or skipping the export) that lives "
+                    "outside this command."
+                )
             self.stdout.write(self.style.SUCCESS("[DRY RUN] No export performed."))
             return
 

--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -16,6 +16,19 @@ from django.contrib.gis.db import models
 from django.utils import timezone
 
 
+# Default census vintage used when an Address is created without an
+# explicit `census_year`. Bumped manually each decade as the canonical
+# TIGER vintage shifts (next bump: 2030 vintage's general-availability
+# date — TBD, currently expected ~2030-2032).
+#
+# This is INTENTIONALLY a module-level int constant, not a callable
+# default reading CensusVintageConfig — that path tangles with F11
+# (#100 — Address.census_year vs CensusVintageConfig dual source of
+# truth) and is being deferred until the dual-source-of-truth question
+# is settled. Tracked: F6 / SW#95.
+DEFAULT_CENSUS_YEAR = 2020
+
+
 class Address(models.Model):
     """
     A geocoded US address with Census boundary assignments.
@@ -70,8 +83,10 @@ class Address(models.Model):
     geocoded_at = models.DateTimeField(null=True, blank=True)
 
     # ── Census year context ──────────────────────────────────────────────
+    # Default sourced from DEFAULT_CENSUS_YEAR module constant so the
+    # "bumped manually each decade" rule has a single edit site.
     census_year = models.IntegerField(
-        default=2020,
+        default=DEFAULT_CENSUS_YEAR,
         help_text="Census year for boundary assignment (2010, 2020)",
     )
 
@@ -193,7 +208,18 @@ class Address(models.Model):
         Populate siege_geo FK references from GEOIDs.
 
         Call after census unit assignment to enable rich hierarchical queries
-        like address.siege_vtd.county.state.name.
+        like ``address.siege_vtd.county.state.name``.
+
+        **Does not persist.** This method mutates the instance in memory and
+        returns ``self``; the caller is responsible for calling ``.save()``
+        (or batching via ``bulk_update``) when ready. This matches the
+        :meth:`assign_census_units_from_fips` convention and the broader
+        Django ORM convention that instance-mutating methods do not save.
+        (F4 + F5 / SW#93 + SW#94 — pre-fix this method called ``self.save()``
+        as a hidden side effect; ``assign_census_units_from_fips`` did not.
+        The asymmetry surprised callers and the bulk-update integration was
+        suboptimal because every populated address triggered an individual
+        UPDATE.)
         """
         from siege_utilities.geo.django.models import (
             State, County, Tract, BlockGroup,
@@ -220,8 +246,7 @@ class Address(models.Model):
                 ).first()
                 setattr(self, fk_field, obj)
 
-        self.save()
-        return True
+        return self
 
 
 # Backwards-compatible alias

--- a/tests/unit/geo/test_address_f_bundle.py
+++ b/tests/unit/geo/test_address_f_bundle.py
@@ -1,0 +1,91 @@
+"""Regression tests for the address.py F-bundle: F4 + F5 + F6.
+
+F4 (#93) + F5 (#94): populate_foreign_keys() does NOT call self.save().
+F6 (#95): census_year default sourced from DEFAULT_CENSUS_YEAR module
+constant (single edit site for the manual-per-decade bump).
+
+Pure behavior tests — F4/F5 use a MagicMock instead of a real DB so the
+test runs without DB fixtures; F6 reads the constant + field default
+directly.
+"""
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from django.test import SimpleTestCase
+
+from socialwarehouse.geo.models import address as _addr_mod
+from socialwarehouse.geo.models.address import Address, DEFAULT_CENSUS_YEAR
+
+
+class TestF6CensusYearDefault(SimpleTestCase):
+
+    def test_module_constant_is_2020(self):
+        # Sentinel: if this constant changes without a coordinated update,
+        # the test fires and surfaces the decade-bump moment.
+        assert DEFAULT_CENSUS_YEAR == 2020
+
+    def test_address_census_year_field_default_uses_constant(self):
+        # The field default must be the constant itself — not a stale
+        # literal that drifts when the constant is bumped.
+        field = Address._meta.get_field("census_year")
+        assert field.default == DEFAULT_CENSUS_YEAR
+
+    def test_default_census_year_documented_in_source(self):
+        # Soft check: the rationale comment should reference F6 / SW#95.
+        src = Path(_addr_mod.__file__).read_text(encoding="utf-8")
+        assert "DEFAULT_CENSUS_YEAR" in src
+        assert "F6" in src or "SW#95" in src
+
+
+class TestF4F5PopulateForeignKeysNoSave(SimpleTestCase):
+
+    def test_populate_foreign_keys_does_not_call_save(self):
+        # Build an Address-like instance but skip the DB write by
+        # patching save. The method must not invoke save() internally.
+        addr = Address(state_geoid="48", county_geoid="48201", census_year=2020)
+        with patch.object(addr, "save") as save_mock, patch(
+            "siege_utilities.geo.django.models.State"
+        ) as State, patch(
+            "siege_utilities.geo.django.models.County"
+        ) as County, patch(
+            "siege_utilities.geo.django.models.Tract"
+        ), patch(
+            "siege_utilities.geo.django.models.BlockGroup"
+        ), patch(
+            "siege_utilities.geo.django.models.CongressionalDistrict"
+        ), patch(
+            "siege_utilities.geo.django.models.VTD"
+        ), patch(
+            "siege_utilities.geo.django.models.StateLegislativeLower"
+        ), patch(
+            "siege_utilities.geo.django.models.StateLegislativeUpper"
+        ):
+            State.objects.filter.return_value.first.return_value = None
+            County.objects.filter.return_value.first.return_value = None
+            result = addr.populate_foreign_keys()
+        save_mock.assert_not_called()
+        # Returns self (Django ORM convention for chainable mutators).
+        assert result is addr
+
+    def test_source_has_no_self_save_inside_populate_foreign_keys(self):
+        # writing-tests:6 carve-out — structural check that the body of
+        # populate_foreign_keys does not contain self.save(). Comment/
+        # docstring stripping per the codebase's existing pattern.
+        src = Path(_addr_mod.__file__).read_text(encoding="utf-8")
+        cleaned = re.sub(r'"""[\s\S]*?"""', "", src)
+        cleaned = re.sub(r"'''[\s\S]*?'''", "", cleaned)
+        cleaned = "\n".join(line.split("#", 1)[0] for line in cleaned.splitlines())
+
+        # Slice out the body of populate_foreign_keys to scope the grep.
+        match = re.search(
+            r"def populate_foreign_keys\(self\):([\s\S]*?)(?=\n    def |\nclass |\Z)",
+            cleaned,
+        )
+        assert match, "could not find populate_foreign_keys body in source"
+        body = match.group(1)
+        assert "self.save()" not in body, (
+            "self.save() reintroduced into populate_foreign_keys — pre-F4 "
+            "asymmetric-save behavior has returned"
+        )


### PR DESCRIPTION
## Summary

Five E1-review sub-findings on the \`address.py\` call-graph + the export_to_delta dry-run output.

| Finding | Change |
|---|---|
| **F4 / #93 + F5 / #94** | Drop hidden \`self.save()\` from \`populate_foreign_keys()\`. Method now mutates and returns \`self\`; matches \`assign_census_units_from_fips\` convention. Only caller (\`assign_boundaries.py:369\`) reordered so geoid + FK assignments share one UPDATE. |
| **F6 / #95** | Hoist \`census_year\` default to module constant \`DEFAULT_CENSUS_YEAR = 2020\`. Single edit site for the manual-per-decade bump. CensusVintageConfig callable-default deferred to F11. |
| **F9 / #98** | Document method-local-imports pattern in \`assign_boundaries.py\` at module top — AppRegistryNotReady, GST submodule cost, conditional plan-aware paths. |
| **M7 / #151** | \`export_to_delta\` dry-run flags the \`postgis\` recommendation case explicitly (command unconditionally uses Spark on real run; recommendation is informational). |

## Why F6's CensusVintageConfig path was deferred

F11 / #100 (\"Address.census_year vs CensusVintageConfig dual source of truth\") is still open. Building the callable default in this PR would tangle the small fix with the open design ticket; the resolver's THINK gate exists to prevent exactly that scope-creep. Module constant is the path-of-least-resistance fix; F11's eventual resolution can graduate it to a callable default cleanly.

## Test plan

- [x] \`tests/unit/geo/test_address_f_bundle.py\`: F4/F5 (populate_foreign_keys does NOT call save, returns self), F6 (constant value, model field default sourced from constant, no bare-literal drift).
- [x] F9 and M7 are comment/print-only — explicit no-test rationale in commit body (writing-tests:6 floor-cost).
- [x] Manually traced the single caller of \`populate_foreign_keys\` before reordering. AddressBoundaryPeriod creation doesn't read the populated FK fields, so the order change is safe.
- [x] Entity doc \`docs/entities/address.md\` updated (methods of interest, new module constants section, fixed stale M6 gotcha, survey log).
- [ ] CI run.

## Closes

#93, #94, #95, #98, #151.

## Self-review

See trailer in commit message.