### PR TITLE
M5/SW#149: rewrite intersections via GeoDjango ORM (Option A)

### DIFF
--- a/socialwarehouse/geo/management/commands/compute_geographic_intersections.py
+++ b/socialwarehouse/geo/management/commands/compute_geographic_intersections.py
@@ -10,13 +10,44 @@ Usage:
     python manage.py compute_geographic_intersections --year 2020
     python manage.py compute_geographic_intersections --year 2020 --state 06
     python manage.py compute_geographic_intersections --year 2020 --type county-cd
+
+Implementation note (M5 / SW#149):
+    Geometry math runs server-side via GeoDjango ORM functions
+    (Intersection, Area, Transform). Areas are measured in a projected
+    metric CRS — the SRID is picked per-region by state-FIPS prefix.
+    See socialwarehouse/geo/projection.py for the lookup, and
+    docs/designs/m5-postgis-st-intersection.md for the rationale.
 """
 
 import logging
 
+from django.contrib.gis.db.models.functions import Area, Intersection, Transform
+from django.contrib.gis.geos import MultiPolygon, Polygon
 from django.core.management.base import BaseCommand
 
+from socialwarehouse.geo.projection import area_srid_for_geoid
+
 logger = logging.getLogger("socialwarehouse.geo")
+
+
+def _as_multipolygon(geom):
+    """Coerce a GEOSGeometry to MultiPolygon for storage in MultiPolygonField.
+
+    ST_Intersection can return Polygon, MultiPolygon, or GeometryCollection.
+    The target column is MultiPolygonField; everything else needs wrapping or
+    filtering. GeometryCollections from edge-touching pairs are treated as
+    empty for storage purposes.
+    """
+    if geom is None or geom.empty:
+        return None
+    if isinstance(geom, MultiPolygon):
+        return geom
+    if isinstance(geom, Polygon):
+        return MultiPolygon(geom, srid=geom.srid)
+    polys = [g for g in geom if isinstance(g, Polygon)] if hasattr(geom, "__iter__") else []
+    if not polys:
+        return None
+    return MultiPolygon(polys, srid=geom.srid)
 
 
 class Command(BaseCommand):
@@ -66,21 +97,38 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Processing {total} counties...")
 
-        for i, county in enumerate(counties, 1):
-            cds = CongressionalDistrict.objects.filter(
-                vintage_year=year,
-                geom__intersects=county.geom,
+        for i, county in enumerate(counties.iterator(), 1):
+            srid = area_srid_for_geoid(county.geoid)
+
+            cd_rows = list(
+                CongressionalDistrict.objects
+                .filter(vintage_year=year, geom__intersects=county.geom)
+                .annotate(
+                    sw_intersection_geom=Intersection("geom", county.geom),
+                    sw_intersection_area=Area(
+                        Transform(Intersection("geom", county.geom), srid)
+                    ),
+                    sw_cd_area=Area(Transform("geom", srid)),
+                )
             )
 
-            for cd in cds:
+            county_area_sqm = (
+                County.objects
+                .filter(pk=county.pk)
+                .annotate(sw_area=Area(Transform("geom", srid)))
+                .values_list("sw_area", flat=True)
+                .first()
+            )
+            county_area = float(county_area_sqm.sq_m) if county_area_sqm else 0.0
+
+            for cd in cd_rows:
                 try:
-                    intersection_geom = county.geom.intersection(cd.geom)
-                    if intersection_geom.empty:
+                    intersection_geom = _as_multipolygon(cd.sw_intersection_geom)
+                    if intersection_geom is None:
                         continue
 
-                    intersection_area = intersection_geom.area
-                    county_area = county.geom.area
-                    cd_area = cd.geom.area
+                    intersection_area = float(cd.sw_intersection_area.sq_m)
+                    cd_area = float(cd.sw_cd_area.sq_m)
 
                     pct_county = (intersection_area / county_area * 100) if county_area > 0 else 0
                     pct_cd = (intersection_area / cd_area * 100) if cd_area > 0 else 0
@@ -134,21 +182,38 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Processing {total} VTDs...")
 
-        for i, vtd in enumerate(vtds, 1):
-            cds = CongressionalDistrict.objects.filter(
-                vintage_year=year,
-                geom__intersects=vtd.geom,
+        for i, vtd in enumerate(vtds.iterator(), 1):
+            srid = area_srid_for_geoid(vtd.geoid)
+
+            cd_rows = list(
+                CongressionalDistrict.objects
+                .filter(vintage_year=year, geom__intersects=vtd.geom)
+                .annotate(
+                    sw_intersection_geom=Intersection("geom", vtd.geom),
+                    sw_intersection_area=Area(
+                        Transform(Intersection("geom", vtd.geom), srid)
+                    ),
+                    sw_cd_area=Area(Transform("geom", srid)),
+                )
             )
 
-            for cd in cds:
+            vtd_area_sqm = (
+                VTD.objects
+                .filter(pk=vtd.pk)
+                .annotate(sw_area=Area(Transform("geom", srid)))
+                .values_list("sw_area", flat=True)
+                .first()
+            )
+            vtd_area = float(vtd_area_sqm.sq_m) if vtd_area_sqm else 0.0
+
+            for cd in cd_rows:
                 try:
-                    intersection_geom = vtd.geom.intersection(cd.geom)
-                    if intersection_geom.empty:
+                    intersection_geom = _as_multipolygon(cd.sw_intersection_geom)
+                    if intersection_geom is None:
                         continue
 
-                    intersection_area = intersection_geom.area
-                    vtd_area = vtd.geom.area
-                    cd_area = cd.geom.area
+                    intersection_area = float(cd.sw_intersection_area.sq_m)
+                    cd_area = float(cd.sw_cd_area.sq_m)
 
                     pct_vtd = (intersection_area / vtd_area * 100) if vtd_area > 0 else 0
                     pct_cd = (intersection_area / cd_area * 100) if cd_area > 0 else 0

--- a/socialwarehouse/geo/projection.py
+++ b/socialwarehouse/geo/projection.py
@@ -1,0 +1,44 @@
+"""
+Projected-CRS lookup for area math.
+
+Picks an equal-area projected SRID for a given U.S. geography based on the
+two-digit state FIPS prefix of its GEOID. Used by geometry-area code paths
+that must measure in square meters rather than degree-squared.
+
+End state: a single global equal-area projection (EPSG:6933, NSIDC EASE-Grid
+2.0) replaces this per-region table. Tracked as a follow-up; see the design
+note at docs/designs/m5-postgis-st-intersection.md.
+"""
+
+EPSG_GLOBAL_EQUAL_AREA = 6933
+
+_REGIONAL_AREA_SRID = {
+    "02": 3338,
+    "15": 3563,
+    "60": EPSG_GLOBAL_EQUAL_AREA,
+    "66": EPSG_GLOBAL_EQUAL_AREA,
+    "69": EPSG_GLOBAL_EQUAL_AREA,
+    "72": 32161,
+    "78": 32161,
+}
+
+_CONUS_AREA_SRID = 5070
+
+
+def area_srid_for_state_fips(state_fips):
+    """Return the projected SRID to use for area math given a state FIPS.
+
+    Falls back to EPSG:6933 (global equal-area) when the input is missing or
+    unrecognized — safer than refusing to compute, and the fallback CRS still
+    produces a meaningful planar area.
+    """
+    if not state_fips:
+        return EPSG_GLOBAL_EQUAL_AREA
+    return _REGIONAL_AREA_SRID.get(str(state_fips)[:2], _CONUS_AREA_SRID)
+
+
+def area_srid_for_geoid(geoid):
+    """Convenience: state FIPS is always the leading 2 chars of a Census GEOID."""
+    if not geoid:
+        return EPSG_GLOBAL_EQUAL_AREA
+    return area_srid_for_state_fips(str(geoid)[:2])

--- a/tests/unit/geo/test_projection.py
+++ b/tests/unit/geo/test_projection.py
@@ -1,0 +1,47 @@
+"""Unit tests for the per-region projected-CRS lookup (M5 / SW#149)."""
+
+import pytest
+
+from socialwarehouse.geo.projection import (
+    EPSG_GLOBAL_EQUAL_AREA,
+    area_srid_for_geoid,
+    area_srid_for_state_fips,
+)
+
+
+@pytest.mark.parametrize(
+    "state_fips,expected",
+    [
+        ("06", 5070),   # CA (CONUS)
+        ("48", 5070),   # TX (CONUS)
+        ("36", 5070),   # NY (CONUS)
+        ("02", 3338),   # AK
+        ("15", 3563),   # HI
+        ("72", 32161),  # PR
+        ("78", 32161),  # USVI
+        ("60", EPSG_GLOBAL_EQUAL_AREA),  # American Samoa
+        ("66", EPSG_GLOBAL_EQUAL_AREA),  # Guam
+        ("69", EPSG_GLOBAL_EQUAL_AREA),  # Northern Mariana
+    ],
+)
+def test_area_srid_for_state_fips_known_regions(state_fips, expected):
+    assert area_srid_for_state_fips(state_fips) == expected
+
+
+def test_area_srid_for_state_fips_empty_falls_back_to_global():
+    assert area_srid_for_state_fips("") == EPSG_GLOBAL_EQUAL_AREA
+    assert area_srid_for_state_fips(None) == EPSG_GLOBAL_EQUAL_AREA
+
+
+def test_area_srid_for_geoid_uses_two_char_prefix():
+    # County GEOID = state(2) + county(3)
+    assert area_srid_for_geoid("06075") == 5070   # SF County, CA
+    assert area_srid_for_geoid("02020") == 3338   # Anchorage, AK
+    # VTD GEOID = state(2) + county(3) + vtd(6)
+    assert area_srid_for_geoid("06075123456") == 5070
+    assert area_srid_for_geoid("15003000123") == 3563  # Honolulu
+
+
+def test_area_srid_for_geoid_empty_falls_back_to_global():
+    assert area_srid_for_geoid("") == EPSG_GLOBAL_EQUAL_AREA
+    assert area_srid_for_geoid(None) == EPSG_GLOBAL_EQUAL_AREA


### PR DESCRIPTION
## Summary

Implements **Option A** from the v3 design at `docs/designs/m5-postgis-st-intersection.md` — the GeoDjango ORM rewrite that pushes geometry math server-side via `Intersection`, `Area`, and `Transform` from `django.contrib.gis.db.models.functions`. No raw SQL, no `_meta.db_table` introspection, no `ON CONFLICT` constraint-matching footguns.

Closes the maintainer-answered gating questions on the v3 design:
- **Q1 (area-units):** fixed. Area is now measured in a projected metric CRS, not degree-squared.
- **Projection coverage:** option (ii) — per-region branching by state-FIPS prefix for now. Option (iii) — single global equal-area projection (EPSG:6933) everywhere — is the eventual end state, to be filed as a follow-up so this lookup doesn't become permanent.

## What changed

- `socialwarehouse/geo/projection.py` (new) — `area_srid_for_state_fips` and `area_srid_for_geoid` return the SRID to use for area math:
  - CONUS: **EPSG:5070** (NAD83 / Conus Albers Equal Area)
  - AK (02): **EPSG:3338** (NAD83 / Alaska Albers)
  - HI (15): **EPSG:3563** (NAD83(HARN) / Hawaii Albers Equal Area)
  - PR (72) / USVI (78): **EPSG:32161** (NAD83 / Puerto Rico & Virgin Is.)
  - AS (60) / GU (66) / MP (69): **EPSG:6933** (NSIDC EASE-Grid 2.0)
  - Empty/unknown input: **EPSG:6933** fallback
- `socialwarehouse/geo/management/commands/compute_geographic_intersections.py` — replaced `county.geom.intersection(cd.geom)` and `.geom.area` (WKB-round-trip + degree-squared math) with ORM annotations. Inner geometry math now runs in PostGIS in one query per outer county/VTD. Per-base-geom area is computed once per outer-loop iteration (not once per intersecting CD). New `_as_multipolygon` helper coerces `ST_Intersection`'s variable output type into a MultiPolygon before storage.
- `tests/unit/geo/test_projection.py` (new) — parametrized coverage for the per-region SRID table, the global-equal-area fallback, and GEOID-prefix slicing.

## Data-correction effect

After this lands and the cron runs, existing rows in `sw_geo_intersection_county_cd` and `sw_geo_intersection_vtd_cd` will be **rewritten** with metric-CRS percentages. The new percentages are the correct ones — the old ones were degree-squared/degree-squared ratios, which is not a meaningful planar area on a curved earth (latitude-dependent distortion). This is the intended Q1 correction, captured in the design v3 commit on SW#182.

## Follow-ups owed

1. File the **option (iii) ticket**: drop the per-region table and use EPSG:6933 everywhere — the eventual end state per the design.
2. **Measure cron apply-time** after this lands; only build Option B (raw SQL INSERT...SELECT per the design) if the measurement says Option A isn't enough.

## Test plan
- [ ] CI green (Django checks + new projection tests).
- [ ] Manual: run on a small CONUS state (e.g. RI: `--state 44 --year 2020`) and confirm `pct_of_county` values land in 0-100 and `intersection_area_sqm` values are in plausible square-meter ranges.
- [ ] Manual: run on AK (`--state 02 --year 2020`) and confirm the per-region branch picks EPSG:3338.
- [ ] Spot-check one row against a GIS tool (QGIS or ad-hoc psql `ST_Area(ST_Transform(...))`).

## References
- Design v3: docs/designs/m5-postgis-st-intersection.md (SW#182).
- Issue: SW#149.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added geographic projection selection system to ensure accurate area calculations across U.S. regions and territories.

* **Improvements**
  * Optimized geographic intersection computation for county-congressional district and voting district relationship calculations.

* **Tests**
  * Added comprehensive unit tests validating geographic projection selection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/184?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->