### PR TITLE
F11/SW#100 step 2: temporal boundary helpers on Address

### DIFF
--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -60,6 +60,34 @@ BoundaryTimelineEntry = namedtuple(
 )
 
 
+def _safe_plan_name(plan_id):
+    """Return a RedistrictingPlan's plan_name without triggering the SU#527 columns.
+
+    Calling ``abp.redistricting_plan`` triggers a SELECT that includes
+    ``effective_from`` / ``effective_to``, columns the siege_utilities
+    migrations don't create (SU#527). Using
+    ``RedistrictingPlan.objects.filter(...).values_list("plan_name", flat=True)``
+    restricts the SELECT to only the columns we need, dodging the
+    missing-column crash.
+
+    Returns ``None`` for null ``plan_id``, for orphan FKs (non-existent
+    plan), or if any error occurs during the lookup.
+    """
+    if plan_id is None:
+        return None
+    try:
+        from siege_utilities.geo.django.models import RedistrictingPlan
+
+        return (
+            RedistrictingPlan.objects
+            .filter(pk=plan_id)
+            .values_list("plan_name", flat=True)
+            .first()
+        )
+    except Exception:
+        return None
+
+
 class Address(models.Model):
     """
     A geocoded US address with Census boundary assignments.
@@ -336,7 +364,12 @@ class Address(models.Model):
             (Postgres default for NULLS LAST). For most-recent-first
             timelines this is the expected behavior.
         """
-        qs = self.boundary_periods.select_related("vintage", "redistricting_plan")
+        # NOTE: select_related on `redistricting_plan` triggers a SELECT
+        # that includes `effective_from` / `effective_to` columns the
+        # current siege_utilities migrations don't create (SU#527).
+        # Loading the plan lazily via id-based lookup avoids that crash.
+        # Restore once SU#527 lands and SW's SU pin is bumped.
+        qs = self.boundary_periods.select_related("vintage")
         if boundary_type:
             if boundary_type not in self._BOUNDARY_TYPES:
                 raise ValueError(
@@ -350,14 +383,22 @@ class Address(models.Model):
     def boundaries_on(self, on_date):
         """Boundaries this address was in on ``on_date``.
 
-        Resolves the active redistricting plan(s) for ``on_date`` and
-        returns one ABP row per boundary type whose plan was active on
-        that date. Boundary types not covered by any plan-bound row fall
-        back to the NULL-plan (Census default) row when one exists for
-        the vintage covering ``on_date``.
+        For each boundary type, returns the ABP row whose ``context_date``
+        is the most recent on-or-before ``on_date`` (with rows whose
+        ``context_date`` is NULL treated as fallback / always-applicable).
 
         Returns a dict ``{boundary_type: AddressBoundaryPeriod}``.
         Missing keys mean no ABP row covers ``on_date`` for that type.
+
+        NOTE: An earlier version of this helper resolved plan-bound rows
+        by reading ``redistricting_plan.effective_from`` /
+        ``effective_to``. Those columns are declared on the SU model but
+        the SU migrations don't create them (SU#527). Until that lands,
+        we use ``context_date`` as the temporal indicator — which
+        ``assign_boundaries`` already sets to "the date this assignment
+        is valid for" — and skip the plan-effective-range path entirely.
+        Restore the richer resolution once SU#527 ships and SW's SU pin
+        bumps.
         """
         from socialwarehouse.geo.models import CensusVintageConfig
 
@@ -368,38 +409,22 @@ class Address(models.Model):
         periods = list(
             self.boundary_periods
             .filter(vintage=vintage)
-            .select_related("redistricting_plan")
+            .filter(
+                models.Q(context_date__lte=on_date)
+                | models.Q(context_date__isnull=True)
+            )
+            .order_by(models.F("context_date").desc(nulls_last=True))
         )
 
         result = {}
         for btype in self._BOUNDARY_TYPES:
             field = f"{btype}_geoid"
-            active = next(
-                (
-                    p for p in periods
-                    if p.redistricting_plan
-                    and p.redistricting_plan.effective_from <= on_date
-                    and (
-                        p.redistricting_plan.effective_to is None
-                        or p.redistricting_plan.effective_to >= on_date
-                    )
-                    and getattr(p, field, None)
-                ),
+            chosen = next(
+                (p for p in periods if getattr(p, field, None)),
                 None,
             )
-            if active:
-                result[btype] = active
-                continue
-            default = next(
-                (
-                    p for p in periods
-                    if p.redistricting_plan_id is None
-                    and getattr(p, field, None)
-                ),
-                None,
-            )
-            if default:
-                result[btype] = default
+            if chosen:
+                result[btype] = chosen
 
         return result
 
@@ -466,36 +491,38 @@ class Address(models.Model):
         sorted oldest-first. Each entry exposes:
 
           - ``geoid`` — the boundary GEOID for that period.
-          - ``effective_from`` — :class:`datetime.date` the period began.
-          - ``effective_to`` — :class:`datetime.date` it ended, or
-            ``None`` for "still active."
+          - ``effective_from`` — :class:`datetime.date` the period began,
+            taken from the ABP row's ``context_date`` (or the linked
+            vintage's start year when ``context_date`` is NULL).
+          - ``effective_to`` — :class:`datetime.date` it ended, derived
+            as the day before the next entry's ``effective_from``;
+            ``None`` for the most recent entry ("still active").
           - ``plan_name`` — the redistricting plan name that established
-            the assignment, or ``None`` for the Census-default (no plan).
+            the assignment, or ``None`` for the Census-default (no plan)
+            and for orphan FKs (non-existent plan id).
           - ``abp`` — the raw :class:`AddressBoundaryPeriod` row, for
-            callers wanting fields beyond the four headline ones
-            (``assignment_method``, ``congressional_term``,
-            ``plan_district_*``, etc.).
+            callers wanting fields beyond the four headline ones.
 
-        Effective ranges:
-          - Plan-bound rows: ``redistricting_plan.effective_from`` and
-            ``.effective_to``. ``effective_to`` may be ``None`` meaning
-            "currently active."
-          - NULL-plan rows (Census defaults): the linked vintage's
-            ``effective_start`` and ``effective_end`` years, converted
-            to ``date(year, 1, 1)`` and ``date(year, 12, 31)``.
+        Effective range derivation:
+          We use ``context_date`` (set by ``assign_boundaries`` to
+          "the date this assignment is valid for") to thread the
+          timeline. ``effective_to`` is derived from the next entry's
+          start. The first entry's ``effective_from`` falls back to
+          the vintage's effective start year when its ``context_date``
+          is NULL.
+
+          An earlier version of this helper read ``effective_from`` /
+          ``effective_to`` from the linked ``RedistrictingPlan`` row,
+          but those columns are declared on the SU model without a
+          matching migration (SU#527). Once that lands and SW's SU pin
+          bumps, this method should be revised to prefer plan-side
+          dates when available.
 
         Adjacent same-geoid rows are NOT collapsed. Callers wanting
         collapse-by-geoid can use :func:`itertools.groupby` on the
-        result — collapse semantics are opinionated (across vintage
-        boundaries? plan-name-aware?) and forcing them here would
-        mis-shape the layered API.
-
-        Rows whose ``redistricting_plan_id`` points at a non-existent
-        plan (the FK is ``db_constraint=False``, so orphans are
-        possible) are treated as NULL-plan; the entry's ``plan_name``
-        is ``None`` and the effective range falls back to the vintage.
+        result.
         """
-        from datetime import date
+        from datetime import date, timedelta
 
         if boundary_type not in self._BOUNDARY_TYPES:
             raise ValueError(
@@ -503,31 +530,30 @@ class Address(models.Model):
                 f"expected one of {self._BOUNDARY_TYPES}"
             )
 
-        rows = list(self.boundary_history(boundary_type=boundary_type))
+        # boundary_history returns newest-first; reverse to walk oldest-first.
+        rows = list(reversed(list(self.boundary_history(boundary_type=boundary_type))))
         entries = []
         field = f"{boundary_type}_geoid"
 
-        for abp in rows:
+        for i, abp in enumerate(rows):
             geoid = getattr(abp, field, None)
             if not geoid:
                 continue
 
-            plan = None
-            if abp.redistricting_plan_id is not None:
-                try:
-                    plan = abp.redistricting_plan
-                except Exception:
-                    plan = None
+            eff_from = abp.context_date
+            if eff_from is None and abp.vintage_id is not None:
+                eff_from = date(abp.vintage.effective_start, 1, 1)
 
-            if plan is not None:
-                eff_from = getattr(plan, "effective_from", None)
-                eff_to = getattr(plan, "effective_to", None)
-                plan_name = getattr(plan, "plan_name", None) or str(plan)
-            else:
-                vintage = abp.vintage
-                eff_from = date(vintage.effective_start, 1, 1)
-                eff_to = date(vintage.effective_end, 12, 31)
-                plan_name = None
+            eff_to = None
+            if i + 1 < len(rows):
+                next_abp = rows[i + 1]
+                next_start = next_abp.context_date
+                if next_start is None and next_abp.vintage_id is not None:
+                    next_start = date(next_abp.vintage.effective_start, 1, 1)
+                if next_start is not None:
+                    eff_to = next_start - timedelta(days=1)
+
+            plan_name = _safe_plan_name(abp.redistricting_plan_id)
 
             entries.append(BoundaryTimelineEntry(
                 geoid=geoid,
@@ -537,10 +563,7 @@ class Address(models.Model):
                 abp=abp,
             ))
 
-        return sorted(
-            entries,
-            key=lambda e: e.effective_from or date.min,
-        )
+        return entries
 
     def geoid_on(self, boundary_type, on_date):
         """The GEOID string for one boundary type as of ``on_date``, or None.

--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -281,6 +281,116 @@ class Address(models.Model):
 
         return self
 
+    # F11 / SW#100 step-2 helpers: temporal boundary history.
+    #
+    # The Address-level GEOID fields (cd_geoid, sldl_geoid, ...) are a
+    # cache of the *current* boundary assignment. The authoritative
+    # source for "which boundaries did this address belong to on date X"
+    # and "every boundary this address has ever been in" is the
+    # AddressBoundaryPeriod table, accessed through these helpers.
+    #
+    # Until the step-2b signal lands, the cache may drift from the
+    # helper's answer when ABP is written without updating Address. Use
+    # the cache for hot-path filters; use the helpers when correctness
+    # against the temporal record matters.
+    _BOUNDARY_TYPES = (
+        "state", "county", "tract", "block_group", "block",
+        "vtd", "cd", "sldl", "sldu",
+    )
+
+    def boundary_history(self, boundary_type=None):
+        """Every recorded boundary assignment for this address.
+
+        ``boundary_type``, if given, filters to ABP rows that carry a
+        non-empty geoid for that type. Valid values: ``state``,
+        ``county``, ``tract``, ``block_group``, ``block``, ``vtd``,
+        ``cd``, ``sldl``, ``sldu``.
+
+        Returns a queryset of :class:`AddressBoundaryPeriod` ordered
+        most-recent-first by ``context_date`` then ``assigned_at``.
+        Includes the linked ``vintage`` and ``redistricting_plan`` via
+        ``select_related`` so callers can read the plan / vintage
+        metadata without N+1 lookups.
+        """
+        qs = self.boundary_periods.select_related("vintage", "redistricting_plan")
+        if boundary_type:
+            if boundary_type not in self._BOUNDARY_TYPES:
+                raise ValueError(
+                    f"Unknown boundary_type {boundary_type!r}; "
+                    f"expected one of {self._BOUNDARY_TYPES}"
+                )
+            field = f"{boundary_type}_geoid"
+            qs = qs.exclude(**{f"{field}__isnull": True}).exclude(**{field: ""})
+        return qs.order_by("-context_date", "-assigned_at")
+
+    def boundaries_on(self, on_date):
+        """Boundaries this address was in on ``on_date``.
+
+        Resolves the active redistricting plan(s) for ``on_date`` and
+        returns one ABP row per boundary type whose plan was active on
+        that date. Boundary types not covered by any plan-bound row fall
+        back to the NULL-plan (Census default) row when one exists for
+        the vintage covering ``on_date``.
+
+        Returns a dict ``{boundary_type: AddressBoundaryPeriod}``.
+        Missing keys mean no ABP row covers ``on_date`` for that type.
+        """
+        from socialwarehouse.geo.models import CensusVintageConfig
+
+        vintage = CensusVintageConfig.for_year(on_date.year)
+        if not vintage:
+            return {}
+
+        periods = list(
+            self.boundary_periods
+            .filter(vintage=vintage)
+            .select_related("redistricting_plan")
+        )
+
+        result = {}
+        for btype in self._BOUNDARY_TYPES:
+            field = f"{btype}_geoid"
+            active = next(
+                (
+                    p for p in periods
+                    if p.redistricting_plan
+                    and p.redistricting_plan.effective_from <= on_date
+                    and (
+                        p.redistricting_plan.effective_to is None
+                        or p.redistricting_plan.effective_to >= on_date
+                    )
+                    and getattr(p, field, None)
+                ),
+                None,
+            )
+            if active:
+                result[btype] = active
+                continue
+            default = next(
+                (
+                    p for p in periods
+                    if p.redistricting_plan_id is None
+                    and getattr(p, field, None)
+                ),
+                None,
+            )
+            if default:
+                result[btype] = default
+
+        return result
+
+    def current_boundaries(self):
+        """Sugar for :meth:`boundaries_on(today)`.
+
+        Once the F11 step-2b signal-driven cache refresh is in place,
+        ``current_boundaries()[btype].{btype}_geoid`` returns the same
+        value as ``self.{btype}_geoid`` for every type. Until then, the
+        helper is authoritative and the cache may lag.
+        """
+        from django.utils import timezone
+
+        return self.boundaries_on(timezone.localdate())
+
 
 # Backwards-compatible alias
 United_States_Address = Address

--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -391,6 +391,44 @@ class Address(models.Model):
 
         return self.boundaries_on(timezone.localdate())
 
+    def boundary_on(self, boundary_type, on_date):
+        """The ABP row for one boundary type, as of ``on_date``.
+
+        Sugar for ``self.boundaries_on(on_date).get(boundary_type)``.
+        Returns the ABP row, or ``None`` if no row covers ``on_date``
+        for that type. Validates ``boundary_type`` against the known
+        set up-front so a typo doesn't silently return ``None``.
+        """
+        if boundary_type not in self._BOUNDARY_TYPES:
+            raise ValueError(
+                f"Unknown boundary_type {boundary_type!r}; "
+                f"expected one of {self._BOUNDARY_TYPES}"
+            )
+        return self.boundaries_on(on_date).get(boundary_type)
+
+    def boundary_at(self, boundary_type, position):
+        """The ABP row at ``position`` in reverse-chron history for ``boundary_type``.
+
+        ``position`` is 0-indexed (Python convention; the audience is
+        data analysts, not domain users, so SQL/Python's 0-based
+        indexing matches the caller reflex). ``position=0`` is the
+        most recent ABP row for the given boundary type; ``position=4``
+        is the fifth most recent.
+
+        Returns ``None`` for out-of-range positions rather than
+        raising; callers asking for "the 50th most recent CD" on an
+        address with two CD periods get a clean ``None`` rather than
+        an IndexError.
+
+        For a slice (e.g. the 3rd through 8th most recent), use the
+        underlying queryset directly:
+            ``addr.boundary_history(boundary_type="cd")[2:8]``
+        """
+        if position < 0:
+            raise ValueError(f"position must be non-negative, got {position}")
+        qs = self.boundary_history(boundary_type=boundary_type)
+        return qs[position:position + 1].first()
+
 
 # Backwards-compatible alias
 United_States_Address = Address

--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -12,6 +12,8 @@ Design:
     rich queries.
 """
 
+from collections import namedtuple
+
 from django.contrib.gis.db import models
 from django.utils import timezone
 
@@ -45,6 +47,17 @@ GEOCODE_SOURCE_CHOICES = [
     ("google", "Google Geocoding API"),
     ("smartystreets", "SmartyStreets"),
 ]
+
+
+# F11 / SW#100: one entry in an address's temporal-boundary timeline.
+# Returned by Address.boundary_timeline(). Named-tuple so callers can
+# unpack positionally or dot-access; `abp` carries the raw
+# AddressBoundaryPeriod row for fields beyond the four headline ones
+# (assignment_method, congressional_term, plan_district_*, ...).
+BoundaryTimelineEntry = namedtuple(
+    "BoundaryTimelineEntry",
+    ["geoid", "effective_from", "effective_to", "plan_name", "abp"],
+)
 
 
 class Address(models.Model):
@@ -311,6 +324,17 @@ class Address(models.Model):
         Includes the linked ``vintage`` and ``redistricting_plan`` via
         ``select_related`` so callers can read the plan / vintage
         metadata without N+1 lookups.
+
+        Notes:
+          - Unfiltered (``boundary_type=None``) returns rows with
+            sparse geoid fills: plan-bound CD rows have null sldl /
+            sldu, plan-bound SLDL rows have null cd, etc. Each row
+            carries the geoids for the boundary types its plan covers.
+            Filter by ``boundary_type`` for the all-rows-have-this-geoid
+            shape.
+          - Rows with NULL ``context_date`` sort last under DESC
+            (Postgres default for NULLS LAST). For most-recent-first
+            timelines this is the expected behavior.
         """
         qs = self.boundary_periods.select_related("vintage", "redistricting_plan")
         if boundary_type:
@@ -386,6 +410,12 @@ class Address(models.Model):
         ``current_boundaries()[btype].{btype}_geoid`` returns the same
         value as ``self.{btype}_geoid`` for every type. Until then, the
         helper is authoritative and the cache may lag.
+
+        "Today" is ``django.utils.timezone.localdate()`` — the date
+        in the active timezone (or settings.TIME_ZONE). At midnight
+        boundaries, two callers in different timezones may see
+        different answers for an address whose temporal record changes
+        on that day.
         """
         from django.utils import timezone
 
@@ -428,6 +458,115 @@ class Address(models.Model):
             raise ValueError(f"position must be non-negative, got {position}")
         qs = self.boundary_history(boundary_type=boundary_type)
         return qs[position:position + 1].first()
+
+    def boundary_timeline(self, boundary_type):
+        """Chronological timeline of one boundary type for this address.
+
+        Returns a list of :class:`BoundaryTimelineEntry` namedtuples
+        sorted oldest-first. Each entry exposes:
+
+          - ``geoid`` — the boundary GEOID for that period.
+          - ``effective_from`` — :class:`datetime.date` the period began.
+          - ``effective_to`` — :class:`datetime.date` it ended, or
+            ``None`` for "still active."
+          - ``plan_name`` — the redistricting plan name that established
+            the assignment, or ``None`` for the Census-default (no plan).
+          - ``abp`` — the raw :class:`AddressBoundaryPeriod` row, for
+            callers wanting fields beyond the four headline ones
+            (``assignment_method``, ``congressional_term``,
+            ``plan_district_*``, etc.).
+
+        Effective ranges:
+          - Plan-bound rows: ``redistricting_plan.effective_from`` and
+            ``.effective_to``. ``effective_to`` may be ``None`` meaning
+            "currently active."
+          - NULL-plan rows (Census defaults): the linked vintage's
+            ``effective_start`` and ``effective_end`` years, converted
+            to ``date(year, 1, 1)`` and ``date(year, 12, 31)``.
+
+        Adjacent same-geoid rows are NOT collapsed. Callers wanting
+        collapse-by-geoid can use :func:`itertools.groupby` on the
+        result — collapse semantics are opinionated (across vintage
+        boundaries? plan-name-aware?) and forcing them here would
+        mis-shape the layered API.
+
+        Rows whose ``redistricting_plan_id`` points at a non-existent
+        plan (the FK is ``db_constraint=False``, so orphans are
+        possible) are treated as NULL-plan; the entry's ``plan_name``
+        is ``None`` and the effective range falls back to the vintage.
+        """
+        from datetime import date
+
+        if boundary_type not in self._BOUNDARY_TYPES:
+            raise ValueError(
+                f"Unknown boundary_type {boundary_type!r}; "
+                f"expected one of {self._BOUNDARY_TYPES}"
+            )
+
+        rows = list(self.boundary_history(boundary_type=boundary_type))
+        entries = []
+        field = f"{boundary_type}_geoid"
+
+        for abp in rows:
+            geoid = getattr(abp, field, None)
+            if not geoid:
+                continue
+
+            plan = None
+            if abp.redistricting_plan_id is not None:
+                try:
+                    plan = abp.redistricting_plan
+                except Exception:
+                    plan = None
+
+            if plan is not None:
+                eff_from = getattr(plan, "effective_from", None)
+                eff_to = getattr(plan, "effective_to", None)
+                plan_name = getattr(plan, "plan_name", None) or str(plan)
+            else:
+                vintage = abp.vintage
+                eff_from = date(vintage.effective_start, 1, 1)
+                eff_to = date(vintage.effective_end, 12, 31)
+                plan_name = None
+
+            entries.append(BoundaryTimelineEntry(
+                geoid=geoid,
+                effective_from=eff_from,
+                effective_to=eff_to,
+                plan_name=plan_name,
+                abp=abp,
+            ))
+
+        return sorted(
+            entries,
+            key=lambda e: e.effective_from or date.min,
+        )
+
+    def geoid_on(self, boundary_type, on_date):
+        """The GEOID string for one boundary type as of ``on_date``, or None.
+
+        Sugar for ``self.boundary_on(boundary_type, on_date).{boundary_type}_geoid``
+        with None-safety: returns ``None`` if no ABP row covers
+        ``on_date`` for that type, rather than raising AttributeError.
+        """
+        row = self.boundary_on(boundary_type, on_date)
+        if row is None:
+            return None
+        return getattr(row, f"{boundary_type}_geoid", None) or None
+
+    def current_geoid(self, boundary_type):
+        """The GEOID string for one boundary type as of today, or None.
+
+        Sugar for :meth:`geoid_on(boundary_type, today)`. With the
+        F11 step-2b signal-driven cache refresh in place, returns the
+        same value as ``self.{boundary_type}_geoid`` directly.
+
+        "Today" is ``django.utils.timezone.localdate()``; see the note
+        on :meth:`current_boundaries` for the midnight-boundary caveat.
+        """
+        from django.utils import timezone
+
+        return self.geoid_on(boundary_type, timezone.localdate())
 
 
 # Backwards-compatible alias

--- a/tests/unit/geo/test_address_boundary_helpers.py
+++ b/tests/unit/geo/test_address_boundary_helpers.py
@@ -96,13 +96,13 @@ class TestBoundaryHistory(TestCase):
             address=self.addr,
             vintage=self.vintage_2020,
             redistricting_plan_id=99,
-            sldl_geoid="01-005",
+            sldl_geoid="01005",
             context_date=date(2024, 6, 1),
             assignment_method="PLAN_SPATIAL_JOIN",
         )
         sldl_history = list(self.addr.boundary_history(boundary_type="sldl"))
         assert len(sldl_history) == 1
-        assert sldl_history[0].sldl_geoid == "01-005"
+        assert sldl_history[0].sldl_geoid == "01005"
 
     def test_unknown_boundary_type_raises(self):
         import pytest

--- a/tests/unit/geo/test_address_boundary_helpers.py
+++ b/tests/unit/geo/test_address_boundary_helpers.py
@@ -270,6 +270,172 @@ class TestBoundaryAt(TestCase):
         assert rows == [self.abp_mid, self.abp_old]
 
 
+class TestGeoidOn(TestCase):
+    """geoid_on: one-step GEOID string lookup, None-safe."""
+
+    def setUp(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+
+        CensusVintageConfig.seed_defaults()
+        vintage = CensusVintageConfig.objects.get(decade=2020)
+        self.addr = Address.objects.create(state_abbreviation="MI")
+
+        AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=vintage,
+            state_geoid="26",
+            county_geoid="26163",
+            context_date=date(2023, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+
+    def test_returns_string_when_present(self):
+        assert self.addr.geoid_on("county", date(2023, 6, 1)) == "26163"
+
+    def test_returns_none_when_type_absent(self):
+        assert self.addr.geoid_on("cd", date(2023, 6, 1)) is None
+
+    def test_returns_none_when_no_row(self):
+        from socialwarehouse.geo.models import Address
+
+        other = Address.objects.create(state_abbreviation="OH")
+        assert other.geoid_on("county", date(2023, 6, 1)) is None
+
+    def test_unknown_boundary_type_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            self.addr.geoid_on("precinct", date(2023, 6, 1))
+
+
+class TestCurrentGeoid(TestCase):
+    """current_geoid: geoid_on(today) sugar."""
+
+    def test_delegates_to_today(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+        from django.utils import timezone
+
+        CensusVintageConfig.seed_defaults()
+        vintage = CensusVintageConfig.objects.get(decade=2020)
+        addr = Address.objects.create(state_abbreviation="WA")
+
+        AddressBoundaryPeriod.objects.create(
+            address=addr,
+            vintage=vintage,
+            state_geoid="53",
+            county_geoid="53033",
+            context_date=timezone.localdate(),
+            assignment_method="SPATIAL_JOIN",
+        )
+
+        assert addr.current_geoid("state") == "53"
+        assert addr.current_geoid("county") == "53033"
+        assert addr.current_geoid("cd") is None
+
+
+class TestBoundaryTimeline(TestCase):
+    """boundary_timeline: chronological list of BoundaryTimelineEntry tuples.
+
+    Plan-bound effective-range derivation requires real siege_utilities
+    RedistrictingPlan rows; this unit suite exercises the NULL-plan
+    path (vintage-derived dates), the orphan-FK path (treated as
+    NULL-plan), and the ordering / shape contract. End-to-end coverage
+    of the plan-bound path lives in integration tests.
+    """
+
+    def setUp(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+
+        CensusVintageConfig.seed_defaults()
+        self.vintage_2010 = CensusVintageConfig.objects.get(decade=2010)
+        self.vintage_2020 = CensusVintageConfig.objects.get(decade=2020)
+
+        self.addr = Address.objects.create(state_abbreviation="AL")
+
+        # Two NULL-plan rows on different vintages.
+        self.abp_2010 = AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2010,
+            cd_geoid="0107",
+            context_date=date(2015, 6, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+        self.abp_2020 = AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2020,
+            cd_geoid="0107",
+            context_date=date(2021, 6, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+        # Orphan-FK row (plan_id points to a non-existent row).
+        self.abp_orphan = AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2020,
+            redistricting_plan_id=999_999,
+            cd_geoid="0102",
+            context_date=date(2024, 6, 1),
+            assignment_method="PLAN_SPATIAL_JOIN",
+        )
+
+    def test_entries_are_oldest_first(self):
+        timeline = self.addr.boundary_timeline("cd")
+        assert len(timeline) == 3
+        assert timeline[0].abp == self.abp_2010
+        assert timeline[1].abp == self.abp_2020
+        assert timeline[2].abp == self.abp_orphan
+
+    def test_null_plan_range_comes_from_vintage(self):
+        timeline = self.addr.boundary_timeline("cd")
+        entry_2010 = timeline[0]
+        assert entry_2010.effective_from == date(2010, 1, 1)
+        assert entry_2010.effective_to == date(2019, 12, 31)
+        assert entry_2010.plan_name is None
+
+    def test_orphan_fk_treated_as_null_plan(self):
+        timeline = self.addr.boundary_timeline("cd")
+        orphan_entry = timeline[2]
+        assert orphan_entry.effective_from == date(2020, 1, 1)
+        assert orphan_entry.effective_to == date(2029, 12, 31)
+        assert orphan_entry.plan_name is None
+
+    def test_entry_carries_geoid_and_abp(self):
+        timeline = self.addr.boundary_timeline("cd")
+        assert timeline[0].geoid == "0107"
+        assert timeline[2].geoid == "0102"
+        assert timeline[0].abp == self.abp_2010
+
+    def test_entry_namedtuple_unpacks(self):
+        timeline = self.addr.boundary_timeline("cd")
+        geoid, eff_from, eff_to, plan_name, abp = timeline[0]
+        assert geoid == "0107"
+        assert eff_from == date(2010, 1, 1)
+        assert eff_to == date(2019, 12, 31)
+        assert plan_name is None
+        assert abp == self.abp_2010
+
+    def test_unknown_boundary_type_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            self.addr.boundary_timeline("precinct")
+
+    def test_empty_when_no_rows_of_type(self):
+        # No sldl_geoid populated on any row.
+        assert self.addr.boundary_timeline("sldl") == []
+
+    def test_isolation_between_addresses(self):
+        from socialwarehouse.geo.models import Address
+
+        other = Address.objects.create(state_abbreviation="GA")
+        assert other.boundary_timeline("cd") == []
+
+
 class TestCurrentBoundaries(TestCase):
     """current_boundaries delegates to boundaries_on(today)."""
 

--- a/tests/unit/geo/test_address_boundary_helpers.py
+++ b/tests/unit/geo/test_address_boundary_helpers.py
@@ -169,6 +169,107 @@ class TestBoundariesOnNullPlanFallback(TestCase):
         assert result == {}
 
 
+class TestBoundaryOn(TestCase):
+    """boundary_on: single-type sugar over boundaries_on."""
+
+    def setUp(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+
+        CensusVintageConfig.seed_defaults()
+        vintage = CensusVintageConfig.objects.get(decade=2020)
+        self.addr = Address.objects.create(state_abbreviation="GA")
+
+        self.abp = AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=vintage,
+            state_geoid="13",
+            county_geoid="13089",
+            context_date=date(2023, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+
+    def test_returns_row_when_type_present(self):
+        result = self.addr.boundary_on("county", date(2023, 6, 1))
+        assert result == self.abp
+
+    def test_returns_none_when_type_absent(self):
+        # No cd_geoid on the row, so cd should resolve to None.
+        result = self.addr.boundary_on("cd", date(2023, 6, 1))
+        assert result is None
+
+    def test_unknown_boundary_type_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError) as exc:
+            self.addr.boundary_on("precinct", date(2023, 6, 1))
+        assert "precinct" in str(exc.value)
+
+
+class TestBoundaryAt(TestCase):
+    """boundary_at: positional access into reverse-chron history (0-indexed)."""
+
+    def setUp(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+
+        CensusVintageConfig.seed_defaults()
+        vintage = CensusVintageConfig.objects.get(decade=2020)
+        self.addr = Address.objects.create(state_abbreviation="AL")
+
+        # Three CD-bearing periods, oldest first; will sort newest-first.
+        self.abp_old = AddressBoundaryPeriod.objects.create(
+            address=self.addr, vintage=vintage,
+            cd_geoid="0107", context_date=date(2020, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+        self.abp_mid = AddressBoundaryPeriod.objects.create(
+            address=self.addr, vintage=vintage,
+            redistricting_plan_id=1,
+            cd_geoid="0102", context_date=date(2022, 6, 1),
+            assignment_method="PLAN_SPATIAL_JOIN",
+        )
+        self.abp_new = AddressBoundaryPeriod.objects.create(
+            address=self.addr, vintage=vintage,
+            redistricting_plan_id=2,
+            cd_geoid="0102", context_date=date(2024, 6, 1),
+            assignment_method="PLAN_SPATIAL_JOIN",
+        )
+
+    def test_position_zero_is_most_recent(self):
+        result = self.addr.boundary_at("cd", 0)
+        assert result == self.abp_new
+
+    def test_position_n_walks_back_in_time(self):
+        assert self.addr.boundary_at("cd", 1) == self.abp_mid
+        assert self.addr.boundary_at("cd", 2) == self.abp_old
+
+    def test_out_of_range_returns_none(self):
+        assert self.addr.boundary_at("cd", 50) is None
+
+    def test_negative_position_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError):
+            self.addr.boundary_at("cd", -1)
+
+    def test_unknown_boundary_type_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError) as exc:
+            self.addr.boundary_at("precinct", 0)
+        assert "precinct" in str(exc.value)
+
+    def test_slice_via_queryset_for_ranges(self):
+        # Documenting the canonical range pattern: use queryset slicing
+        # directly rather than a separate boundary_range helper.
+        history = self.addr.boundary_history(boundary_type="cd")
+        rows = list(history[1:3])
+        assert rows == [self.abp_mid, self.abp_old]
+
+
 class TestCurrentBoundaries(TestCase):
     """current_boundaries delegates to boundaries_on(today)."""
 

--- a/tests/unit/geo/test_address_boundary_helpers.py
+++ b/tests/unit/geo/test_address_boundary_helpers.py
@@ -340,11 +340,13 @@ class TestCurrentGeoid(TestCase):
 class TestBoundaryTimeline(TestCase):
     """boundary_timeline: chronological list of BoundaryTimelineEntry tuples.
 
-    Plan-bound effective-range derivation requires real siege_utilities
-    RedistrictingPlan rows; this unit suite exercises the NULL-plan
-    path (vintage-derived dates), the orphan-FK path (treated as
-    NULL-plan), and the ordering / shape contract. End-to-end coverage
-    of the plan-bound path lives in integration tests.
+    Effective ranges are derived from ABP rows' ``context_date`` field
+    (entry N's effective_to = entry N+1's effective_from - 1 day; the
+    most recent entry's effective_to is None). Plan-side effective
+    dates are NOT consulted today (SU#527 — RedistrictingPlan declares
+    `effective_from` / `effective_to` but the SU migrations don't
+    create those columns). When SU#527 lands and SW bumps its pin, a
+    follow-up should restore plan-side date preference where available.
     """
 
     def setUp(self):
@@ -390,19 +392,28 @@ class TestBoundaryTimeline(TestCase):
         assert timeline[1].abp == self.abp_2020
         assert timeline[2].abp == self.abp_orphan
 
-    def test_null_plan_range_comes_from_vintage(self):
+    def test_effective_range_threads_through_context_date(self):
         timeline = self.addr.boundary_timeline("cd")
-        entry_2010 = timeline[0]
-        assert entry_2010.effective_from == date(2010, 1, 1)
-        assert entry_2010.effective_to == date(2019, 12, 31)
-        assert entry_2010.plan_name is None
+        # Entry 0 (oldest): from its own context_date, to the day before entry 1.
+        assert timeline[0].effective_from == date(2015, 6, 1)
+        assert timeline[0].effective_to == date(2021, 5, 31)
+        # Entry 1: from its context_date, to the day before entry 2.
+        assert timeline[1].effective_from == date(2021, 6, 1)
+        assert timeline[1].effective_to == date(2024, 5, 31)
+        # Entry 2 (newest): from its context_date; effective_to is None.
+        assert timeline[2].effective_from == date(2024, 6, 1)
+        assert timeline[2].effective_to is None
 
-    def test_orphan_fk_treated_as_null_plan(self):
+    def test_plan_name_is_none_for_null_plan_rows(self):
         timeline = self.addr.boundary_timeline("cd")
-        orphan_entry = timeline[2]
-        assert orphan_entry.effective_from == date(2020, 1, 1)
-        assert orphan_entry.effective_to == date(2029, 12, 31)
-        assert orphan_entry.plan_name is None
+        assert timeline[0].plan_name is None
+        assert timeline[1].plan_name is None
+
+    def test_orphan_fk_resolves_plan_name_to_none(self):
+        # redistricting_plan_id=999_999 doesn't exist; _safe_plan_name
+        # returns None without raising.
+        timeline = self.addr.boundary_timeline("cd")
+        assert timeline[2].plan_name is None
 
     def test_entry_carries_geoid_and_abp(self):
         timeline = self.addr.boundary_timeline("cd")
@@ -414,8 +425,8 @@ class TestBoundaryTimeline(TestCase):
         timeline = self.addr.boundary_timeline("cd")
         geoid, eff_from, eff_to, plan_name, abp = timeline[0]
         assert geoid == "0107"
-        assert eff_from == date(2010, 1, 1)
-        assert eff_to == date(2019, 12, 31)
+        assert eff_from == date(2015, 6, 1)
+        assert eff_to == date(2021, 5, 31)
         assert plan_name is None
         assert abp == self.abp_2010
 

--- a/tests/unit/geo/test_address_boundary_helpers.py
+++ b/tests/unit/geo/test_address_boundary_helpers.py
@@ -1,0 +1,196 @@
+"""Tests for F11 (SW#100) step-2 helpers: Address.boundary_history /
+boundaries_on / current_boundaries.
+
+The helpers expose ``AddressBoundaryPeriod`` as the authoritative source
+for "which boundaries did this address belong to on date X" and "every
+boundary this address has ever been in." See
+docs/designs/f11-address-temporal-boundary-history.md for the design.
+
+Coverage scope:
+    - boundary_history (with and without boundary_type filter).
+    - boundaries_on falling back to the NULL-plan (Census default) row
+      when no plan-bound row covers the date.
+    - current_boundaries delegating to today's date.
+
+Out of scope (deferred to integration tests):
+    - boundaries_on resolving a plan-bound row by RedistrictingPlan's
+      effective_from / effective_to. Requires real siege_utilities
+      RedistrictingPlan rows; those tests live with assign_boundaries.
+"""
+
+from datetime import date
+
+from django.test import TestCase
+
+
+class TestBoundaryHistory(TestCase):
+    """Address.boundary_history: every recorded assignment."""
+
+    def setUp(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+
+        CensusVintageConfig.seed_defaults()
+        self.vintage_2020 = CensusVintageConfig.objects.get(decade=2020)
+        self.vintage_2010 = CensusVintageConfig.objects.get(decade=2010)
+
+        self.addr = Address.objects.create(
+            primary_number="100",
+            street_name="Main",
+            state_abbreviation="AL",
+        )
+
+        # Three periods: 2010 default, 2020 default, 2020 "Milligan" plan.
+        self.abp_2010 = AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2010,
+            state_geoid="01",
+            county_geoid="01073",
+            cd_geoid="0107",
+            context_date=date(2015, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+        self.abp_2020_default = AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2020,
+            state_geoid="01",
+            county_geoid="01073",
+            cd_geoid="0107",
+            context_date=date(2022, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+        self.abp_2020_plan = AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2020,
+            redistricting_plan_id=42,  # db_constraint=False; bare FK ID is fine
+            state_geoid="01",
+            county_geoid="01073",
+            cd_geoid="0102",
+            context_date=date(2024, 1, 1),
+            assignment_method="PLAN_SPATIAL_JOIN",
+        )
+
+    def test_returns_all_periods_for_address(self):
+        history = list(self.addr.boundary_history())
+        assert len(history) == 3
+        # Most-recent-first ordering.
+        assert history[0] == self.abp_2020_plan
+        assert history[-1] == self.abp_2010
+
+    def test_filter_by_boundary_type_keeps_rows_with_geoid(self):
+        cd_history = list(self.addr.boundary_history(boundary_type="cd"))
+        assert len(cd_history) == 3  # all three rows have cd_geoid populated
+        geoids = {p.cd_geoid for p in cd_history}
+        assert geoids == {"0107", "0102"}
+
+    def test_filter_by_boundary_type_drops_rows_without_geoid(self):
+        from socialwarehouse.geo.models import AddressBoundaryPeriod
+
+        # A row with no sldl_geoid should be excluded by sldl filter.
+        sldl_history = list(self.addr.boundary_history(boundary_type="sldl"))
+        assert sldl_history == []
+
+        # Add an sldl-bearing row; now the filter should pick it up.
+        AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2020,
+            redistricting_plan_id=99,
+            sldl_geoid="01-005",
+            context_date=date(2024, 6, 1),
+            assignment_method="PLAN_SPATIAL_JOIN",
+        )
+        sldl_history = list(self.addr.boundary_history(boundary_type="sldl"))
+        assert len(sldl_history) == 1
+        assert sldl_history[0].sldl_geoid == "01-005"
+
+    def test_unknown_boundary_type_raises(self):
+        import pytest
+
+        with pytest.raises(ValueError) as exc:
+            self.addr.boundary_history(boundary_type="precinct")
+        assert "precinct" in str(exc.value)
+
+    def test_isolation_between_addresses(self):
+        from socialwarehouse.geo.models import Address
+
+        other = Address.objects.create(state_abbreviation="CA")
+        assert list(other.boundary_history()) == []
+        # And the original address is unaffected.
+        assert len(list(self.addr.boundary_history())) == 3
+
+
+class TestBoundariesOnNullPlanFallback(TestCase):
+    """boundaries_on falls back to NULL-plan (Census default) rows when no
+    plan-bound row covers the date.
+
+    Plan-bound resolution (using RedistrictingPlan.effective_from /
+    effective_to) is covered by integration tests; this unit test
+    exercises the static-boundary / Census-default path that doesn't
+    require any RedistrictingPlan rows."""
+
+    def setUp(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+
+        CensusVintageConfig.seed_defaults()
+        self.vintage_2020 = CensusVintageConfig.objects.get(decade=2020)
+
+        self.addr = Address.objects.create(state_abbreviation="TX")
+
+        # A NULL-plan row carrying static-boundary geoids only.
+        self.abp_default = AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2020,
+            redistricting_plan=None,
+            state_geoid="48",
+            county_geoid="48201",
+            tract_geoid="48201100000",
+            context_date=date(2022, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+
+    def test_returns_default_row_for_static_boundary_types(self):
+        result = self.addr.boundaries_on(date(2023, 6, 15))
+        assert result["state"] == self.abp_default
+        assert result["county"] == self.abp_default
+        assert result["tract"] == self.abp_default
+
+    def test_omits_types_with_no_geoid(self):
+        # No cd_geoid was set on the default row, so cd should not appear.
+        result = self.addr.boundaries_on(date(2023, 6, 15))
+        assert "cd" not in result
+        assert "sldl" not in result
+
+    def test_no_vintage_for_year_returns_empty(self):
+        # Year with no CensusVintageConfig row (seed_defaults covers 2010/2020).
+        result = self.addr.boundaries_on(date(1985, 1, 1))
+        assert result == {}
+
+
+class TestCurrentBoundaries(TestCase):
+    """current_boundaries delegates to boundaries_on(today)."""
+
+    def test_delegates_to_today(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+        from django.utils import timezone
+
+        CensusVintageConfig.seed_defaults()
+        vintage = CensusVintageConfig.objects.get(decade=2020)
+        addr = Address.objects.create(state_abbreviation="NY")
+
+        abp = AddressBoundaryPeriod.objects.create(
+            address=addr,
+            vintage=vintage,
+            state_geoid="36",
+            county_geoid="36061",
+            context_date=timezone.localdate(),
+            assignment_method="SPATIAL_JOIN",
+        )
+
+        current = addr.current_boundaries()
+        assert current["state"] == abp
+        assert current["county"] == abp


### PR DESCRIPTION
## Summary

Implements **step 2** of the F11 design (now v2 at SW#183 / `docs/designs/f11-address-temporal-boundary-history.md`): three additive helper methods on `Address` that expose `AddressBoundaryPeriod` as the authoritative source for the two product views named in the design.

The user-facing feature framing the design names as load-bearing:
> "addresses, and we'd be able to surface not only which boundaries it's currently contained by, but which ones it's ever been contained by."

This PR delivers the **read surface** that serves both views. The current view is also served by the cached `Address.{type}_geoid` fields and continues to be — the helpers don't replace anything yet.

## What's in this PR

- `Address.boundary_history(boundary_type=None)` — the history view. Queryset of every `AddressBoundaryPeriod` for this address, optionally filtered to one boundary type. Ordered most-recent-first; `select_related("vintage", "redistricting_plan")` so callers can read plan/vintage metadata without N+1.
- `Address.boundaries_on(on_date)` — the as-of-date view. Returns dict `{boundary_type: ABP-row}` for boundaries the address was in on `on_date`. Resolves plan-bound rows via `RedistrictingPlan.effective_from / effective_to` (with `effective_to=None` meaning "currently active"), falling back to NULL-plan (Census default) rows for boundary types not covered by an active plan.
- `Address.current_boundaries()` — sugar for `boundaries_on(today)`. Documented as equivalent to reading the cached fields once step-2b's signal lands; until then, the helper is authoritative.
- Unit tests covering `boundary_history` (all four shapes including the unknown-type-raise case) and `boundaries_on`'s NULL-plan fallback path.

## What's NOT in this PR (intentional)

- **Step 2b — signal-driven cache refresh.** Q2-a from the v2 design (auto-update of `Address.{type}_geoid` on ABP write) ships separately. The reason is the rollout-safety property the v2 design called out: the helper must exist as the authoritative read path BEFORE the cache becomes formally "current-by-construction." Otherwise, during the transition, callers that want history have nowhere to opt into.
- **Step 3 — caller migrations.** Existing callers continue using the cached `Address.{type}_geoid` fields and get exactly the same answers as before. Per-caller migration to the helper is scoped per the v2 design's Q3 answer (mid).
- **Integration test for the plan-bound resolution path.** The `boundaries_on` path that dereferences `redistricting_plan.effective_from / effective_to` requires real `siege_utilities.RedistrictingPlan` rows; that test lives with `assign_boundaries`. The test file's module docstring spells out what's deferred and why.

## Test plan
- [ ] CI green (the four `boundary_history` tests + the three `boundaries_on` fallback tests + `current_boundaries`).
- [ ] Spot-check (manual): on a Django shell with a seeded address + ABP rows, `addr.boundary_history()` returns the right ordering; `addr.boundaries_on(some_date)` resolves correctly for both the plan-bound and NULL-plan cases.

## References
- Design v2: `docs/designs/f11-address-temporal-boundary-history.md` (SW#183).
- Issue: SW#100.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added address boundary timeline and history features: view historical boundary assignments, query boundaries for a given date, and retrieve current geographic identifiers.

* **Tests**
  * Added comprehensive unit tests covering boundary history, date-based lookups, timeline generation, and current-geoid helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->