### PR TITLE
docs(geo): codify GeoDjango server-side-math discipline

### DIFF
--- a/docs/entities/geo-orm-discipline.md
+++ b/docs/entities/geo-orm-discipline.md
@@ -1,0 +1,63 @@
+# Geo ORM discipline (in-repo rule)
+
+**Surveyed at:** 2026-05-19
+**Owner:** geo + warehouse maintainers
+**Companion skill:** `geodjango-server-side-math` (workspace skills tree)
+
+## The reflex
+
+This project uses GeoDjango against PostGIS. **Geometry math runs server-side.** Reach for `django.contrib.gis.db.models.functions.*` (`Intersection`, `Union`, `Difference`, `Area`, `Length`, `Distance`, `Transform`, `Centroid`, `Buffer`, ...) inside a `.annotate(...)` or filter expression. PostGIS does the math; only result attributes cross the wire.
+
+The antipattern is calling `geom1.method(geom2)` on a Python `GEOSGeometry` inside a loop. Both geometries cross the wire as WKB, GEOS computes the result in Python, and any write goes back as a third serde. Same `libgeos` runs in both places — no compute advantage, only round-trip cost.
+
+## The recognition test
+
+Read the code as it's written. If you see any of these *inside* an iteration over a queryset (or in a per-row service callback), it's the antipattern:
+
+- `.intersection(`, `.union(`, `.difference(`, `.symmetric_difference(` on a `.geom`
+- `.area`, `.length`, `.centroid`, `.envelope` on a `.geom`
+- `.distance(`, `.contains(`, `.touches(`, `.within(`, `.overlaps(`, `.crosses(`, `.disjoint(` on a `.geom`
+- `.buffer(`, `.simplify(`, `.transform(` on a `.geom` inside a loop body
+
+## The fix shape
+
+```python
+from django.contrib.gis.db.models.functions import Area, Intersection, Transform
+
+cd_rows = (
+    CongressionalDistrict.objects
+    .filter(vintage_year=year, geom__intersects=county.geom)
+    .annotate(
+        intersection_geom=Intersection("geom", county.geom),
+        intersection_area_m2=Area(
+            Transform(Intersection("geom", county.geom), srid)
+        ),
+    )
+)
+```
+
+For Area and Length, **project to a metric CRS before measuring**. `geom.area` on a 4269- or 4326-SRID geometry returns degree-squared, which is not a planar area on a curved earth. Use `Area(Transform(geom, <projected_srid>))`. The per-region projection lookup lives at `socialwarehouse/geo/projection.py`.
+
+## The exceptions
+
+Python-side geometry calls are **not** the antipattern when:
+
+- **Building a value object from non-database input.** `Point(lon, lat, srid=4326)` from a user-supplied lat/lon, or a geocoder result — that point is then passed to a queryset (`Model.objects.filter(geom__contains=point)`), which runs server-side. See `socialwarehouse/api/geo/views.py` lines 170 and 345 for the canonical example.
+- **One-time normalization, then many filters.** `point.clone()` + `point.transform(4269)` once per address, followed by many `Model.objects.filter(geom__contains=point, ...)` calls. See `socialwarehouse/geo/management/commands/assign_boundaries.py:272` — the alternative (wrapping every filter in `Transform(...)`) is wordier for the same SQL.
+- **Single-row diagnostic.** After `qs.first()` returns one row, accessing `.geom.area` for a print or one-shot computation is fine. The antipattern is the *loop* shape, not the access pattern.
+
+## Audit baseline (2026-05-19)
+
+A full grep of `socialwarehouse/` for the antipattern signatures (`.intersection(`, `.union(`, `.difference(`, `.area`, `.distance(`, `.contains(` on a Python `GEOSGeometry`) found **exactly one instance**: `geo/management/commands/compute_geographic_intersections.py`. That instance is fixed by the M5 work tracked in issue #149 (design note SW#182, implementation SW#184).
+
+The audit confirms SW is otherwise well-shaped around the ORM. This doc exists to keep it that way, not to remediate a backlog.
+
+## Worked example
+
+The pre-M5 `compute_geographic_intersections.py` is the canonical antipattern, preserved in git history. The post-M5 form (`Intersection`/`Area`/`Transform` annotations + per-region SRID lookup from `socialwarehouse/geo/projection.py`) is the canonical fix.
+
+For the full design reasoning (including when to break the rule for a raw-SQL `INSERT...SELECT` form, and the three footguns that path carries), see `docs/designs/m5-postgis-st-intersection.md`.
+
+## When to break the rule
+
+Only when measurement says you must. The full bulk-rewrite path (raw `INSERT ... SELECT ST_Intersection ... ON CONFLICT DO UPDATE`) is a real performance win over the ORM annotation form, but it carries three footguns the annotation form does not: `_meta.db_table` introspection, SRID reconciliation, `ON CONFLICT (...)` column-vs-constraint matching. Adopt only after measuring the annotation form and judging it insufficient. The M5 design note documents this path in full.


### PR DESCRIPTION
## Summary

New entity doc at `docs/entities/geo-orm-discipline.md` codifying the GeoDjango-against-PostGIS discipline: geometry math runs server-side via `django.contrib.gis.db.models.functions.*`. The antipattern (Python-side `.intersection`, `.area`, `.distance` inside a loop) is named, the fix shape is shown, and the three legitimate exceptions are anchored to file:line citations from the audit so future readers don't over-correct them.

## Audit finding (the why)

The operator (2026-05-19) raised concern that "so many operations that should be happening in the ORM are happening outside it" after seeing the M5 case. A full grep of `socialwarehouse/` for the antipattern signatures (`.intersection(`, `.union(`, `.difference(`, `.area`, `.distance(`, `.contains(` on a Python `GEOSGeometry`) found **exactly one instance** — `compute_geographic_intersections.py` — and it's already fixed by SW#184 (M5).

The three sites I expected to find issues (and didn't):
- `assign_boundaries.py:272` — `query_point.transform(4269)` is one-time SRID normalization before many server-side `geom__contains` filters. Correct pattern.
- `api/geo/views.py:170,345` — `Point(lon, lat, srid=4326)` builds a Django value from user input, then passes it to manager methods that do server-side work. Correct pattern.
- `geocode_addresses.py:158,228` — `addr.geom = Point(...)` just stores a value. Correct pattern.

This doc exists to keep SW in its currently-healthy state, not to remediate a backlog.

## Companion artifact (not in this PR)

A workspace skill `geodjango-server-side-math` was added to the agent workspace skills tree (lives outside this repo). It carries the same discipline in resolver-discoverable form so future agent runs surface it when touching geo code.

## Test plan
- [ ] Doc renders correctly on GitHub.
- [ ] Future SW PRs touching geo code can be reviewed against the "recognition test" section.

## References
- M5 design v3: `docs/designs/m5-postgis-st-intersection.md` (SW#182)
- M5 implementation: SW#184
- Companion workspace skill: `~/.craft-agent/workspaces/my-workspace/skills/geodjango-server-side-math/SKILL.md`
