### PR TITLE
R2/SW#103 (partial): use siege_utilities download_file_with_retry for RDH plan downloads

### DIFF
--- a/scripts/fetch_rdh_boundaries.py
+++ b/scripts/fetch_rdh_boundaries.py
@@ -104,8 +104,15 @@ def check_for_updates(state_file: Path, states: list[str] | None = None) -> tupl
 
 
 def download_plans(plans: list[dict], output_dir: Path) -> list[Path]:
-    """Download boundary plan files."""
-    import requests
+    """Download boundary plan files.
+
+    Uses ``siege_utilities.files.remote.download_file_with_retry`` for the
+    actual HTTP download — it provides retry on transient failure,
+    streaming, and consistent logging. Pre-fix this function used raw
+    ``requests.get(..., stream=True)`` with a hand-rolled chunk loop and
+    no retry. (R2 / SW#103)
+    """
+    from siege_utilities.files.remote import download_file_with_retry
 
     output_dir.mkdir(parents=True, exist_ok=True)
     downloaded = []
@@ -125,15 +132,24 @@ def download_plans(plans: list[dict], output_dir: Path) -> list[Path]:
             continue
 
         logger.info("Downloading: %s", name)
-        try:
-            resp = requests.get(url, stream=True, timeout=300)
-            resp.raise_for_status()
-            with open(output_path, "wb") as f:
-                for chunk in resp.iter_content(chunk_size=8192):
-                    f.write(chunk)
-            downloaded.append(output_path)
-        except Exception as e:
-            logger.error("Failed to download %s: %s", name, e)
+        # download_file_with_retry returns the local filename string on
+        # success or False on failure (after all retries). We convert the
+        # success return back to a Path for the existing downstream
+        # consumers.
+        result = download_file_with_retry(
+            url=url,
+            local_filename=str(output_path),
+            max_retries=3,
+            retry_delay=5,
+        )
+        if result:
+            downloaded.append(Path(result))
+        else:
+            logger.error(
+                "Failed to download %s after retries; see siege_utilities "
+                "log for per-attempt detail.",
+                name,
+            )
 
     return downloaded
 


### PR DESCRIPTION
## Summary

Partial close on #103. \`scripts/fetch_rdh_boundaries.py:download_plans\` now uses \`siege_utilities.files.remote.download_file_with_retry\` instead of raw \`requests.get(..., stream=True)\` + a hand-rolled chunk loop. Gets 3-retry / 5s-backoff transient-failure handling for free.

## Recon outcomes

Surveyed the three R-bucket scripts against SU's \`siege_utilities.files.remote\` surface:

| Script | Outcome |
|---|---|
| \`fetch_rdh_boundaries.py\` | **This PR**: swap the file-download path to \`download_file_with_retry\`. Catalog API call stays on raw \`requests.get\` (it's a JSON API GET, not a file download). |
| \`fetch_acs_demographics.py\` | **No swap applicable.** Only HTTP usage is the Census API catalog GET (JSON response). Will close #103 with a recon comment when this PR merges. |
| \`fetch_census_tiger.py\` (R1 / #102) | **Different scope.** Uses FTP, not HTTP. SU's surface is HTTP-only AND lacks the remote-vintage-discovery capability that's the script's primary job. R1 needs a SU port-up first; an upstream SU ticket will follow. |

## Test plan

- [x] Syntax check.
- [x] Read \`siege_utilities/files/remote.py:276-314\` to confirm \`download_file_with_retry\` signature + return semantics (str on success, False on failure after all retries).
- [x] External contract preserved: function still returns \`list[Path]\`; partial-failure semantics now better (3 retries before logging failure, instead of one shot).
- [ ] CI run.
- [ ] Operational test surface is the cron — next monthly run validates the swap end-to-end.

## Closes

The RDH portion of #103. The ACS portion will close with a recon comment.

## Self-review

See trailer in commit message.