### PR TITLE
B/SW#190 PR #1: polymorphic Vintage model + per-kind subclasses + seed (additive)

### DIFF
--- a/socialwarehouse/geo/management/commands/seed_known_vintages.py
+++ b/socialwarehouse/geo/management/commands/seed_known_vintages.py
@@ -1,0 +1,228 @@
+"""Pre-populate Vintage rows for every known vintage across the four
+data domains.
+
+Template-readiness B (SW#190 PR #1, additive): seeds the Vintage table
+with the published-vintage catalogs each domain ships with. Idempotent
+— rerunning adds only new vintages, never duplicates.
+
+Usage:
+    python manage.py seed_known_vintages
+    python manage.py seed_known_vintages --kinds census-decadal,acs
+    python manage.py seed_known_vintages --dry-run
+
+Run automatically by the migration that creates the Vintage tables; can
+also be invoked manually after new vintages are published upstream
+(e.g., after Census drops 2030 boundaries, or after BLS publishes
+2025Q1 QCEW).
+
+Per the v2 design: redistricting-plan vintages are NOT pre-seeded by
+this command. Those rows are created on demand from
+siege_utilities.RedistrictingPlan as `assign_boundaries` writes ABP
+rows for new plans.
+"""
+
+from datetime import date
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+
+# Cutoffs / catalogs per kind. Update as new vintages are published.
+
+CENSUS_DECADES = [2010, 2020]  # add 2030 when boundaries drop
+
+ACS_5YEAR_ENDPOINTS = list(range(2013, 2024))  # 2009-2013 through 2019-2023
+ACS_1YEAR_YEARS = [y for y in range(2010, 2024) if y != 2020]  # ACS 1-year skipped 2020 (COVID)
+
+BLS_QCEW_RANGE = [
+    (year, quarter) for year in range(2010, 2025) for quarter in range(1, 5)
+]  # 2010Q1 through 2024Q4
+
+BEA_REGIONAL_YEARS = list(range(2010, 2025))  # 2010 through 2024
+
+NCES_SCHOOL_YEARS = [(start, start + 1) for start in range(2010, 2024)]  # 2010-11 through 2023-24
+
+
+ALL_KINDS = ["census-decadal", "acs", "bls-qcew", "bea-regional", "nces-school-year"]
+
+
+class Command(BaseCommand):
+    help = "Pre-populate Vintage rows for known published vintages."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--kinds",
+            type=str,
+            default=",".join(ALL_KINDS),
+            help=(
+                f"Comma-separated kinds to seed. Default: all five "
+                f"({', '.join(ALL_KINDS)}). 'redistricting-plan' is "
+                f"created on demand by assign_boundaries and is NOT "
+                f"seeded by this command."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would be created without writing.",
+        )
+
+    def handle(self, *args, **options):
+        kinds = set(options["kinds"].split(","))
+        dry_run = options["dry_run"]
+        unknown = kinds - set(ALL_KINDS)
+        if unknown:
+            self.stdout.write(self.style.ERROR(
+                f"Unknown kinds: {', '.join(sorted(unknown))}. "
+                f"Valid: {', '.join(ALL_KINDS)}"
+            ))
+            return
+
+        created_total = 0
+        with transaction.atomic():
+            if "census-decadal" in kinds:
+                created_total += self._seed_census_decadal(dry_run)
+            if "acs" in kinds:
+                created_total += self._seed_acs(dry_run)
+            if "bls-qcew" in kinds:
+                created_total += self._seed_bls_qcew(dry_run)
+            if "bea-regional" in kinds:
+                created_total += self._seed_bea_regional(dry_run)
+            if "nces-school-year" in kinds:
+                created_total += self._seed_nces_school_year(dry_run)
+            if dry_run:
+                transaction.set_rollback(True)
+
+        verb = "Would create" if dry_run else "Created"
+        self.stdout.write(self.style.SUCCESS(f"{verb} {created_total} vintage rows."))
+
+    def _seed_census_decadal(self, dry_run):
+        from socialwarehouse.geo.models import CensusDecadalVintage
+
+        created = 0
+        latest_decade = max(CENSUS_DECADES)
+        for decade in CENSUS_DECADES:
+            if CensusDecadalVintage.objects.filter(decade=decade).exists():
+                continue
+            eff_from = date(decade, 1, 1)
+            eff_to = None if decade == latest_decade else date(decade + 10, 1, 1)
+            if dry_run:
+                self.stdout.write(f"  [DRY] CensusDecadalVintage decade={decade}")
+            else:
+                CensusDecadalVintage.objects.create(
+                    decade=decade, effective_from=eff_from, effective_to=eff_to,
+                )
+            created += 1
+        return created
+
+    def _seed_acs(self, dry_run):
+        from socialwarehouse.geo.models import ACSVintage
+
+        created = 0
+        latest_5year_end = max(ACS_5YEAR_ENDPOINTS)
+        for end_year in ACS_5YEAR_ENDPOINTS:
+            start_year = end_year - 4
+            exists = ACSVintage.objects.filter(
+                start_year=start_year, end_year=end_year, span_years=ACSVintage.SPAN_5YEAR,
+            ).exists()
+            if exists:
+                continue
+            eff_from = date(end_year, 12, 1)  # ACS 5-year typically released ~Dec of end-year+1
+            eff_to = None if end_year == latest_5year_end else date(end_year + 1, 12, 1)
+            if dry_run:
+                self.stdout.write(f"  [DRY] ACSVintage 5-year {start_year}-{end_year}")
+            else:
+                ACSVintage.objects.create(
+                    start_year=start_year, end_year=end_year,
+                    span_years=ACSVintage.SPAN_5YEAR,
+                    effective_from=eff_from, effective_to=eff_to,
+                )
+            created += 1
+
+        latest_1year = max(ACS_1YEAR_YEARS)
+        for year in ACS_1YEAR_YEARS:
+            exists = ACSVintage.objects.filter(
+                start_year=year, end_year=year, span_years=ACSVintage.SPAN_1YEAR,
+            ).exists()
+            if exists:
+                continue
+            eff_from = date(year, 9, 1)  # ACS 1-year typically released ~Sep of year+1
+            eff_to = None if year == latest_1year else date(year + 1, 9, 1)
+            if dry_run:
+                self.stdout.write(f"  [DRY] ACSVintage 1-year {year}")
+            else:
+                ACSVintage.objects.create(
+                    start_year=year, end_year=year,
+                    span_years=ACSVintage.SPAN_1YEAR,
+                    effective_from=eff_from, effective_to=eff_to,
+                )
+            created += 1
+        return created
+
+    def _seed_bls_qcew(self, dry_run):
+        from socialwarehouse.geo.models import BLSQCEWVintage
+
+        created = 0
+        latest = max(BLS_QCEW_RANGE)
+        for year, quarter in BLS_QCEW_RANGE:
+            if BLSQCEWVintage.objects.filter(year=year, quarter=quarter).exists():
+                continue
+            eff_from = date(year, (quarter - 1) * 3 + 1, 1)
+            next_year = year + (1 if quarter == 4 else 0)
+            next_quarter_first_month = (quarter % 4) * 3 + 1
+            eff_to = None if (year, quarter) == latest else date(
+                next_year, next_quarter_first_month, 1
+            )
+            if dry_run:
+                self.stdout.write(f"  [DRY] BLSQCEWVintage {year}Q{quarter}")
+            else:
+                BLSQCEWVintage.objects.create(
+                    year=year, quarter=quarter,
+                    effective_from=eff_from, effective_to=eff_to,
+                )
+            created += 1
+        return created
+
+    def _seed_bea_regional(self, dry_run):
+        from socialwarehouse.geo.models import BEARegionalVintage
+
+        created = 0
+        latest = max(BEA_REGIONAL_YEARS)
+        for year in BEA_REGIONAL_YEARS:
+            if BEARegionalVintage.objects.filter(year=year).exists():
+                continue
+            eff_from = date(year, 1, 1)
+            eff_to = None if year == latest else date(year + 1, 1, 1)
+            if dry_run:
+                self.stdout.write(f"  [DRY] BEARegionalVintage {year}")
+            else:
+                BEARegionalVintage.objects.create(
+                    year=year, effective_from=eff_from, effective_to=eff_to,
+                )
+            created += 1
+        return created
+
+    def _seed_nces_school_year(self, dry_run):
+        from socialwarehouse.geo.models import NCESSchoolYearVintage
+
+        created = 0
+        latest = max(NCES_SCHOOL_YEARS)
+        for start_year, end_year in NCES_SCHOOL_YEARS:
+            exists = NCESSchoolYearVintage.objects.filter(
+                start_year=start_year, end_year=end_year,
+            ).exists()
+            if exists:
+                continue
+            eff_from = date(start_year, 8, 1)  # academic year starts ~August
+            eff_to = None if (start_year, end_year) == latest else date(end_year, 8, 1)
+            if dry_run:
+                self.stdout.write(
+                    f"  [DRY] NCESSchoolYearVintage {start_year}-{str(end_year)[-2:]}"
+                )
+            else:
+                NCESSchoolYearVintage.objects.create(
+                    start_year=start_year, end_year=end_year,
+                    effective_from=eff_from, effective_to=eff_to,
+                )
+            created += 1
+        return created

--- a/socialwarehouse/geo/migrations/0004_polymorphic_vintage_models.py
+++ b/socialwarehouse/geo/migrations/0004_polymorphic_vintage_models.py
@@ -1,0 +1,183 @@
+"""Create the polymorphic Vintage parent + per-kind subclass tables.
+
+Template-readiness B PR #1 (SW#190): additive only. ABP's existing FK
+to CensusVintageConfig is NOT touched in this migration; B PR #2
+retargets ABP and drops CensusVintageConfig.
+
+After this migration runs, the Vintage tables exist but are unused by
+ABP. A data-migration step at the end runs the seed_known_vintages
+command to pre-populate the standard catalogs across census-decadal,
+ACS, BLS QCEW, BEA regional, and NCES school year. Redistricting-plan
+vintages are seeded on demand by assign_boundaries.
+"""
+
+from django.db import migrations, models
+
+
+def _run_seed_known_vintages(apps, schema_editor):
+    """Data-migration step that runs seed_known_vintages."""
+    from django.core.management import call_command
+    call_command("seed_known_vintages", verbosity=0)
+
+
+def _reverse_seed(apps, schema_editor):
+    """Reverse: delete every Vintage row this migration's seed created.
+    Safe because the subclass tables are dropped by the schema reverse
+    anyway; this is here to make the migration explicitly reversible.
+    """
+    Vintage = apps.get_model("sw_geo", "Vintage")
+    Vintage.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_geo", "0003_address_charfield_null_to_blank_default"),
+    ]
+
+    operations = [
+        # Parent table.
+        migrations.CreateModel(
+            name="Vintage",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("name", models.CharField(db_index=True, max_length=100)),
+                ("kind", models.CharField(
+                    choices=[
+                        ("census-decadal", "Decennial Census"),
+                        ("acs", "American Community Survey"),
+                        ("bls-qcew", "BLS Quarterly Census of Employment and Wages"),
+                        ("bea-regional", "BEA Regional"),
+                        ("nces-school-year", "NCES School Year"),
+                        ("redistricting-plan", "Redistricting Plan"),
+                    ],
+                    db_index=True, max_length=30,
+                )),
+                ("effective_from", models.DateField(db_index=True)),
+                ("effective_to", models.DateField(blank=True, db_index=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "sw_geo_vintage",
+                "ordering": ["kind", "-effective_from"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="vintage",
+            index=models.Index(fields=["kind", "effective_to"], name="sw_geo_vint_kind_effto_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="vintage",
+            index=models.Index(fields=["effective_from", "effective_to"], name="sw_geo_vint_effrange_idx"),
+        ),
+
+        # Subclass tables (multi-table inheritance: each has a 1:1 FK to parent).
+        migrations.CreateModel(
+            name="CensusDecadalVintage",
+            fields=[
+                ("vintage_ptr", models.OneToOneField(
+                    auto_created=True, on_delete=models.CASCADE, parent_link=True,
+                    primary_key=True, serialize=False, to="sw_geo.vintage",
+                )),
+                ("decade", models.PositiveSmallIntegerField(unique=True)),
+            ],
+            options={
+                "db_table": "sw_geo_vintage_census_decadal",
+                "verbose_name": "Census Decadal Vintage",
+            },
+            bases=("sw_geo.vintage",),
+        ),
+        migrations.CreateModel(
+            name="ACSVintage",
+            fields=[
+                ("vintage_ptr", models.OneToOneField(
+                    auto_created=True, on_delete=models.CASCADE, parent_link=True,
+                    primary_key=True, serialize=False, to="sw_geo.vintage",
+                )),
+                ("start_year", models.PositiveSmallIntegerField()),
+                ("end_year", models.PositiveSmallIntegerField()),
+                ("span_years", models.PositiveSmallIntegerField(
+                    choices=[(1, "1-year"), (5, "5-year")],
+                )),
+            ],
+            options={
+                "db_table": "sw_geo_vintage_acs",
+                "verbose_name": "ACS Vintage",
+                "unique_together": {("start_year", "end_year", "span_years")},
+            },
+            bases=("sw_geo.vintage",),
+        ),
+        migrations.CreateModel(
+            name="BLSQCEWVintage",
+            fields=[
+                ("vintage_ptr", models.OneToOneField(
+                    auto_created=True, on_delete=models.CASCADE, parent_link=True,
+                    primary_key=True, serialize=False, to="sw_geo.vintage",
+                )),
+                ("year", models.PositiveSmallIntegerField()),
+                ("quarter", models.PositiveSmallIntegerField(
+                    choices=[(1, "Q1"), (2, "Q2"), (3, "Q3"), (4, "Q4")],
+                )),
+            ],
+            options={
+                "db_table": "sw_geo_vintage_bls_qcew",
+                "verbose_name": "BLS QCEW Vintage",
+                "unique_together": {("year", "quarter")},
+            },
+            bases=("sw_geo.vintage",),
+        ),
+        migrations.CreateModel(
+            name="BEARegionalVintage",
+            fields=[
+                ("vintage_ptr", models.OneToOneField(
+                    auto_created=True, on_delete=models.CASCADE, parent_link=True,
+                    primary_key=True, serialize=False, to="sw_geo.vintage",
+                )),
+                ("year", models.PositiveSmallIntegerField(unique=True)),
+            ],
+            options={
+                "db_table": "sw_geo_vintage_bea_regional",
+                "verbose_name": "BEA Regional Vintage",
+            },
+            bases=("sw_geo.vintage",),
+        ),
+        migrations.CreateModel(
+            name="NCESSchoolYearVintage",
+            fields=[
+                ("vintage_ptr", models.OneToOneField(
+                    auto_created=True, on_delete=models.CASCADE, parent_link=True,
+                    primary_key=True, serialize=False, to="sw_geo.vintage",
+                )),
+                ("start_year", models.PositiveSmallIntegerField()),
+                ("end_year", models.PositiveSmallIntegerField()),
+            ],
+            options={
+                "db_table": "sw_geo_vintage_nces_school_year",
+                "verbose_name": "NCES School Year Vintage",
+                "unique_together": {("start_year", "end_year")},
+            },
+            bases=("sw_geo.vintage",),
+        ),
+        migrations.CreateModel(
+            name="RedistrictingPlanVintage",
+            fields=[
+                ("vintage_ptr", models.OneToOneField(
+                    auto_created=True, on_delete=models.CASCADE, parent_link=True,
+                    primary_key=True, serialize=False, to="sw_geo.vintage",
+                )),
+                ("siege_redistricting_plan_id", models.PositiveBigIntegerField(unique=True)),
+                ("state_fips", models.CharField(db_index=True, max_length=2)),
+                ("chamber", models.CharField(db_index=True, max_length=20)),
+                ("plan_name", models.CharField(max_length=255)),
+            ],
+            options={
+                "db_table": "sw_geo_vintage_redistricting_plan",
+                "verbose_name": "Redistricting Plan Vintage",
+            },
+            bases=("sw_geo.vintage",),
+        ),
+
+        # Seed the standard catalogs (census-decadal / ACS / BLS QCEW / BEA / NCES).
+        migrations.RunPython(_run_seed_known_vintages, _reverse_seed),
+    ]

--- a/socialwarehouse/geo/models/__init__.py
+++ b/socialwarehouse/geo/models/__init__.py
@@ -11,6 +11,15 @@ from .political import (
     PoliticalStateLegislativeLower,
     PoliticalStateLegislativeUpper,
 )
+from .vintages import (
+    ACSVintage,
+    BEARegionalVintage,
+    BLSQCEWVintage,
+    CensusDecadalVintage,
+    NCESSchoolYearVintage,
+    RedistrictingPlanVintage,
+    Vintage,
+)
 
 __all__ = [
     "Address",
@@ -23,4 +32,11 @@ __all__ = [
     "PoliticalCongressionalDistrict",
     "PoliticalStateLegislativeUpper",
     "PoliticalStateLegislativeLower",
+    "Vintage",
+    "CensusDecadalVintage",
+    "ACSVintage",
+    "BLSQCEWVintage",
+    "BEARegionalVintage",
+    "NCESSchoolYearVintage",
+    "RedistrictingPlanVintage",
 ]

--- a/socialwarehouse/geo/models/vintages.py
+++ b/socialwarehouse/geo/models/vintages.py
@@ -1,0 +1,261 @@
+"""Polymorphic Vintage models.
+
+Template-readiness B (SW#190): replaces the single-table
+`CensusVintageConfig` assumption with a concept that accommodates the
+temporal shapes of every data domain the template ships.
+
+Shape decision (per design v2, PR #199): **Shape A2 — Django
+multi-table inheritance**. A concrete `Vintage` parent table carries
+the fields every kind needs (`name`, `effective_from`,
+`effective_to`, `kind`, `created_at`). Per-kind subclasses
+(`CensusDecadalVintage`, `ACSVintage`, ...) carry their type-safe
+extras and get their own backing tables with a 1:1 FK back to the
+parent.
+
+Downstream consumers FK the parent (`Vintage`); they read flat
+`effective_from / effective_to` columns directly. Kind-specific
+fields are accessible via the subclass downcast accessor
+(`vintage.acsvintage.span_years`, etc.).
+
+This module ships as part of B-PR-1 (additive only — does not touch
+ABP's existing `vintage` FK). B-PR-2 retargets ABP and drops
+`CensusVintageConfig`.
+"""
+
+from django.db import models
+
+
+# Kind strings; subclass `save()` methods set these on the parent
+# automatically so callers don't have to.
+KIND_CENSUS_DECADAL = "census-decadal"
+KIND_ACS = "acs"
+KIND_BLS_QCEW = "bls-qcew"
+KIND_BEA_REGIONAL = "bea-regional"
+KIND_NCES_SCHOOL_YEAR = "nces-school-year"
+KIND_REDISTRICTING_PLAN = "redistricting-plan"
+
+KIND_CHOICES = [
+    (KIND_CENSUS_DECADAL, "Decennial Census"),
+    (KIND_ACS, "American Community Survey"),
+    (KIND_BLS_QCEW, "BLS Quarterly Census of Employment and Wages"),
+    (KIND_BEA_REGIONAL, "BEA Regional"),
+    (KIND_NCES_SCHOOL_YEAR, "NCES School Year"),
+    (KIND_REDISTRICTING_PLAN, "Redistricting Plan"),
+]
+
+
+class Vintage(models.Model):
+    """Concrete parent for all temporal-period concepts.
+
+    Carries shared fields. Per-kind subclasses inherit via Django
+    multi-table inheritance and add their kind-specific fields.
+    Queries against `Vintage` return parent rows; downcast via the
+    subclass attribute accessor (e.g., `v.acsvintage.span_years`).
+    """
+
+    name = models.CharField(
+        max_length=100,
+        db_index=True,
+        help_text=(
+            "Human-readable identifier for this vintage. Format conventions "
+            "per kind; e.g. '2020' for census-decadal, '2019-2023' for "
+            "acs-5year, '2024Q3' for bls-qcew."
+        ),
+    )
+    kind = models.CharField(
+        max_length=30,
+        choices=KIND_CHOICES,
+        db_index=True,
+        help_text=(
+            "Discriminator. Set automatically by each subclass's save() "
+            "method; downstream code can filter by kind without downcasting."
+        ),
+    )
+    effective_from = models.DateField(
+        db_index=True,
+        help_text="Date the vintage's data became current / authoritative.",
+    )
+    effective_to = models.DateField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text=(
+            "Date the vintage was superseded; NULL = unreplaced / "
+            "currently in effect. Set by the `seal_superseded_vintages` "
+            "management command when a newer vintage of the same kind lands."
+        ),
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "sw_geo_vintage"
+        ordering = ["kind", "-effective_from"]
+        indexes = [
+            models.Index(fields=["kind", "effective_to"]),
+            models.Index(fields=["effective_from", "effective_to"]),
+        ]
+
+    def __str__(self):
+        return f"{self.kind}:{self.name}"
+
+    def is_current(self, on_date=None):
+        """True if this vintage's window contains `on_date` (default: today)."""
+        from datetime import date as _date
+
+        on_date = on_date or _date.today()
+        if self.effective_from and self.effective_from > on_date:
+            return False
+        if self.effective_to is not None and self.effective_to <= on_date:
+            return False
+        return True
+
+
+class CensusDecadalVintage(Vintage):
+    """Decennial Census vintage (2010, 2020, ...).
+
+    A new row is created each decade; the previous decade's vintage
+    gets `effective_to` set when the new one lands.
+    """
+
+    decade = models.PositiveSmallIntegerField(
+        unique=True,
+        help_text="Decade marker year, e.g. 2010, 2020, 2030.",
+    )
+
+    class Meta:
+        db_table = "sw_geo_vintage_census_decadal"
+        verbose_name = "Census Decadal Vintage"
+
+    def save(self, *args, **kwargs):
+        if not self.kind:
+            self.kind = KIND_CENSUS_DECADAL
+        if not self.name:
+            self.name = str(self.decade)
+        super().save(*args, **kwargs)
+
+
+class ACSVintage(Vintage):
+    """American Community Survey vintage.
+
+    Carries `start_year`, `end_year`, and `span_years`. For 1-year ACS,
+    start_year == end_year. For 5-year ACS, end_year = start_year + 4.
+    """
+
+    SPAN_1YEAR = 1
+    SPAN_5YEAR = 5
+    SPAN_CHOICES = [
+        (SPAN_1YEAR, "1-year"),
+        (SPAN_5YEAR, "5-year"),
+    ]
+
+    start_year = models.PositiveSmallIntegerField()
+    end_year = models.PositiveSmallIntegerField()
+    span_years = models.PositiveSmallIntegerField(choices=SPAN_CHOICES)
+
+    class Meta:
+        db_table = "sw_geo_vintage_acs"
+        verbose_name = "ACS Vintage"
+        unique_together = [["start_year", "end_year", "span_years"]]
+
+    def save(self, *args, **kwargs):
+        if not self.kind:
+            self.kind = KIND_ACS
+        if not self.name:
+            if self.span_years == self.SPAN_1YEAR:
+                self.name = f"{self.start_year}"
+            else:
+                self.name = f"{self.start_year}-{self.end_year}"
+        super().save(*args, **kwargs)
+
+
+class BLSQCEWVintage(Vintage):
+    """BLS Quarterly Census of Employment and Wages vintage."""
+
+    year = models.PositiveSmallIntegerField()
+    quarter = models.PositiveSmallIntegerField(
+        choices=[(1, "Q1"), (2, "Q2"), (3, "Q3"), (4, "Q4")],
+    )
+
+    class Meta:
+        db_table = "sw_geo_vintage_bls_qcew"
+        verbose_name = "BLS QCEW Vintage"
+        unique_together = [["year", "quarter"]]
+
+    def save(self, *args, **kwargs):
+        if not self.kind:
+            self.kind = KIND_BLS_QCEW
+        if not self.name:
+            self.name = f"{self.year}Q{self.quarter}"
+        super().save(*args, **kwargs)
+
+
+class BEARegionalVintage(Vintage):
+    """BEA Regional Economic Accounts vintage. Annual."""
+
+    year = models.PositiveSmallIntegerField(unique=True)
+
+    class Meta:
+        db_table = "sw_geo_vintage_bea_regional"
+        verbose_name = "BEA Regional Vintage"
+
+    def save(self, *args, **kwargs):
+        if not self.kind:
+            self.kind = KIND_BEA_REGIONAL
+        if not self.name:
+            self.name = str(self.year)
+        super().save(*args, **kwargs)
+
+
+class NCESSchoolYearVintage(Vintage):
+    """NCES school-year vintage. Each row spans two calendar years
+    (e.g., 2023-24 = academic year starting Aug 2023, ending May 2024).
+    """
+
+    start_year = models.PositiveSmallIntegerField()
+    end_year = models.PositiveSmallIntegerField()
+
+    class Meta:
+        db_table = "sw_geo_vintage_nces_school_year"
+        verbose_name = "NCES School Year Vintage"
+        unique_together = [["start_year", "end_year"]]
+
+    def save(self, *args, **kwargs):
+        if not self.kind:
+            self.kind = KIND_NCES_SCHOOL_YEAR
+        if not self.name:
+            self.name = f"{self.start_year}-{str(self.end_year)[-2:]}"
+        super().save(*args, **kwargs)
+
+
+class RedistrictingPlanVintage(Vintage):
+    """Vintage corresponding to a single siege_utilities.RedistrictingPlan.
+
+    `effective_from` / `effective_to` track the plan's lifecycle as
+    reflected in the upstream plan's `effective_from` / `effective_to`
+    columns (added in SU#528).
+    """
+
+    siege_redistricting_plan_id = models.PositiveBigIntegerField(
+        unique=True,
+        help_text=(
+            "FK-like reference to siege_utilities RedistrictingPlan.id. "
+            "Not a Django FK because siege_geo is a separate app whose "
+            "migrations evolve independently; use the id-based lookup "
+            "pattern (RedistrictingPlan.objects.filter(pk=...))."
+        ),
+    )
+    state_fips = models.CharField(max_length=2, db_index=True)
+    chamber = models.CharField(max_length=20, db_index=True)
+    plan_name = models.CharField(max_length=255)
+
+    class Meta:
+        db_table = "sw_geo_vintage_redistricting_plan"
+        verbose_name = "Redistricting Plan Vintage"
+
+    def save(self, *args, **kwargs):
+        if not self.kind:
+            self.kind = KIND_REDISTRICTING_PLAN
+        if not self.name:
+            self.name = self.plan_name
+        super().save(*args, **kwargs)

--- a/tests/unit/geo/test_vintages.py
+++ b/tests/unit/geo/test_vintages.py
@@ -1,0 +1,189 @@
+"""Tests for the polymorphic Vintage models.
+
+Template-readiness B PR #1 (SW#190): models exist as additive new
+tables; ABP's FK is unchanged. Tests cover the parent + per-kind
+subclass shape, `is_current` semantics, and the
+`seed_known_vintages` management command's idempotency.
+"""
+
+from datetime import date
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestVintageParent(TestCase):
+    """`Vintage`'s shared fields + `is_current` semantics."""
+
+    def test_is_current_when_today_in_window(self):
+        from socialwarehouse.geo.models import Vintage
+
+        v = Vintage.objects.create(
+            name="test", kind="acs",
+            effective_from=date(2024, 1, 1),
+            effective_to=date(2026, 1, 1),
+        )
+        assert v.is_current(on_date=date(2025, 6, 1))
+
+    def test_is_current_false_after_window(self):
+        from socialwarehouse.geo.models import Vintage
+
+        v = Vintage.objects.create(
+            name="old", kind="acs",
+            effective_from=date(2020, 1, 1),
+            effective_to=date(2023, 1, 1),
+        )
+        assert not v.is_current(on_date=date(2025, 6, 1))
+
+    def test_is_current_false_before_window(self):
+        from socialwarehouse.geo.models import Vintage
+
+        v = Vintage.objects.create(
+            name="future", kind="acs",
+            effective_from=date(2030, 1, 1),
+            effective_to=None,
+        )
+        assert not v.is_current(on_date=date(2025, 6, 1))
+
+    def test_is_current_true_with_null_effective_to(self):
+        from socialwarehouse.geo.models import Vintage
+
+        v = Vintage.objects.create(
+            name="ongoing", kind="acs",
+            effective_from=date(2020, 1, 1),
+            effective_to=None,
+        )
+        assert v.is_current(on_date=date(2026, 6, 1))
+
+
+class TestCensusDecadalVintage(TestCase):
+
+    def test_save_sets_kind_and_name_automatically(self):
+        from socialwarehouse.geo.models import CensusDecadalVintage
+
+        # 2010 was seeded by the migration; create 2040 for a fresh slot.
+        v = CensusDecadalVintage.objects.create(
+            decade=2040, effective_from=date(2040, 1, 1),
+        )
+        assert v.kind == "census-decadal"
+        assert v.name == "2040"
+
+    def test_parent_table_query_returns_decadal_rows(self):
+        from socialwarehouse.geo.models import (
+            CensusDecadalVintage, Vintage,
+        )
+
+        # Seeded 2010 and 2020 exist; verify parent-table query finds them.
+        decadal_in_parent = Vintage.objects.filter(kind="census-decadal").count()
+        decadal_count = CensusDecadalVintage.objects.count()
+        assert decadal_in_parent == decadal_count
+
+
+class TestACSVintage(TestCase):
+
+    def test_5year_naming(self):
+        from socialwarehouse.geo.models import ACSVintage
+
+        # 2019-2023 was seeded by migration; create a hypothetical 2024-2028.
+        v = ACSVintage.objects.create(
+            start_year=2024, end_year=2028, span_years=ACSVintage.SPAN_5YEAR,
+            effective_from=date(2029, 12, 1),
+        )
+        assert v.name == "2024-2028"
+        assert v.kind == "acs"
+
+    def test_1year_naming(self):
+        from socialwarehouse.geo.models import ACSVintage
+
+        v = ACSVintage.objects.create(
+            start_year=2025, end_year=2025, span_years=ACSVintage.SPAN_1YEAR,
+            effective_from=date(2026, 9, 1),
+        )
+        assert v.name == "2025"
+
+    def test_unique_constraint(self):
+        from django.db import IntegrityError
+        from socialwarehouse.geo.models import ACSVintage
+
+        ACSVintage.objects.create(
+            start_year=2050, end_year=2054, span_years=ACSVintage.SPAN_5YEAR,
+            effective_from=date(2055, 12, 1),
+        )
+        with self.assertRaises(IntegrityError):
+            ACSVintage.objects.create(
+                start_year=2050, end_year=2054, span_years=ACSVintage.SPAN_5YEAR,
+                effective_from=date(2055, 12, 1),
+            )
+
+
+class TestBLSQCEWVintage(TestCase):
+
+    def test_naming_quarter_format(self):
+        from socialwarehouse.geo.models import BLSQCEWVintage
+
+        v = BLSQCEWVintage.objects.create(
+            year=2030, quarter=2, effective_from=date(2030, 4, 1),
+        )
+        assert v.name == "2030Q2"
+
+
+class TestNCESSchoolYearVintage(TestCase):
+
+    def test_naming_two_digit_end(self):
+        from socialwarehouse.geo.models import NCESSchoolYearVintage
+
+        v = NCESSchoolYearVintage.objects.create(
+            start_year=2030, end_year=2031, effective_from=date(2030, 8, 1),
+        )
+        assert v.name == "2030-31"
+
+
+class TestSeedKnownVintages(TestCase):
+
+    def test_command_is_idempotent(self):
+        from socialwarehouse.geo.models import Vintage
+
+        # The migration ran seed_known_vintages already; rerunning must
+        # not duplicate rows.
+        before = Vintage.objects.count()
+        call_command("seed_known_vintages", verbosity=0)
+        after = Vintage.objects.count()
+        assert before == after
+
+    def test_dry_run_does_not_write(self):
+        from socialwarehouse.geo.models import Vintage
+
+        before = Vintage.objects.count()
+        call_command("seed_known_vintages", "--dry-run", verbosity=0, stdout=StringIO())
+        after = Vintage.objects.count()
+        assert before == after
+
+    def test_unknown_kind_reports_error(self):
+        out = StringIO()
+        err = StringIO()
+        call_command(
+            "seed_known_vintages", "--kinds=fictional-domain",
+            stdout=out, stderr=err, verbosity=0,
+        )
+        assert "Unknown kinds" in out.getvalue() or "Unknown kinds" in err.getvalue()
+
+    def test_seeded_catalog_includes_each_kind(self):
+        from socialwarehouse.geo.models import (
+            ACSVintage, BEARegionalVintage, BLSQCEWVintage,
+            CensusDecadalVintage, NCESSchoolYearVintage,
+        )
+
+        assert CensusDecadalVintage.objects.count() >= 2
+        assert ACSVintage.objects.count() >= 10
+        assert BLSQCEWVintage.objects.count() >= 20
+        assert BEARegionalVintage.objects.count() >= 10
+        assert NCESSchoolYearVintage.objects.count() >= 10
+
+    def test_latest_vintage_has_null_effective_to(self):
+        """The most recent vintage of each kind is the 'unreplaced' one."""
+        from socialwarehouse.geo.models import CensusDecadalVintage
+
+        latest = CensusDecadalVintage.objects.order_by("-decade").first()
+        assert latest is not None
+        assert latest.effective_to is None


### PR DESCRIPTION
## Summary

**Template-readiness sub-issue B, PR #1 of 2** (per the design's Q4-ii sequencing). Purely additive: introduces the polymorphic `Vintage` model + per-kind subclasses + the `seed_known_vintages` management command. ABP's existing FK to `CensusVintageConfig` is **untouched**; PR #2 retargets ABP and drops `CensusVintageConfig`.

## What ships

### Models (`socialwarehouse/geo/models/vintages.py`)

Per the design v2's Shape A2 (Django multi-table inheritance):

- **`Vintage`** — concrete parent with shared fields (`name`, `kind`, `effective_from`, `effective_to`, `created_at`, `updated_at`). Carries `is_current(on_date)`.
- **Six per-kind subclasses** — `CensusDecadalVintage`, `ACSVintage`, `BLSQCEWVintage`, `BEARegionalVintage`, `NCESSchoolYearVintage`, `RedistrictingPlanVintage`. Each has its own backing table with a 1:1 FK to the parent. Each `save()` sets `kind` and `name` automatically.

### Management command (`seed_known_vintages`)

Pre-populates the catalog rows for the five non-redistricting kinds:

| Kind | Seeded |
|---|---|
| Census decadal | 2010, 2020 |
| ACS 5-year | 2009-2013 through 2019-2023 (11 vintages) |
| ACS 1-year | 2010-2023 minus 2020 (13 vintages) |
| BLS QCEW | 2010Q1 through 2024Q4 (60 vintages) |
| BEA regional | 2010-2024 (15 vintages) |
| NCES school year | 2010-11 through 2023-24 (14 vintages) |

Idempotent; rerunnable as new vintages are published. Redistricting-plan vintages are NOT pre-seeded — those are created on demand by `assign_boundaries`.

### Migration

`0004_polymorphic_vintage_models.py` creates the seven tables and runs `seed_known_vintages` as a RunPython data-migration step.

### Tests

`tests/unit/geo/test_vintages.py` covers:
- `Vintage.is_current` semantics (in window, after window, before window, null effective_to = "ongoing").
- Per-subclass auto-naming + auto-kind.
- Parent-table queries return subclass rows.
- Unique constraints.
- Seed-command idempotency, dry-run, unknown-kind error.
- Catalog content (counts per kind).
- Latest-vintage-has-null-effective-to invariant.

The test file doubles as the model-vs-migration schema verifier — informed by SU#527, every subclass is instantiated via `.objects.create(...)` so any field declared in the model but missing from the migration trips a clear test failure.

## What's NOT in this PR (intentional, sequenced for PR #2)

- ABP's FK retarget.
- Caller migration off `CensusVintageConfig`.
- Removal of `CensusVintageConfig` itself.

## Initiative impact

Unblocks sub-issues C / D / E / F (each needs the polymorphic Vintage table to exist before its rows are well-shaped). PR #2 will fully cut over and remove `CensusVintageConfig`.

## Test plan
- [ ] CI green.
- [ ] Manual: `python manage.py seed_known_vintages --dry-run` reports the standard catalog.

## References
- Design v2: `docs/designs/template-b-vintage-polymorphization.md` (PR #199, merged)
- Initiative: #189
- Sub-issue: #190
