### PR TITLE
C/SW#191 high-priority batch (SW-side): zcta, place, cbsa, school_district cache fields

### DIFF
--- a/socialwarehouse/geo/migrations/0006_c_high_priority_boundary_caches.py
+++ b/socialwarehouse/geo/migrations/0006_c_high_priority_boundary_caches.py
@@ -1,0 +1,68 @@
+"""Template-readiness C high-priority batch (SW#191): add cache fields
+for the four new boundary types — ZCTA, Place, CBSA, SchoolDistrict —
+on Address and AddressBoundaryPeriod.
+
+Additive only. The boundary models themselves live upstream in
+siege_utilities (tracked SU#532); these are pure string caches keyed
+by the same `{type}_geoid` convention as the existing nine types.
+
+After this migration, `Address._BOUNDARY_TYPES` includes the four new
+types, so F11 helpers (`boundary_history`, `boundary_on`,
+`boundary_timeline`, etc.) automatically cover them. Field values
+remain empty until SU#532 ships and `assign_boundaries` is updated to
+populate them.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_geo", "0005_template_b_cutover"),
+    ]
+
+    operations = [
+        # Address cache fields.
+        migrations.AddField(
+            model_name="address",
+            name="zcta_geoid",
+            field=models.CharField(blank=True, default="", max_length=5),
+        ),
+        migrations.AddField(
+            model_name="address",
+            name="place_geoid",
+            field=models.CharField(blank=True, default="", max_length=7),
+        ),
+        migrations.AddField(
+            model_name="address",
+            name="cbsa_geoid",
+            field=models.CharField(blank=True, default="", max_length=5),
+        ),
+        migrations.AddField(
+            model_name="address",
+            name="school_district_geoid",
+            field=models.CharField(blank=True, default="", max_length=7),
+        ),
+        # AddressBoundaryPeriod cache fields.
+        migrations.AddField(
+            model_name="addressboundaryperiod",
+            name="zcta_geoid",
+            field=models.CharField(blank=True, max_length=5, null=True),
+        ),
+        migrations.AddField(
+            model_name="addressboundaryperiod",
+            name="place_geoid",
+            field=models.CharField(blank=True, max_length=7, null=True),
+        ),
+        migrations.AddField(
+            model_name="addressboundaryperiod",
+            name="cbsa_geoid",
+            field=models.CharField(blank=True, max_length=5, null=True),
+        ),
+        migrations.AddField(
+            model_name="addressboundaryperiod",
+            name="school_district_geoid",
+            field=models.CharField(blank=True, max_length=7, null=True),
+        ),
+    ]

--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -180,6 +180,29 @@ class Address(models.Model):
         max_length=5, blank=True, default="",
         help_text="State Legislative District Upper GEOID (state FIPS + district)",
     )
+
+    # ── Template-readiness C high-priority batch (SW#191) ────────────────
+    # Cache fields for the four new boundary types unblocking D / E / F
+    # Phase 1. The boundary models themselves live in siege_utilities
+    # (tracked SU#532); these are pure string caches keyed by the same
+    # `{type}_geoid` convention as the existing nine types.
+    zcta_geoid = models.CharField(
+        max_length=5, blank=True, default="",
+        help_text="ZIP Code Tabulation Area (5-digit ZCTA, Census-derived). Distinct from postal `zip5`; see SW#207 Q3.",
+    )
+    place_geoid = models.CharField(
+        max_length=7, blank=True, default="",
+        help_text="Census Place GEOID (state FIPS + place FIPS).",
+    )
+    cbsa_geoid = models.CharField(
+        max_length=5, blank=True, default="",
+        help_text="Core-Based Statistical Area code (Census/OMB; MSA or micropolitan).",
+    )
+    school_district_geoid = models.CharField(
+        max_length=7, blank=True, default="",
+        help_text="NCES Local Education Agency (LEAID); for the district containing this address.",
+    )
+
     census_units_assigned_at = models.DateTimeField(null=True, blank=True)
 
     # ── Address construction timeline (TIGER ADDRFEAT) ──────────────────
@@ -340,6 +363,8 @@ class Address(models.Model):
     _BOUNDARY_TYPES = (
         "state", "county", "tract", "block_group", "block",
         "vtd", "cd", "sldl", "sldu",
+        # Template-readiness C high-priority batch (SW#191):
+        "zcta", "place", "cbsa", "school_district",
     )
 
     def boundary_history(self, boundary_type=None):

--- a/socialwarehouse/geo/models/address_boundary.py
+++ b/socialwarehouse/geo/models/address_boundary.py
@@ -84,6 +84,14 @@ class AddressBoundaryPeriod(models.Model):
     sldl_geoid = models.CharField(max_length=5, null=True, blank=True)
     sldu_geoid = models.CharField(max_length=5, null=True, blank=True)
 
+    # Template-readiness C high-priority batch (SW#191): new boundary types.
+    # Static (non-redistricting) boundaries; populated by assign_boundaries
+    # once SU#532 ships the corresponding boundary models.
+    zcta_geoid = models.CharField(max_length=5, null=True, blank=True)
+    place_geoid = models.CharField(max_length=7, null=True, blank=True)
+    cbsa_geoid = models.CharField(max_length=5, null=True, blank=True)
+    school_district_geoid = models.CharField(max_length=7, null=True, blank=True)
+
     # siege_geo ForeignKeys (optional, for rich queries)
     siege_state = models.ForeignKey(
         "siege_geo.State", on_delete=models.SET_NULL,

--- a/tests/unit/geo/test_c_high_priority_boundary_types.py
+++ b/tests/unit/geo/test_c_high_priority_boundary_types.py
@@ -1,0 +1,121 @@
+"""Tests for Template-readiness C high-priority batch (SW#191):
+Address and ABP carry cache fields for ZCTA, Place, CBSA, and
+SchoolDistrict; F11 helpers cover the new types automatically.
+
+The boundary models themselves live in siege_utilities (SU#532);
+these tests cover the SW-side cache contract only.
+"""
+
+from datetime import date
+
+from django.test import TestCase
+
+
+class TestAddressNewGeoidFields(TestCase):
+    """Address has the four new cache fields with the documented max_lengths."""
+
+    def test_all_four_fields_default_to_empty_string(self):
+        from socialwarehouse.geo.models import Address
+
+        addr = Address.objects.create(state_abbreviation="TX")
+        assert addr.zcta_geoid == ""
+        assert addr.place_geoid == ""
+        assert addr.cbsa_geoid == ""
+        assert addr.school_district_geoid == ""
+
+    def test_fields_accept_realistic_values(self):
+        from socialwarehouse.geo.models import Address
+
+        addr = Address.objects.create(
+            state_abbreviation="IL",
+            zcta_geoid="60601",        # Chicago downtown ZCTA
+            place_geoid="1714000",     # Chicago place GEOID (state 17 + place 14000)
+            cbsa_geoid="16980",        # Chicago-Naperville-Elgin CBSA
+            school_district_geoid="1709930",  # Chicago Public Schools LEAID
+        )
+        addr.refresh_from_db()
+        assert addr.zcta_geoid == "60601"
+        assert addr.place_geoid == "1714000"
+        assert addr.cbsa_geoid == "16980"
+        assert addr.school_district_geoid == "1709930"
+
+
+class TestBoundaryTypesCoverage(TestCase):
+    """The four new types appear in `Address._BOUNDARY_TYPES`."""
+
+    def test_new_types_are_in_boundary_types_tuple(self):
+        from socialwarehouse.geo.models import Address
+
+        for btype in ("zcta", "place", "cbsa", "school_district"):
+            assert btype in Address._BOUNDARY_TYPES, (
+                f"{btype} missing from Address._BOUNDARY_TYPES"
+            )
+
+    def test_f11_helpers_recognize_new_types_without_raising(self):
+        from socialwarehouse.geo.models import Address
+
+        addr = Address.objects.create(state_abbreviation="NY")
+        # Should not raise; returns empty queryset/dict for an address
+        # with no ABP rows.
+        assert list(addr.boundary_history(boundary_type="zcta")) == []
+        assert addr.boundary_on("place", date(2024, 6, 1)) is None
+        assert addr.geoid_on("cbsa", date(2024, 6, 1)) is None
+        assert addr.boundary_timeline("school_district") == []
+
+
+class TestABPNewGeoidFields(TestCase):
+    """AddressBoundaryPeriod has the four new geoid columns."""
+
+    def test_abp_can_carry_new_geoids(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusDecadalVintage,
+        )
+
+        addr = Address.objects.create(state_abbreviation="IL")
+        vintage = CensusDecadalVintage.objects.get(decade=2020)
+
+        abp = AddressBoundaryPeriod.objects.create(
+            address=addr,
+            vintage=vintage,
+            zcta_geoid="60601",
+            place_geoid="1714000",
+            cbsa_geoid="16980",
+            school_district_geoid="1709930",
+            context_date=date(2024, 6, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+
+        abp.refresh_from_db()
+        assert abp.zcta_geoid == "60601"
+        assert abp.place_geoid == "1714000"
+        assert abp.cbsa_geoid == "16980"
+        assert abp.school_district_geoid == "1709930"
+
+    def test_step_2b_signal_propagates_new_geoids_to_address_cache(self):
+        """The F11 step-2b signal should refresh the new cache fields too,
+        since they're members of Address._BOUNDARY_TYPES.
+        """
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusDecadalVintage,
+        )
+
+        addr = Address.objects.create(state_abbreviation="IL")
+        vintage = CensusDecadalVintage.objects.get(decade=2020)
+
+        AddressBoundaryPeriod.objects.create(
+            address=addr,
+            vintage=vintage,
+            zcta_geoid="60601",
+            cbsa_geoid="16980",
+            context_date=date(2024, 6, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+
+        addr.refresh_from_db()
+        # The signal short-circuits if vintage isn't current; vintage_2020
+        # is current as of today (effective_to=None), so cache updates.
+        assert addr.zcta_geoid == "60601"
+        assert addr.cbsa_geoid == "16980"
+        # place / school_district were not set on the ABP row; cache stays empty.
+        assert addr.place_geoid == ""
+        assert addr.school_district_geoid == ""


### PR DESCRIPTION
First implementation PR for template-readiness C. Adds SW-side cache fields for the four high-priority boundary types per Q1 = (b) batched. The SU-side boundary models are tracked upstream as [SU#532](https://github.com/siege-analytics/siege_utilities/issues/532); this PR doesn't depend on them — the cache fields are pure strings, populated once assign_boundaries is updated post-SU.

Per C answers:
- Q1 = (b) batched: this is the high-priority half (zcta, place, cbsa, school_district)
- Q3 = separate: zcta_geoid is distinct from postal Address.zip5
- Q2 = one-model-per-kind applies to medium-priority special_district batch (not in this PR)

## Test plan
- [ ] CI green
- [ ] Signal-propagation test exercises the load-bearing invariant (new types populate via F11 step-2b automatically)

## References
- C design: #207 (merged for direction)
- SU#532: upstream boundary models
- Initiative: #189

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for four new Census geographic boundary types: ZCTA, Place, CBSA, and School District
  * Address records can now cache and retrieve geographic boundary identifiers for these boundary types

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->