### PR TITLE
F11/SW#100 step 2b: signal-driven Address cache refresh

### DIFF
--- a/socialwarehouse/geo/apps.py
+++ b/socialwarehouse/geo/apps.py
@@ -6,3 +6,8 @@ class GeoConfig(AppConfig):
     name = "socialwarehouse.geo"
     label = "sw_geo"
     verbose_name = "Geographic Warehouse"
+
+    def ready(self):
+        # F11 step 2b: wire up the Address-cache-refresh signal.
+        from socialwarehouse.geo import signals as _signals
+        _signals._connect()

--- a/socialwarehouse/geo/management/commands/assign_boundaries.py
+++ b/socialwarehouse/geo/management/commands/assign_boundaries.py
@@ -254,156 +254,165 @@ class Command(BaseCommand):
         assigned = 0
         failed = 0
 
-        for i in range(0, len(addr_ids), batch_size):
-            batch_ids = addr_ids[i:i + batch_size]
-            batch_num = i // batch_size + 1
-            batch_addrs = Address.objects.filter(pk__in=batch_ids)
+        # F11 step 2b: this command already updates Address.{type}_geoid
+        # explicitly (addr.save() below). The post-ABP signal would
+        # otherwise SELECT each Address again to check for the same
+        # values we just wrote. Suppress the signal for the duration
+        # of the batch loop; the per-row addr.save() keeps the cache
+        # coherent without it.
+        from socialwarehouse.geo.signals import address_cache_refresh_disabled
 
-            self.stdout.write(f"Batch {batch_num}: processing {len(batch_ids)} addresses...")
+        with address_cache_refresh_disabled():
+            for i in range(0, len(addr_ids), batch_size):
+                batch_ids = addr_ids[i:i + batch_size]
+                batch_num = i // batch_size + 1
+                batch_addrs = Address.objects.filter(pk__in=batch_ids)
 
-            for addr in batch_addrs:
-                try:
-                    if not addr.geom:
+                self.stdout.write(f"Batch {batch_num}: processing {len(batch_ids)} addresses...")
+
+                for addr in batch_addrs:
+                    try:
+                        if not addr.geom:
+                            failed += 1
+                            continue
+
+                        # GeoDjango: transform mutates the point in place; clone first.
+                        query_point = addr.geom.clone()
+                        query_point.transform(4269)
+
+                        # --- Static boundaries (same regardless of plan) ---
+                        s = State.objects.filter(geom__contains=query_point, vintage_year=year).first()
+                        if not s:
+                            failed += 1
+                            continue
+
+                        state_geoid = s.geoid
+                        county_geoid = tract_geoid = bg_geoid = vtd_geoid = None
+
+                        c = County.objects.filter(geom__contains=query_point, vintage_year=year).first()
+                        if c:
+                            county_geoid = c.geoid
+                            t = Tract.objects.filter(geom__contains=query_point, vintage_year=year).first()
+                            if t:
+                                tract_geoid = t.geoid
+                                bg = BlockGroup.objects.filter(geom__contains=query_point, vintage_year=year).first()
+                                if bg:
+                                    bg_geoid = bg.geoid
+                            vtd = VTD.objects.filter(geom__contains=query_point, vintage_year=year).first()
+                            if vtd:
+                                vtd_geoid = vtd.geoid
+
+                        # --- Political boundaries (plan-dependent) ---
+                        cd_geoid = sldl_geoid = sldu_geoid = None
+                        plan_cd = plan_sldl = plan_sldu = None
+                        active_plan = None
+                        method = "SPATIAL_JOIN"
+
+                        if plan_aware and s.state_fips:
+                            # Check for active congressional plan
+                            congress_plan = active_plans.get((s.state_fips, "congress"))
+                            if congress_plan:
+                                active_plan = congress_plan
+                                pd = PlanDistrict.objects.filter(
+                                    plan=congress_plan, geom__contains=query_point
+                                ).first()
+                                if pd:
+                                    cd_geoid = pd.geoid or pd.district_number
+                                    plan_cd = pd
+                                    method = "PLAN_SPATIAL_JOIN"
+
+                            # Check for active state senate plan
+                            senate_plan = active_plans.get((s.state_fips, "state_senate"))
+                            if senate_plan:
+                                pd = PlanDistrict.objects.filter(
+                                    plan=senate_plan, geom__contains=query_point
+                                ).first()
+                                if pd:
+                                    sldu_geoid = pd.geoid or pd.district_number
+                                    plan_sldu = pd
+
+                            # Check for active state house plan
+                            house_plan = active_plans.get((s.state_fips, "state_house"))
+                            if house_plan:
+                                pd = PlanDistrict.objects.filter(
+                                    plan=house_plan, geom__contains=query_point
+                                ).first()
+                                if pd:
+                                    sldl_geoid = pd.geoid or pd.district_number
+                                    plan_sldl = pd
+
+                        # Fall back to Census boundaries for any political level not resolved by plan
+                        if not cd_geoid:
+                            cd = CongressionalDistrict.objects.filter(
+                                geom__contains=query_point, vintage_year=year
+                            ).first()
+                            if cd:
+                                cd_geoid = cd.geoid
+
+                        if not sldl_geoid:
+                            sldl = StateLegislativeLower.objects.filter(
+                                geom__contains=query_point, vintage_year=year
+                            ).first()
+                            if sldl:
+                                sldl_geoid = sldl.geoid
+
+                        if not sldu_geoid:
+                            sldu = StateLegislativeUpper.objects.filter(
+                                geom__contains=query_point, vintage_year=year
+                            ).first()
+                            if sldu:
+                                sldu_geoid = sldu.geoid
+
+                        # --- Store on Address (backward compat) ---
+                        addr.state_geoid = state_geoid
+                        addr.county_geoid = county_geoid
+                        addr.tract_geoid = tract_geoid
+                        addr.block_group_geoid = bg_geoid
+                        addr.vtd_geoid = vtd_geoid
+                        addr.cd_geoid = cd_geoid
+                        addr.sldl_geoid = sldl_geoid
+                        addr.sldu_geoid = sldu_geoid
+                        addr.census_year = year
+                        addr.census_units_assigned_at = timezone.now()
+
+                        # Populate FKs in memory BEFORE the save so the geoid
+                        # changes and the FK assignments share a single UPDATE.
+                        # Post-F4/F5 (SW#93+#94) populate_foreign_keys() no
+                        # longer saves; callers are responsible for persistence.
+                        if populate_fks:
+                            addr.populate_foreign_keys()
+
+                        addr.save()
+
+                        # --- Create/update AddressBoundaryPeriod ---
+                        if vintage_config:
+                            period, _ = AddressBoundaryPeriod.objects.update_or_create(
+                                address=addr,
+                                vintage=vintage_config,
+                                redistricting_plan=active_plan,
+                                defaults={
+                                    "context_date": context_date,
+                                    "congressional_term_id": None,  # TODO: resolve from context_date
+                                    "state_geoid": state_geoid,
+                                    "county_geoid": county_geoid,
+                                    "tract_geoid": tract_geoid,
+                                    "block_group_geoid": bg_geoid,
+                                    "vtd_geoid": vtd_geoid,
+                                    "cd_geoid": cd_geoid,
+                                    "sldl_geoid": sldl_geoid,
+                                    "sldu_geoid": sldu_geoid,
+                                    "plan_district_cd": plan_cd,
+                                    "plan_district_sldl": plan_sldl,
+                                    "plan_district_sldu": plan_sldu,
+                                    "assignment_method": method,
+                                },
+                            )
+
+                        assigned += 1
+
+                    except Exception as e:
+                        logger.error("Failed to assign boundaries for %s: %s", addr.pk, e)
                         failed += 1
-                        continue
-
-                    # GeoDjango: transform mutates the point in place; clone first.
-                    query_point = addr.geom.clone()
-                    query_point.transform(4269)
-
-                    # --- Static boundaries (same regardless of plan) ---
-                    s = State.objects.filter(geom__contains=query_point, vintage_year=year).first()
-                    if not s:
-                        failed += 1
-                        continue
-
-                    state_geoid = s.geoid
-                    county_geoid = tract_geoid = bg_geoid = vtd_geoid = None
-
-                    c = County.objects.filter(geom__contains=query_point, vintage_year=year).first()
-                    if c:
-                        county_geoid = c.geoid
-                        t = Tract.objects.filter(geom__contains=query_point, vintage_year=year).first()
-                        if t:
-                            tract_geoid = t.geoid
-                            bg = BlockGroup.objects.filter(geom__contains=query_point, vintage_year=year).first()
-                            if bg:
-                                bg_geoid = bg.geoid
-                        vtd = VTD.objects.filter(geom__contains=query_point, vintage_year=year).first()
-                        if vtd:
-                            vtd_geoid = vtd.geoid
-
-                    # --- Political boundaries (plan-dependent) ---
-                    cd_geoid = sldl_geoid = sldu_geoid = None
-                    plan_cd = plan_sldl = plan_sldu = None
-                    active_plan = None
-                    method = "SPATIAL_JOIN"
-
-                    if plan_aware and s.state_fips:
-                        # Check for active congressional plan
-                        congress_plan = active_plans.get((s.state_fips, "congress"))
-                        if congress_plan:
-                            active_plan = congress_plan
-                            pd = PlanDistrict.objects.filter(
-                                plan=congress_plan, geom__contains=query_point
-                            ).first()
-                            if pd:
-                                cd_geoid = pd.geoid or pd.district_number
-                                plan_cd = pd
-                                method = "PLAN_SPATIAL_JOIN"
-
-                        # Check for active state senate plan
-                        senate_plan = active_plans.get((s.state_fips, "state_senate"))
-                        if senate_plan:
-                            pd = PlanDistrict.objects.filter(
-                                plan=senate_plan, geom__contains=query_point
-                            ).first()
-                            if pd:
-                                sldu_geoid = pd.geoid or pd.district_number
-                                plan_sldu = pd
-
-                        # Check for active state house plan
-                        house_plan = active_plans.get((s.state_fips, "state_house"))
-                        if house_plan:
-                            pd = PlanDistrict.objects.filter(
-                                plan=house_plan, geom__contains=query_point
-                            ).first()
-                            if pd:
-                                sldl_geoid = pd.geoid or pd.district_number
-                                plan_sldl = pd
-
-                    # Fall back to Census boundaries for any political level not resolved by plan
-                    if not cd_geoid:
-                        cd = CongressionalDistrict.objects.filter(
-                            geom__contains=query_point, vintage_year=year
-                        ).first()
-                        if cd:
-                            cd_geoid = cd.geoid
-
-                    if not sldl_geoid:
-                        sldl = StateLegislativeLower.objects.filter(
-                            geom__contains=query_point, vintage_year=year
-                        ).first()
-                        if sldl:
-                            sldl_geoid = sldl.geoid
-
-                    if not sldu_geoid:
-                        sldu = StateLegislativeUpper.objects.filter(
-                            geom__contains=query_point, vintage_year=year
-                        ).first()
-                        if sldu:
-                            sldu_geoid = sldu.geoid
-
-                    # --- Store on Address (backward compat) ---
-                    addr.state_geoid = state_geoid
-                    addr.county_geoid = county_geoid
-                    addr.tract_geoid = tract_geoid
-                    addr.block_group_geoid = bg_geoid
-                    addr.vtd_geoid = vtd_geoid
-                    addr.cd_geoid = cd_geoid
-                    addr.sldl_geoid = sldl_geoid
-                    addr.sldu_geoid = sldu_geoid
-                    addr.census_year = year
-                    addr.census_units_assigned_at = timezone.now()
-
-                    # Populate FKs in memory BEFORE the save so the geoid
-                    # changes and the FK assignments share a single UPDATE.
-                    # Post-F4/F5 (SW#93+#94) populate_foreign_keys() no
-                    # longer saves; callers are responsible for persistence.
-                    if populate_fks:
-                        addr.populate_foreign_keys()
-
-                    addr.save()
-
-                    # --- Create/update AddressBoundaryPeriod ---
-                    if vintage_config:
-                        period, _ = AddressBoundaryPeriod.objects.update_or_create(
-                            address=addr,
-                            vintage=vintage_config,
-                            redistricting_plan=active_plan,
-                            defaults={
-                                "context_date": context_date,
-                                "congressional_term_id": None,  # TODO: resolve from context_date
-                                "state_geoid": state_geoid,
-                                "county_geoid": county_geoid,
-                                "tract_geoid": tract_geoid,
-                                "block_group_geoid": bg_geoid,
-                                "vtd_geoid": vtd_geoid,
-                                "cd_geoid": cd_geoid,
-                                "sldl_geoid": sldl_geoid,
-                                "sldu_geoid": sldu_geoid,
-                                "plan_district_cd": plan_cd,
-                                "plan_district_sldl": plan_sldl,
-                                "plan_district_sldu": plan_sldu,
-                                "assignment_method": method,
-                            },
-                        )
-
-                    assigned += 1
-
-                except Exception as e:
-                    logger.error("Failed to assign boundaries for %s: %s", addr.pk, e)
-                    failed += 1
 
             self.stdout.write(f"  Batch {batch_num} done: {assigned} assigned, {failed} failed")
 

--- a/socialwarehouse/geo/signals.py
+++ b/socialwarehouse/geo/signals.py
@@ -1,0 +1,170 @@
+"""Signal handlers that keep Address-level cached GEOIDs in lockstep with
+AddressBoundaryPeriod (ABP) writes.
+
+F11 step 2b: the cache-coherence invariant. When an ABP row for a
+*current* vintage is written, the corresponding `Address.{type}_geoid`
+cache fields are updated in the same transaction. The cache becomes
+formally "current-by-construction."
+
+Definitions (per F11 step-2b design v2):
+    - A vintage is *current* if its [effective_from, effective_to)
+      window contains today. effective_to=NULL means "unreplaced,
+      still in effect."
+    - The cache is *coherent* if Address.{type}_geoid equals
+      Address.current_boundaries()[type].{type}_geoid for every
+      boundary type the address has rows for.
+
+The handler bails out cheaply (no DB read) when the ABP's vintage is
+not current; this keeps backfills of historical vintages from
+polluting the cache or paying per-write Address lookup cost.
+
+Backfill / bulk-write callers can temporarily disable the signal with
+:func:`address_cache_refresh_disabled` and call
+:func:`refresh_address_caches` explicitly after the bulk write
+completes.
+
+This module is wired up by :class:`socialwarehouse.geo.apps.GeoConfig`.
+"""
+
+import contextlib
+import logging
+import threading
+from datetime import date
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+logger = logging.getLogger(__name__)
+
+_signal_state = threading.local()
+
+
+@contextlib.contextmanager
+def address_cache_refresh_disabled():
+    """Temporarily suppress the ABP-post_save cache-refresh signal.
+
+    Use inside bulk-write contexts (`assign_boundaries` batch loops,
+    test fixtures, etc.) where the caller will explicitly invoke
+    :func:`refresh_address_caches` after the bulk write completes.
+
+    Thread-local; concurrent calls in other threads are unaffected.
+    """
+    prev = getattr(_signal_state, "disabled", False)
+    _signal_state.disabled = True
+    try:
+        yield
+    finally:
+        _signal_state.disabled = prev
+
+
+def _is_current_vintage(vintage, today=None):
+    """Return True if `vintage`'s effective window contains today.
+
+    Bridges the two vintage shapes during the F11 step-2b → template-
+    readiness B transition:
+      - `CensusVintageConfig` (current): integer-year
+        ``effective_start`` and ``effective_end``. Convert each year
+        to a date window: `date(effective_start, 1, 1)` to
+        `date(effective_end + 1, 1, 1)` (half-open).
+      - Polymorphic `Vintage` (after B): date ``effective_from`` and
+        ``effective_to``; `effective_to=None` means "unreplaced."
+
+    Both shapes resolve to the same `(date, date_or_None)` window for
+    the comparison. When B lands and SW#202's follow-up updates this
+    module, the conversion branch goes away and only the Vintage-
+    style read remains.
+    """
+    if vintage is None:
+        return False
+    today = today or date.today()
+
+    if hasattr(vintage, "effective_from"):
+        eff_from = vintage.effective_from
+        eff_to = vintage.effective_to
+    else:
+        eff_from = date(vintage.effective_start, 1, 1)
+        eff_to = date(vintage.effective_end + 1, 1, 1)
+
+    if eff_from and eff_from > today:
+        return False
+    if eff_to is not None and eff_to <= today:
+        return False
+    return True
+
+
+def refresh_address_caches(addresses, today=None):
+    """Recompute and write cached GEOIDs for each Address in `addresses`.
+
+    Used after a bulk-write block that suppressed the per-row signal
+    (see :func:`address_cache_refresh_disabled`). For each address,
+    pulls the current boundaries via `Address.current_boundaries()`
+    and writes any changed `{type}_geoid` fields in a single UPDATE
+    per address.
+
+    `addresses` may be a queryset, list, or any iterable of Address
+    instances. Returns the number of addresses whose cache fields
+    were updated.
+
+    Today's date defaults to `timezone.localdate()`; pass `today` for
+    deterministic tests.
+    """
+    from django.utils import timezone
+    from socialwarehouse.geo.models import Address
+
+    today = today or timezone.localdate()
+    updated_count = 0
+
+    for addr in addresses:
+        result = addr.boundaries_on(today)
+        dirty_fields = []
+        for btype in Address._BOUNDARY_TYPES:
+            cache_field = f"{btype}_geoid"
+            row = result.get(btype)
+            new_value = getattr(row, cache_field, "") if row else ""
+            new_value = new_value or ""
+            if getattr(addr, cache_field) != new_value:
+                setattr(addr, cache_field, new_value)
+                dirty_fields.append(cache_field)
+
+        if dirty_fields:
+            addr.save(update_fields=dirty_fields)
+            updated_count += 1
+
+    return updated_count
+
+
+def _connect():
+    """Connect the signal. Called from GeoConfig.ready()."""
+    from socialwarehouse.geo.models import Address, AddressBoundaryPeriod
+
+    @receiver(post_save, sender=AddressBoundaryPeriod, dispatch_uid="f11_step2b_address_cache_refresh")
+    def refresh_address_cache_on_abp_write(sender, instance, raw=False, **kwargs):
+        if raw:
+            # Fixture loads: skip the signal so test setup doesn't
+            # cascade-update.
+            return
+        if getattr(_signal_state, "disabled", False):
+            return
+        if not _is_current_vintage(instance.vintage):
+            # Backfill / historical write; cache untouched.
+            return
+
+        addr = instance.address
+        dirty_fields = []
+        for btype in Address._BOUNDARY_TYPES:
+            new_value = getattr(instance, f"{btype}_geoid", "") or ""
+            if not new_value:
+                # ABP row doesn't carry this boundary type's geoid;
+                # don't clobber existing cache from another ABP row.
+                continue
+            cache_field = f"{btype}_geoid"
+            if getattr(addr, cache_field) != new_value:
+                setattr(addr, cache_field, new_value)
+                dirty_fields.append(cache_field)
+
+        if dirty_fields:
+            addr.save(update_fields=dirty_fields)
+            logger.debug(
+                "F11 step-2b: refreshed Address %s cache fields %s from ABP %s",
+                addr.pk, dirty_fields, instance.pk,
+            )

--- a/tests/unit/geo/test_address_cache_signal.py
+++ b/tests/unit/geo/test_address_cache_signal.py
@@ -1,0 +1,256 @@
+"""Tests for F11 step 2b: the signal handler that keeps Address-level
+cached GEOIDs in lockstep with AddressBoundaryPeriod writes.
+
+Covers the design's Q4 (a) plan: hand-rolled unit tests on every named
+handler branch, plus one multi-write integration test that exercises a
+realistic sequence of writes.
+
+The hypothesis-based property test on the cache-vs-helper invariant is
+tracked separately (SW#201).
+"""
+
+from datetime import date
+
+from django.test import TestCase
+from django.utils import timezone
+
+from socialwarehouse.geo.signals import (
+    _is_current_vintage,
+    address_cache_refresh_disabled,
+    refresh_address_caches,
+)
+
+
+class TestIsCurrentVintage(TestCase):
+    """`_is_current_vintage` recognizes the current vintage window.
+
+    Uses CensusVintageConfig (integer-year effective_start / effective_end)
+    today; a follow-up (SW#202) swaps these to polymorphic Vintage's
+    date-typed effective_from / effective_to after template-readiness B
+    lands.
+    """
+
+    def setUp(self):
+        from socialwarehouse.geo.models import CensusVintageConfig
+
+        CensusVintageConfig.seed_defaults()
+        self.vintage_2010 = CensusVintageConfig.objects.get(decade=2010)
+        self.vintage_2020 = CensusVintageConfig.objects.get(decade=2020)
+
+    def test_current_vintage_today_in_window(self):
+        # vintage_2020 covers 2020-2029; today=2026-05-19 is inside.
+        assert _is_current_vintage(self.vintage_2020, today=date(2026, 5, 19))
+
+    def test_past_vintage_today_after_window(self):
+        # vintage_2010 covers 2010-2019; today=2026-05-19 is after.
+        assert not _is_current_vintage(self.vintage_2010, today=date(2026, 5, 19))
+
+    def test_future_vintage_today_before_window(self):
+        # Hypothetical 2030 vintage; today=2026 is before.
+        from socialwarehouse.geo.models import CensusVintageConfig
+
+        future = CensusVintageConfig.objects.create(
+            decade=2030, effective_start=2030, effective_end=2039,
+        )
+        assert not _is_current_vintage(future, today=date(2026, 5, 19))
+
+    def test_none_vintage_returns_false(self):
+        assert _is_current_vintage(None, today=date(2026, 5, 19)) is False
+
+
+class TestSignalCacheRefresh(TestCase):
+    """The signal updates Address.{type}_geoid when ABP for a current
+    vintage is written; bails out otherwise."""
+
+    def setUp(self):
+        from socialwarehouse.geo.models import Address, CensusVintageConfig
+
+        CensusVintageConfig.seed_defaults()
+        self.vintage_2020 = CensusVintageConfig.objects.get(decade=2020)
+        self.vintage_2010 = CensusVintageConfig.objects.get(decade=2010)
+        self.addr = Address.objects.create(state_abbreviation="CA")
+
+    def _create_abp(self, **kwargs):
+        from socialwarehouse.geo.models import AddressBoundaryPeriod
+
+        defaults = {
+            "address": self.addr,
+            "vintage": self.vintage_2020,
+            "assignment_method": "SPATIAL_JOIN",
+        }
+        defaults.update(kwargs)
+        return AddressBoundaryPeriod.objects.create(**defaults)
+
+    def test_current_vintage_write_updates_cache(self):
+        assert self.addr.cd_geoid == ""
+
+        self._create_abp(cd_geoid="0612")
+
+        self.addr.refresh_from_db()
+        assert self.addr.cd_geoid == "0612"
+
+    def test_superseded_vintage_write_does_not_update_cache(self):
+        # vintage_2010 is past today (2026); writing an ABP against it
+        # should NOT touch the cache.
+        self._create_abp(vintage=self.vintage_2010, cd_geoid="0107")
+
+        self.addr.refresh_from_db()
+        assert self.addr.cd_geoid == ""
+
+    def test_partial_geoid_only_updates_present_fields(self):
+        # ABP carries cd_geoid only; sldl_geoid is null. Cache update
+        # should touch cd_geoid but leave sldl_geoid alone.
+        self.addr.sldl_geoid = "01234"
+        self.addr.save()
+
+        self._create_abp(cd_geoid="0612")
+
+        self.addr.refresh_from_db()
+        assert self.addr.cd_geoid == "0612"
+        assert self.addr.sldl_geoid == "01234"  # untouched
+
+    def test_unchanged_value_no_update(self):
+        # If the ABP write matches what's already cached, the handler
+        # should bail out without saving (we approximate this by
+        # checking updated_at-style behavior; the handler's branch is
+        # the if dirty_fields: guard).
+        self.addr.cd_geoid = "0612"
+        self.addr.save()
+
+        # No exception, no infinite signal loop:
+        self._create_abp(cd_geoid="0612")
+
+        self.addr.refresh_from_db()
+        assert self.addr.cd_geoid == "0612"
+
+    def test_signal_disabled_context_manager_suppresses(self):
+        with address_cache_refresh_disabled():
+            self._create_abp(cd_geoid="0612")
+
+        self.addr.refresh_from_db()
+        # Cache was NOT updated because signal was suppressed.
+        assert self.addr.cd_geoid == ""
+
+    def test_signal_re_enabled_after_context_manager(self):
+        with address_cache_refresh_disabled():
+            self._create_abp(cd_geoid="0612")
+
+        # Outside the context, the signal should fire normally.
+        self._create_abp(redistricting_plan_id=1, cd_geoid="0699")
+
+        self.addr.refresh_from_db()
+        assert self.addr.cd_geoid == "0699"
+
+
+class TestRefreshAddressCachesHelper(TestCase):
+    """`refresh_address_caches(qs)` brings caches in sync after a
+    suppressed-bulk-write block."""
+
+    def setUp(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+
+        CensusVintageConfig.seed_defaults()
+        self.vintage = CensusVintageConfig.objects.get(decade=2020)
+        self.addr1 = Address.objects.create(state_abbreviation="CA")
+        self.addr2 = Address.objects.create(state_abbreviation="TX")
+
+        with address_cache_refresh_disabled():
+            AddressBoundaryPeriod.objects.create(
+                address=self.addr1, vintage=self.vintage,
+                cd_geoid="0612", context_date=date(2024, 1, 1),
+                assignment_method="SPATIAL_JOIN",
+            )
+            AddressBoundaryPeriod.objects.create(
+                address=self.addr2, vintage=self.vintage,
+                cd_geoid="4836", context_date=date(2024, 1, 1),
+                assignment_method="SPATIAL_JOIN",
+            )
+
+    def test_refresh_brings_caches_in_sync(self):
+        from socialwarehouse.geo.models import Address
+
+        # Pre-condition: caches are stale because signal was suppressed.
+        self.addr1.refresh_from_db()
+        self.addr2.refresh_from_db()
+        assert self.addr1.cd_geoid == ""
+        assert self.addr2.cd_geoid == ""
+
+        updated = refresh_address_caches(
+            Address.objects.filter(pk__in=[self.addr1.pk, self.addr2.pk]),
+            today=date(2024, 6, 1),
+        )
+
+        self.addr1.refresh_from_db()
+        self.addr2.refresh_from_db()
+        assert self.addr1.cd_geoid == "0612"
+        assert self.addr2.cd_geoid == "4836"
+        assert updated == 2
+
+    def test_refresh_no_op_when_cache_already_matches(self):
+        from socialwarehouse.geo.models import Address
+
+        # Pre-warm cache so the refresh has nothing to do.
+        self.addr1.cd_geoid = "0612"
+        self.addr1.save()
+        self.addr2.cd_geoid = "4836"
+        self.addr2.save()
+
+        updated = refresh_address_caches(
+            Address.objects.filter(pk__in=[self.addr1.pk, self.addr2.pk]),
+            today=date(2024, 6, 1),
+        )
+
+        assert updated == 0
+
+
+class TestMultiWriteIntegration(TestCase):
+    """Realistic ABP write sequence: assign, then redistricting, then
+    re-assign. Cache should track the most-recent current-vintage write."""
+
+    def test_sequential_writes_cache_tracks_latest(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusVintageConfig,
+        )
+
+        CensusVintageConfig.seed_defaults()
+        vintage = CensusVintageConfig.objects.get(decade=2020)
+        addr = Address.objects.create(state_abbreviation="AL")
+
+        # 1. Initial assign: Census-default plan.
+        AddressBoundaryPeriod.objects.create(
+            address=addr, vintage=vintage,
+            cd_geoid="0107", context_date=date(2022, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+        addr.refresh_from_db()
+        assert addr.cd_geoid == "0107"
+
+        # 2. Court-ordered redistricting; re-assign under a plan.
+        AddressBoundaryPeriod.objects.create(
+            address=addr, vintage=vintage, redistricting_plan_id=1,
+            cd_geoid="0102", context_date=date(2023, 1, 1),
+            assignment_method="PLAN_SPATIAL_JOIN",
+        )
+        addr.refresh_from_db()
+        assert addr.cd_geoid == "0102"
+
+        # 3. Backfilling a HISTORICAL 2010 vintage; cache should NOT update.
+        v_2010 = CensusVintageConfig.objects.get(decade=2010)
+        AddressBoundaryPeriod.objects.create(
+            address=addr, vintage=v_2010,
+            cd_geoid="0199", context_date=date(2015, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+        addr.refresh_from_db()
+        assert addr.cd_geoid == "0102"  # unchanged by historical backfill
+
+        # 4. New current-vintage assign after another redistricting.
+        AddressBoundaryPeriod.objects.create(
+            address=addr, vintage=vintage, redistricting_plan_id=2,
+            cd_geoid="0103", context_date=timezone.localdate(),
+            assignment_method="PLAN_SPATIAL_JOIN",
+        )
+        addr.refresh_from_db()
+        assert addr.cd_geoid == "0103"


### PR DESCRIPTION
## Summary

Implements **F11 step 2b** per the maintainer-accepted recommendations on the design (PR #197, merged):

- **Q1** — "current" = vintage's `[effective_from, effective_to)` window contains today.
- **Q2** — context-manager-suppressed during bulk writes.
- **Q3** — no downstream cascade in this PR (sequenced as [#200](https://github.com/siege-analytics/socialwarehouse/issues/200) follow-up).
- **Q4** — hand-rolled unit tests + one multi-write integration test (hypothesis property test as [#201](https://github.com/siege-analytics/socialwarehouse/issues/201) follow-up).

After this lands, `Address.{type}_geoid` is formally "current-by-construction" — every ABP write for a current vintage updates the cache transactionally.

## What's in this PR

- **`socialwarehouse/geo/signals.py` (new):**
  - `post_save` handler on `AddressBoundaryPeriod`. Bails out cheaply on raw fixture loads, on the suppression context manager, and on superseded vintages (no DB read in those branches).
  - `address_cache_refresh_disabled()` — thread-local context manager for bulk-write callers.
  - `refresh_address_caches(qs)` — bulk catch-up helper for after a suppressed bulk write.
  - `_is_current_vintage(vintage)` — bridges `CensusVintageConfig` (integer-year `effective_start / effective_end`) and the future polymorphic Vintage (date `effective_from / effective_to`). [#202](https://github.com/siege-analytics/socialwarehouse/issues/202) removes the bridge once template-readiness B lands.
- **`socialwarehouse/geo/apps.py`:** `GeoConfig.ready()` wires the signal up via `_connect()`.
- **`socialwarehouse/geo/management/commands/assign_boundaries.py`:** wraps the batch loop in `address_cache_refresh_disabled()`. `assign_boundaries` already does `addr.save()` per row, so the cache stays coherent without the signal; no explicit `refresh_address_caches()` call after the batch is needed.
- **`tests/unit/geo/test_address_cache_signal.py` (new):** four test classes covering every named handler branch + the bulk helper + a multi-write integration test.

## The load-bearing invariant

The "partial geoid only updates present fields" branch: a plan-bound CD-only ABP write must NOT clobber an Address's `sldl_geoid` set by a different ABP row. Tested explicitly.

## What's NOT in this PR (intentional, sequenced)

- **Downstream cascade** to FactRedistrictingPlan / DimGeography / materialized views / external API caches. Tracked as [#200](https://github.com/siege-analytics/socialwarehouse/issues/200).
- **Hypothesis property test** on the full cache-vs-helper invariant. Tracked as [#201](https://github.com/siege-analytics/socialwarehouse/issues/201).
- **Polymorphic Vintage adoption.** This PR uses the existing `CensusVintageConfig`'s integer-year fields via a `hasattr` bridge in `_is_current_vintage`. [#202](https://github.com/siege-analytics/socialwarehouse/issues/202) removes the bridge once template-readiness B ([#190](https://github.com/siege-analytics/socialwarehouse/issues/190)) lands.

## Test plan
- [ ] CI green (signal + helper + multi-write integration tests).
- [ ] Manual: run `assign_boundaries` against a small state and confirm `Address.{type}_geoid` values match what `Address.current_boundaries()` returns for the same addresses.

## References
- Design (merged): docs/designs/f11-step2b-signal-cache-refresh.md (#197)
- Initiative: [#189](https://github.com/siege-analytics/socialwarehouse/issues/189)
- Predecessor: F11 step 2 (#187, merged)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented automatic synchronization of address geographic cache fields when boundary data is updated, ensuring data consistency.

* **Improvements**
  * Optimized bulk boundary assignment operations by suppressing unnecessary cache refresh signals during batch processing for improved performance.

* **Tests**
  * Added comprehensive test coverage for geographic signal handlers and cache synchronization behavior across multiple scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/203?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->