### PR TITLE
F/SW#194 Phase 1b: NCES school-level CCD ingest

### DIFF
--- a/socialwarehouse/civic/management/commands/load_nces_schools.py
+++ b/socialwarehouse/civic/management/commands/load_nces_schools.py
@@ -1,0 +1,195 @@
+"""Load NCES CCD school-level aggregates (Phase 1b).
+
+Joins the school-level CCD files (Directory + Nonfiscal) into
+NCESSchoolAggregate rows per NCESSCH per school year.
+
+Usage:
+    python manage.py load_nces_schools --vintage 2022-23 --state 06
+    python manage.py load_nces_schools --vintage 2022-23 --state 06 --dry-run
+"""
+
+import logging
+from decimal import Decimal
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+logger = logging.getLogger(__name__)
+
+
+# NCES CCD school-type code mapping (per CCD documentation).
+SCHOOL_TYPE_MAPPING = {
+    "1": "regular",
+    "2": "special",
+    "3": "vocational",
+    "4": "alternative",
+}
+
+# School status codes (NCES SCHOOL_STATUS / SY_STATUS field).
+SCHOOL_STATUS_MAPPING = {
+    "1": "open",
+    "2": "closed",
+    "3": "new",
+    "4": "added",
+    "5": "changed_boundary",
+    "6": "inactive",
+    "7": "future",
+    "8": "reopened",
+}
+
+
+class Command(BaseCommand):
+    help = "Load NCES CCD school-level aggregates into NCESSchoolAggregate."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--vintage", type=str, required=True,
+            help="School-year vintage name like '2022-23'. Must match NCESSchoolYearVintage.",
+        )
+        parser.add_argument(
+            "--state", type=str, required=True,
+            help="2-digit state FIPS; filters rows to this state.",
+        )
+        parser.add_argument(
+            "--dry-run", action="store_true",
+            help="Fetch + report counts without writing.",
+        )
+
+    def handle(self, *args, **options):
+        from socialwarehouse.civic.models import NCESSchoolAggregate
+        from socialwarehouse.civic.services.nces_files import NCESFiles
+        from socialwarehouse.geo.models import NCESSchoolYearVintage
+
+        vintage_name = options["vintage"]
+        state_fips = options["state"]
+        dry_run = options["dry_run"]
+
+        try:
+            vintage = NCESSchoolYearVintage.objects.get(name=vintage_name)
+        except NCESSchoolYearVintage.DoesNotExist:
+            raise CommandError(
+                f"No NCESSchoolYearVintage with name={vintage_name!r}. "
+                f"Available: "
+                f"{list(NCESSchoolYearVintage.objects.values_list('name', flat=True)[:5])}…"
+            )
+
+        self.stdout.write(f"NCES schools vintage={vintage.name} state={state_fips}")
+
+        files = NCESFiles()
+        directory = files.load_ccd_school_directory(vintage.name)
+        nonfiscal = files.load_ccd_school_nonfiscal(vintage.name)
+
+        if "STATEFIPS" in directory.columns:
+            directory = directory[directory["STATEFIPS"] == state_fips]
+        directory = directory.set_index("NCESSCH", drop=False)
+        if "NCESSCH" in nonfiscal.columns:
+            nonfiscal = nonfiscal.set_index("NCESSCH", drop=False)
+
+        self.stdout.write(
+            f"Parsed {len(directory)} schools / {len(nonfiscal)} nonfiscal rows for state {state_fips}."
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.SUCCESS(
+                f"[DRY] would write up to {len(directory)} NCESSchoolAggregate rows."
+            ))
+            return
+
+        written = 0
+        with transaction.atomic():
+            for nces_id, dir_row in directory.iterrows():
+                nf = nonfiscal.loc[nces_id] if nces_id in nonfiscal.index else None
+
+                NCESSchoolAggregate.objects.update_or_create(
+                    vintage=vintage,
+                    geoid=nces_id,
+                    defaults={
+                        "boundary_type": "school",
+                        "leaid": str(dir_row.get("LEAID", "")),
+                        "state_fips": str(dir_row.get("STATEFIPS", "")),
+                        "school_name": str(dir_row.get("SCH_NAME", ""))[:255],
+                        "school_type": SCHOOL_TYPE_MAPPING.get(
+                            str(dir_row.get("SCH_TYPE", "")), "other",
+                        ),
+                        "school_status": SCHOOL_STATUS_MAPPING.get(
+                            str(dir_row.get("SY_STATUS", "")), "",
+                        ),
+                        "is_charter": _to_bool(dir_row.get("CHARTER_TEXT")),
+                        "is_magnet": _to_bool(dir_row.get("MAGNET_TEXT")),
+                        "is_title_i": _to_bool(dir_row.get("TITLEI_STATUS")),
+                        "grade_low": str(dir_row.get("GSLO", ""))[:4],
+                        "grade_high": str(dir_row.get("GSHI", ""))[:4],
+                        **self._extract_nonfiscal(nf),
+                    },
+                )
+                written += 1
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Wrote {written} NCESSchoolAggregate rows for {vintage.name} state={state_fips}."
+        ))
+
+    @staticmethod
+    def _extract_nonfiscal(row):
+        if row is None:
+            return {}
+        return {
+            "enrollment_total": _to_int(row.get("TOTAL")),
+            "enrollment_pk_grade_k": _sum_grades(row, ["PK", "KG"]),
+            "enrollment_grade_1_5": _sum_grades(row, [f"G{n:02d}" for n in range(1, 6)]),
+            "enrollment_grade_6_8": _sum_grades(row, ["G06", "G07", "G08"]),
+            "enrollment_grade_9_12": _sum_grades(row, ["G09", "G10", "G11", "G12"]),
+            "free_lunch_eligible_count": _to_int(row.get("TOTFRL")),
+            "teachers_fte": _to_decimal(row.get("FTE")),
+        }
+
+
+def _to_int(raw):
+    if raw is None:
+        return None
+    try:
+        if isinstance(raw, float) and raw != raw:
+            return None
+        val = int(Decimal(str(raw)))
+        # NCES negative sentinels for missing/suppressed.
+        if val < 0:
+            return None
+        return val
+    except Exception:
+        return None
+
+
+def _to_decimal(raw):
+    if raw is None:
+        return None
+    try:
+        if isinstance(raw, float) and raw != raw:
+            return None
+        val = Decimal(str(raw))
+        if val < 0:
+            return None
+        return val
+    except Exception:
+        return None
+
+
+def _to_bool(raw):
+    """NCES uses 'Yes' / 'No' / '1' / '2' / missing for booleans depending on field."""
+    if raw is None:
+        return None
+    s = str(raw).strip().upper()
+    if s in ("YES", "1", "TRUE", "Y"):
+        return True
+    if s in ("NO", "2", "FALSE", "N"):
+        return False
+    return None
+
+
+def _sum_grades(row, columns):
+    total = 0
+    found_any = False
+    for col in columns:
+        v = _to_int(row.get(col))
+        if v is not None:
+            total += v
+            found_any = True
+    return total if found_any else None

--- a/socialwarehouse/civic/migrations/0002_nces_school_aggregate.py
+++ b/socialwarehouse/civic/migrations/0002_nces_school_aggregate.py
@@ -1,0 +1,87 @@
+"""F Phase 1b (SW#194): NCESSchoolAggregate for per-school NCES data."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_civic", "0001_initial"),
+        ("sw_geo", "0006_c_high_priority_boundary_caches"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="NCESSchoolAggregate",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("boundary_type", models.CharField(db_index=True, default="school", max_length=30)),
+                ("geoid", models.CharField(db_index=True, max_length=12)),
+                ("leaid", models.CharField(db_index=True, max_length=7)),
+                ("state_fips", models.CharField(blank=True, db_index=True, default="", max_length=2)),
+                ("school_name", models.CharField(blank=True, default="", max_length=255)),
+                ("school_type", models.CharField(
+                    blank=True, default="", max_length=20,
+                    choices=[
+                        ("regular", "Regular school"),
+                        ("special", "Special education school"),
+                        ("vocational", "Vocational school"),
+                        ("alternative", "Alternative school"),
+                        ("other", "Other"),
+                    ],
+                )),
+                ("school_status", models.CharField(
+                    blank=True, default="", max_length=20,
+                    choices=[
+                        ("open", "Open"),
+                        ("closed", "Closed"),
+                        ("new", "New school"),
+                        ("added", "Added to NCES universe"),
+                        ("changed_boundary", "Boundary change"),
+                        ("inactive", "Inactive"),
+                        ("future", "Future open date"),
+                        ("reopened", "Reopened"),
+                    ],
+                )),
+                ("is_charter", models.BooleanField(blank=True, null=True)),
+                ("is_magnet", models.BooleanField(blank=True, null=True)),
+                ("is_title_i", models.BooleanField(blank=True, null=True)),
+                ("grade_low", models.CharField(blank=True, default="", max_length=4)),
+                ("grade_high", models.CharField(blank=True, default="", max_length=4)),
+                ("enrollment_total", models.PositiveIntegerField(blank=True, null=True)),
+                ("enrollment_pk_grade_k", models.PositiveIntegerField(blank=True, null=True)),
+                ("enrollment_grade_1_5", models.PositiveIntegerField(blank=True, null=True)),
+                ("enrollment_grade_6_8", models.PositiveIntegerField(blank=True, null=True)),
+                ("enrollment_grade_9_12", models.PositiveIntegerField(blank=True, null=True)),
+                ("free_lunch_eligible_count", models.PositiveIntegerField(blank=True, null=True)),
+                ("reduced_lunch_eligible_count", models.PositiveIntegerField(blank=True, null=True)),
+                ("teachers_fte", models.DecimalField(blank=True, decimal_places=2, max_digits=10, null=True)),
+                (
+                    "vintage",
+                    models.ForeignKey(
+                        limit_choices_to={"kind": "nces-school-year"},
+                        on_delete=models.CASCADE,
+                        related_name="nces_school_aggregates",
+                        to="sw_geo.vintage",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "sw_civic_nces_school_aggregate",
+                "verbose_name": "NCES School Aggregate",
+                "unique_together": {("vintage", "geoid")},
+            },
+        ),
+        migrations.AddIndex(
+            model_name="ncesschoolaggregate",
+            index=models.Index(fields=["boundary_type", "geoid", "vintage"], name="sw_civic_sch_bgv_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="ncesschoolaggregate",
+            index=models.Index(fields=["leaid", "vintage"], name="sw_civic_sch_lea_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="ncesschoolaggregate",
+            index=models.Index(fields=["state_fips", "vintage"], name="sw_civic_sch_sv_idx"),
+        ),
+    ]

--- a/socialwarehouse/civic/models/__init__.py
+++ b/socialwarehouse/civic/models/__init__.py
@@ -1,3 +1,4 @@
 from .nces_district import NCESDistrictAggregate
+from .nces_school import NCESSchoolAggregate
 
-__all__ = ["NCESDistrictAggregate"]
+__all__ = ["NCESDistrictAggregate", "NCESSchoolAggregate"]

--- a/socialwarehouse/civic/models/nces_school.py
+++ b/socialwarehouse/civic/models/nces_school.py
@@ -1,0 +1,92 @@
+"""NCES CCD school-level aggregate (per-school per-school-year).
+
+Per F design (#210) Q2 = (b) district + school level. Phase 1a
+shipped the district half (NCESDistrictAggregate); this is the
+school half.
+
+NCES School ID is 12 digits: 7-digit LEAID + 5-digit school sequence.
+"""
+
+from django.db import models
+
+
+class NCESSchoolAggregate(models.Model):
+    """One row per NCES school per school year."""
+
+    vintage = models.ForeignKey(
+        "sw_geo.Vintage",
+        on_delete=models.CASCADE,
+        related_name="nces_school_aggregates",
+        limit_choices_to={"kind": "nces-school-year"},
+        help_text="Polymorphic Vintage parent; should be an NCESSchoolYearVintage row.",
+    )
+    boundary_type = models.CharField(
+        max_length=30, default="school", db_index=True,
+        help_text="'school' for this model; kept for D/E/F shape consistency.",
+    )
+    geoid = models.CharField(
+        max_length=12, db_index=True,
+        help_text="NCES School ID (12-digit; LEAID prefix + 5-digit school sequence).",
+    )
+    leaid = models.CharField(
+        max_length=7, db_index=True,
+        help_text="Parent LEA (district) ID; joins to NCESDistrictAggregate.geoid.",
+    )
+    state_fips = models.CharField(max_length=2, blank=True, default="", db_index=True)
+
+    # ── Directory ────────────────────────────────────────────────────────
+    school_name = models.CharField(max_length=255, blank=True, default="")
+    school_type = models.CharField(
+        max_length=20, blank=True, default="",
+        choices=[
+            ("regular", "Regular school"),
+            ("special", "Special education school"),
+            ("vocational", "Vocational school"),
+            ("alternative", "Alternative school"),
+            ("other", "Other"),
+        ],
+    )
+    school_status = models.CharField(
+        max_length=20, blank=True, default="",
+        choices=[
+            ("open", "Open"),
+            ("closed", "Closed"),
+            ("new", "New school"),
+            ("added", "Added to NCES universe"),
+            ("changed_boundary", "Boundary change"),
+            ("inactive", "Inactive"),
+            ("future", "Future open date"),
+            ("reopened", "Reopened"),
+        ],
+    )
+    is_charter = models.BooleanField(null=True, blank=True)
+    is_magnet = models.BooleanField(null=True, blank=True)
+    is_title_i = models.BooleanField(null=True, blank=True)
+    grade_low = models.CharField(max_length=4, blank=True, default="")
+    grade_high = models.CharField(max_length=4, blank=True, default="")
+
+    # ── Enrollment (CCD school-level nonfiscal) ──────────────────────────
+    enrollment_total = models.PositiveIntegerField(null=True, blank=True)
+    enrollment_pk_grade_k = models.PositiveIntegerField(null=True, blank=True)
+    enrollment_grade_1_5 = models.PositiveIntegerField(null=True, blank=True)
+    enrollment_grade_6_8 = models.PositiveIntegerField(null=True, blank=True)
+    enrollment_grade_9_12 = models.PositiveIntegerField(null=True, blank=True)
+    free_lunch_eligible_count = models.PositiveIntegerField(null=True, blank=True)
+    reduced_lunch_eligible_count = models.PositiveIntegerField(null=True, blank=True)
+    teachers_fte = models.DecimalField(max_digits=10, decimal_places=2, null=True, blank=True)
+
+    class Meta:
+        db_table = "sw_civic_nces_school_aggregate"
+        verbose_name = "NCES School Aggregate"
+        unique_together = [["vintage", "geoid"]]
+        indexes = [
+            models.Index(fields=["boundary_type", "geoid", "vintage"]),
+            models.Index(fields=["leaid", "vintage"]),
+            models.Index(fields=["state_fips", "vintage"]),
+        ]
+
+    def __str__(self):
+        return (
+            f"NCES school {self.geoid} ({self.school_name or '?'}) @ "
+            f"{self.vintage.name} (enrollment={self.enrollment_total})"
+        )

--- a/socialwarehouse/civic/services/nces_files.py
+++ b/socialwarehouse/civic/services/nces_files.py
@@ -54,6 +54,14 @@ CCD_F33_URL = (
     "https://nces.ed.gov/ccd/data/zip/sdf{end_2digit}_1a.zip"
 )
 
+# School-level CCD files (per F Phase 1b).
+CCD_SCHOOL_DIRECTORY_URL = (
+    "https://nces.ed.gov/ccd/data/zip/ccd_sch_029_{end_2digit}_l_1a.zip"
+)
+CCD_SCHOOL_NONFISCAL_URL = (
+    "https://nces.ed.gov/ccd/data/zip/ccd_sch_052_{end_2digit}_l_1a.zip"
+)
+
 
 class NCESFiles:
     """Thin wrapper around NCES CCD open data files (Phase 1a)."""
@@ -110,3 +118,21 @@ class NCESFiles:
         url = CCD_F33_URL.format(end_2digit=str(end)[-2:])
         path = self._download_zip(url, f"ccd_lea_finance_{school_year}")
         return pd.read_csv(path, dtype={"LEAID": str}, low_memory=False)
+
+    # ── School-level loaders (Phase 1b) ───────────────────────────────
+
+    def load_ccd_school_directory(self, school_year: str) -> pd.DataFrame:
+        start, end = self._parse_school_year(school_year)
+        url = CCD_SCHOOL_DIRECTORY_URL.format(end_2digit=str(end)[-2:])
+        path = self._download_zip(url, f"ccd_sch_directory_{school_year}")
+        return pd.read_csv(
+            path,
+            dtype={"NCESSCH": str, "LEAID": str, "STATEFIPS": str},
+            low_memory=False,
+        )
+
+    def load_ccd_school_nonfiscal(self, school_year: str) -> pd.DataFrame:
+        start, end = self._parse_school_year(school_year)
+        url = CCD_SCHOOL_NONFISCAL_URL.format(end_2digit=str(end)[-2:])
+        path = self._download_zip(url, f"ccd_sch_nonfiscal_{school_year}")
+        return pd.read_csv(path, dtype={"NCESSCH": str, "LEAID": str}, low_memory=False)

--- a/tests/unit/civic/test_load_nces_schools.py
+++ b/tests/unit/civic/test_load_nces_schools.py
@@ -1,0 +1,158 @@
+"""Tests for F Phase 1b: NCESSchoolAggregate + load_nces_schools.
+
+Mocks NCESFiles's school-level loaders. Pins:
+- School type / status code mapping.
+- Charter / magnet / title-I boolean parsing from NCES Yes/No strings.
+- Negative-sentinel coercion.
+- State filter.
+"""
+
+from datetime import date
+from decimal import Decimal
+from io import StringIO
+from unittest.mock import patch
+
+import pandas as pd
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+
+class LoadNCESSchoolsTestBase(TestCase):
+
+    def setUp(self):
+        from socialwarehouse.geo.models import NCESSchoolYearVintage
+
+        self.vintage = NCESSchoolYearVintage.objects.filter(start_year=2022, end_year=2023).first()
+        if self.vintage is None:
+            self.vintage = NCESSchoolYearVintage.objects.create(
+                start_year=2022, end_year=2023,
+                effective_from=date(2022, 8, 1), effective_to=date(2023, 8, 1),
+            )
+
+    def _patch_loaders(self, directory_rows, nonfiscal_rows):
+        return patch.multiple(
+            "socialwarehouse.civic.services.nces_files.NCESFiles",
+            load_ccd_school_directory=lambda self, school_year: pd.DataFrame(directory_rows),
+            load_ccd_school_nonfiscal=lambda self, school_year: pd.DataFrame(nonfiscal_rows),
+        )
+
+
+class TestLoadSchoolsHappyPath(LoadNCESSchoolsTestBase):
+
+    def test_writes_school_with_joined_nonfiscal(self):
+        from socialwarehouse.civic.models import NCESSchoolAggregate
+
+        directory = [
+            {"NCESSCH": "060000100001", "LEAID": "0600001", "STATEFIPS": "06",
+             "SCH_NAME": "Lincoln High", "SCH_TYPE": "1", "SY_STATUS": "1",
+             "CHARTER_TEXT": "No", "MAGNET_TEXT": "Yes", "TITLEI_STATUS": "1",
+             "GSLO": "09", "GSHI": "12"},
+        ]
+        nonfiscal = [
+            {"NCESSCH": "060000100001", "TOTAL": 2100, "FTE": 115.0,
+             "G09": 540, "G10": 525, "G11": 520, "G12": 515,
+             "TOTFRL": 850, "PK": 0, "KG": 0},
+        ]
+
+        with self._patch_loaders(directory, nonfiscal):
+            call_command("load_nces_schools", f"--vintage={self.vintage.name}", "--state=06", verbosity=0)
+
+        s = NCESSchoolAggregate.objects.get(vintage=self.vintage, geoid="060000100001")
+        assert s.school_name == "Lincoln High"
+        assert s.school_type == "regular"
+        assert s.school_status == "open"
+        assert s.is_charter is False
+        assert s.is_magnet is True
+        assert s.is_title_i is True
+        assert s.grade_low == "09"
+        assert s.grade_high == "12"
+        assert s.enrollment_total == 2100
+        assert s.enrollment_grade_9_12 == 2100  # sum of G09..G12
+        assert s.teachers_fte == Decimal("115.00")
+        assert s.leaid == "0600001"
+
+
+class TestLoadSchoolsNegativeSentinels(LoadNCESSchoolsTestBase):
+
+    def test_negative_values_become_null(self):
+        from socialwarehouse.civic.models import NCESSchoolAggregate
+
+        directory = [
+            {"NCESSCH": "060000100002", "LEAID": "0600001", "STATEFIPS": "06",
+             "SCH_NAME": "Test School", "SCH_TYPE": "1", "SY_STATUS": "1"},
+        ]
+        nonfiscal = [
+            {"NCESSCH": "060000100002", "TOTAL": -1, "FTE": -2, "TOTFRL": 100},
+        ]
+
+        with self._patch_loaders(directory, nonfiscal):
+            call_command("load_nces_schools", f"--vintage={self.vintage.name}", "--state=06", verbosity=0)
+
+        s = NCESSchoolAggregate.objects.get(vintage=self.vintage, geoid="060000100002")
+        assert s.enrollment_total is None
+        assert s.teachers_fte is None
+        assert s.free_lunch_eligible_count == 100
+
+
+class TestLoadSchoolsStateFilter(LoadNCESSchoolsTestBase):
+
+    def test_only_state_rows_written(self):
+        from socialwarehouse.civic.models import NCESSchoolAggregate
+
+        directory = [
+            {"NCESSCH": "060000100001", "LEAID": "0600001", "STATEFIPS": "06",
+             "SCH_NAME": "CA School", "SCH_TYPE": "1", "SY_STATUS": "1"},
+            {"NCESSCH": "480000100001", "LEAID": "4800001", "STATEFIPS": "48",
+             "SCH_NAME": "TX School", "SCH_TYPE": "1", "SY_STATUS": "1"},
+        ]
+        nonfiscal = [
+            {"NCESSCH": "060000100001", "TOTAL": 1500, "FTE": 80},
+            {"NCESSCH": "480000100001", "TOTAL": 2000, "FTE": 100},
+        ]
+
+        with self._patch_loaders(directory, nonfiscal):
+            call_command("load_nces_schools", f"--vintage={self.vintage.name}", "--state=06", verbosity=0)
+
+        rows = NCESSchoolAggregate.objects.filter(vintage=self.vintage)
+        assert rows.count() == 1
+        assert rows.first().geoid == "060000100001"
+
+
+class TestLoadSchoolsCharter(LoadNCESSchoolsTestBase):
+
+    def test_charter_yes(self):
+        from socialwarehouse.civic.models import NCESSchoolAggregate
+
+        directory = [
+            {"NCESSCH": "060000100003", "LEAID": "0600001", "STATEFIPS": "06",
+             "SCH_NAME": "Charter Academy", "SCH_TYPE": "1", "SY_STATUS": "1",
+             "CHARTER_TEXT": "Yes"},
+        ]
+        with self._patch_loaders(directory, []):
+            call_command("load_nces_schools", f"--vintage={self.vintage.name}", "--state=06", verbosity=0)
+        assert NCESSchoolAggregate.objects.get(geoid="060000100003").is_charter is True
+
+
+class TestLoadSchoolsValidation(LoadNCESSchoolsTestBase):
+
+    def test_unknown_vintage_raises(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command("load_nces_schools", "--vintage=NOT-A-VINTAGE", "--state=06", verbosity=0)
+        assert "No NCESSchoolYearVintage" in str(cm.exception)
+
+
+class TestLoadSchoolsDryRun(LoadNCESSchoolsTestBase):
+
+    def test_dry_run_no_writes(self):
+        from socialwarehouse.civic.models import NCESSchoolAggregate
+
+        directory = [
+            {"NCESSCH": "060000100001", "LEAID": "0600001", "STATEFIPS": "06",
+             "SCH_NAME": "X", "SCH_TYPE": "1", "SY_STATUS": "1"},
+        ]
+        before = NCESSchoolAggregate.objects.count()
+        with self._patch_loaders(directory, []):
+            call_command("load_nces_schools", f"--vintage={self.vintage.name}", "--state=06",
+                         "--dry-run", verbosity=0, stdout=StringIO())
+        assert NCESSchoolAggregate.objects.count() == before


### PR DESCRIPTION
Closes the school-level half of F Q2 = (b). NCESSchoolAggregate (per-school per-school-year) + load_nces_schools command + tests. NCESFiles extended with school-level loaders. Logical join NCESSchoolAggregate.leaid -> NCESDistrictAggregate.geoid (no physical FK).

References: F design #210; F Phase 1a #216 (merged); SU#534 (NCESFiles lift, still pending).

## Test plan
- [ ] CI green (mocked NCESFiles)