### PR TITLE
F/SW#194 Phase 1c: NCES EDGE district demographics

### DIFF
--- a/socialwarehouse/civic/management/commands/load_nces_edge.py
+++ b/socialwarehouse/civic/management/commands/load_nces_edge.py
@@ -110,10 +110,14 @@ class Command(BaseCommand):
 
     @staticmethod
     def _extract_demographics(row):
+        # EDGE column names evolve across releases; check both forms.
+        # Use _first to avoid `or` short-circuit treating 0 as missing.
+        child_5_17 = _to_int(_first(row, "CHILD_5_17", "TOT_CHLD"))
+        in_poverty = _to_int(_first(row, "IPR_LT100_5_17", "IPR100_5_17"))
         return {
             "total_population": _to_int(row.get("TOT")),
-            "population_5_17": _to_int(row.get("CHILD_5_17") or row.get("TOT_CHLD")),
-            "population_under_5": _to_int(row.get("CHILD_LT5") or row.get("CHILD_UNDER_5")),
+            "population_5_17": child_5_17,
+            "population_under_5": _to_int(_first(row, "CHILD_LT5", "CHILD_UNDER_5")),
             "pop_5_17_white_nh": _to_int(row.get("WHITE_NH_5_17")),
             "pop_5_17_black_nh": _to_int(row.get("BLACK_NH_5_17")),
             "pop_5_17_asian_nh": _to_int(row.get("ASIAN_NH_5_17")),
@@ -121,18 +125,31 @@ class Command(BaseCommand):
             "pop_5_17_nhpi_nh": _to_int(row.get("NHPI_NH_5_17")),
             "pop_5_17_two_or_more_nh": _to_int(row.get("TWO_NH_5_17")),
             "pop_5_17_hispanic": _to_int(row.get("HISPANIC_5_17")),
-            "pop_5_17_in_poverty": _to_int(row.get("IPR_LT100_5_17") or row.get("IPR100_5_17")),
-            "pop_5_17_poverty_rate": _to_rate(
-                _to_int(row.get("IPR_LT100_5_17") or row.get("IPR100_5_17")),
-                _to_int(row.get("CHILD_5_17") or row.get("TOT_CHLD")),
-            ),
-            "households_total": _to_int(row.get("HH_TOT") or row.get("TOTAL_HH")),
+            "pop_5_17_in_poverty": in_poverty,
+            "pop_5_17_poverty_rate": _to_rate(in_poverty, child_5_17),
+            "households_total": _to_int(_first(row, "HH_TOT", "TOTAL_HH")),
             "households_with_school_age": _to_int(row.get("HH_WITH_CHILDREN")),
-            "median_household_income": _to_int(row.get("MEDIAN_HH_INC") or row.get("MEDIAN_HH_INCOME")),
+            "median_household_income": _to_int(_first(row, "MEDIAN_HH_INC", "MEDIAN_HH_INCOME")),
             "pop_5_17_english_at_home": _to_int(row.get("ENGLISH_5_17")),
             "pop_5_17_other_lang_at_home": _to_int(row.get("OTHER_LANG_5_17")),
             "pop_5_17_foreign_born": _to_int(row.get("FOREIGN_BORN_5_17")),
         }
+
+
+def _first(row, *keys):
+    """Return row[keys[0]] if present (not None / not NaN), else row[keys[1]], etc.
+
+    Distinct from `row.get(a) or row.get(b)` because that treats 0 as
+    missing — 0 is a valid Census count and must not fall through.
+    """
+    for k in keys:
+        v = row.get(k)
+        if v is None:
+            continue
+        if isinstance(v, float) and v != v:  # NaN
+            continue
+        return v
+    return None
 
 
 def _to_int(raw):

--- a/socialwarehouse/civic/management/commands/load_nces_edge.py
+++ b/socialwarehouse/civic/management/commands/load_nces_edge.py
@@ -1,0 +1,156 @@
+"""Load NCES EDGE per-district demographic estimates (Phase 1c).
+
+EDGE re-publishes ACS-derived estimates aggregated to school-district
+boundaries (which ACS itself doesn't directly publish). This command
+loads one EDGE release into NCESDistrictEDGEDemographics rows.
+
+Usage:
+    python manage.py load_nces_edge --vintage 2022-23 --acs-endpoint 2018-22 --state 06
+    python manage.py load_nces_edge --vintage 2022-23 --acs-endpoint 2018-22 --state 06 --dry-run
+
+The school-year vintage anchors the WAREHOUSE side (matching CCD's
+cadence); the --acs-endpoint identifies which ACS 5-year release
+EDGE used as its source.
+"""
+
+import logging
+from decimal import Decimal
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Load NCES EDGE per-district demographic estimates."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--vintage", type=str, required=True,
+            help="NCESSchoolYearVintage name like '2022-23'. The warehouse-side anchor.",
+        )
+        parser.add_argument(
+            "--acs-endpoint", type=str, required=True,
+            help="EDGE source ACS endpoint like '2018-22' (5-year endpoint range).",
+        )
+        parser.add_argument(
+            "--state", type=str, required=True,
+            help="2-digit state FIPS; filters rows to this state.",
+        )
+        parser.add_argument(
+            "--dry-run", action="store_true",
+            help="Fetch + report counts without writing.",
+        )
+
+    def handle(self, *args, **options):
+        from socialwarehouse.civic.models import NCESDistrictEDGEDemographics
+        from socialwarehouse.civic.services.nces_files import NCESFiles
+        from socialwarehouse.geo.models import NCESSchoolYearVintage
+
+        vintage_name = options["vintage"]
+        acs_endpoint = options["acs_endpoint"]
+        state_fips = options["state"]
+        dry_run = options["dry_run"]
+
+        try:
+            vintage = NCESSchoolYearVintage.objects.get(name=vintage_name)
+        except NCESSchoolYearVintage.DoesNotExist:
+            raise CommandError(
+                f"No NCESSchoolYearVintage with name={vintage_name!r}. "
+                f"Available: "
+                f"{list(NCESSchoolYearVintage.objects.values_list('name', flat=True)[:5])}…"
+            )
+
+        self.stdout.write(
+            f"EDGE district demographics vintage={vintage.name} "
+            f"acs_endpoint={acs_endpoint} state={state_fips}"
+        )
+
+        files = NCESFiles()
+        df = files.load_edge_district_demographics(acs_endpoint)
+
+        # State filter — EDGE uses STATEFP or STATEFIPS depending on release.
+        state_col = "STATEFP" if "STATEFP" in df.columns else (
+            "STATEFIPS" if "STATEFIPS" in df.columns else None
+        )
+        if state_col:
+            df = df[df[state_col] == state_fips]
+
+        self.stdout.write(f"Parsed {len(df)} EDGE rows for state {state_fips}.")
+
+        if dry_run:
+            self.stdout.write(self.style.SUCCESS(
+                f"[DRY] would write up to {len(df)} EDGE demographic rows."
+            ))
+            return
+
+        written = 0
+        with transaction.atomic():
+            for _, row in df.iterrows():
+                leaid = str(row.get("LEAID", "")).strip()
+                if not leaid:
+                    continue
+
+                NCESDistrictEDGEDemographics.objects.update_or_create(
+                    vintage=vintage,
+                    geoid=leaid,
+                    defaults={
+                        "boundary_type": "school_district",
+                        "state_fips": str(row.get(state_col, "")) if state_col else "",
+                        "source_acs_endpoint": acs_endpoint,
+                        **self._extract_demographics(row),
+                    },
+                )
+                written += 1
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Wrote {written} EDGE demographic rows for {vintage.name} state={state_fips}."
+        ))
+
+    @staticmethod
+    def _extract_demographics(row):
+        return {
+            "total_population": _to_int(row.get("TOT")),
+            "population_5_17": _to_int(row.get("CHILD_5_17") or row.get("TOT_CHLD")),
+            "population_under_5": _to_int(row.get("CHILD_LT5") or row.get("CHILD_UNDER_5")),
+            "pop_5_17_white_nh": _to_int(row.get("WHITE_NH_5_17")),
+            "pop_5_17_black_nh": _to_int(row.get("BLACK_NH_5_17")),
+            "pop_5_17_asian_nh": _to_int(row.get("ASIAN_NH_5_17")),
+            "pop_5_17_aian_nh": _to_int(row.get("AIAN_NH_5_17")),
+            "pop_5_17_nhpi_nh": _to_int(row.get("NHPI_NH_5_17")),
+            "pop_5_17_two_or_more_nh": _to_int(row.get("TWO_NH_5_17")),
+            "pop_5_17_hispanic": _to_int(row.get("HISPANIC_5_17")),
+            "pop_5_17_in_poverty": _to_int(row.get("IPR_LT100_5_17") or row.get("IPR100_5_17")),
+            "pop_5_17_poverty_rate": _to_rate(
+                _to_int(row.get("IPR_LT100_5_17") or row.get("IPR100_5_17")),
+                _to_int(row.get("CHILD_5_17") or row.get("TOT_CHLD")),
+            ),
+            "households_total": _to_int(row.get("HH_TOT") or row.get("TOTAL_HH")),
+            "households_with_school_age": _to_int(row.get("HH_WITH_CHILDREN")),
+            "median_household_income": _to_int(row.get("MEDIAN_HH_INC") or row.get("MEDIAN_HH_INCOME")),
+            "pop_5_17_english_at_home": _to_int(row.get("ENGLISH_5_17")),
+            "pop_5_17_other_lang_at_home": _to_int(row.get("OTHER_LANG_5_17")),
+            "pop_5_17_foreign_born": _to_int(row.get("FOREIGN_BORN_5_17")),
+        }
+
+
+def _to_int(raw):
+    if raw is None:
+        return None
+    try:
+        if isinstance(raw, float) and raw != raw:
+            return None
+        val = int(Decimal(str(raw)))
+        if val < 0:
+            return None
+        return val
+    except Exception:
+        return None
+
+
+def _to_rate(numerator, denominator):
+    """Compute a 0.0-1.0 rate; None if either component is missing or denom is zero."""
+    if numerator is None or denominator is None or denominator == 0:
+        return None
+    return (Decimal(numerator) / Decimal(denominator)).quantize(Decimal("0.0001"))

--- a/socialwarehouse/civic/migrations/0003_nces_edge_demographics.py
+++ b/socialwarehouse/civic/migrations/0003_nces_edge_demographics.py
@@ -1,0 +1,64 @@
+"""F Phase 1c (SW#194): NCESDistrictEDGEDemographics — per-district ACS-derived estimates."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_civic", "0002_nces_school_aggregate"),
+        ("sw_geo", "0006_c_high_priority_boundary_caches"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="NCESDistrictEDGEDemographics",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("boundary_type", models.CharField(db_index=True, default="school_district", max_length=30)),
+                ("geoid", models.CharField(db_index=True, max_length=7)),
+                ("state_fips", models.CharField(blank=True, db_index=True, default="", max_length=2)),
+                ("source_acs_endpoint", models.CharField(blank=True, default="", max_length=20)),
+                ("total_population", models.PositiveIntegerField(blank=True, null=True)),
+                ("population_5_17", models.PositiveIntegerField(blank=True, null=True)),
+                ("population_under_5", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_white_nh", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_black_nh", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_asian_nh", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_aian_nh", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_nhpi_nh", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_two_or_more_nh", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_hispanic", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_in_poverty", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_poverty_rate", models.DecimalField(blank=True, decimal_places=4, max_digits=6, null=True)),
+                ("households_total", models.PositiveIntegerField(blank=True, null=True)),
+                ("households_with_school_age", models.PositiveIntegerField(blank=True, null=True)),
+                ("median_household_income", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_english_at_home", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_other_lang_at_home", models.PositiveIntegerField(blank=True, null=True)),
+                ("pop_5_17_foreign_born", models.PositiveIntegerField(blank=True, null=True)),
+                (
+                    "vintage",
+                    models.ForeignKey(
+                        limit_choices_to={"kind": "nces-school-year"},
+                        on_delete=models.CASCADE,
+                        related_name="nces_edge_demographics",
+                        to="sw_geo.vintage",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "sw_civic_nces_edge_demographics",
+                "verbose_name": "NCES EDGE District Demographics",
+                "unique_together": {("vintage", "geoid")},
+            },
+        ),
+        migrations.AddIndex(
+            model_name="ncesdistrictedgedemographics",
+            index=models.Index(fields=["boundary_type", "geoid", "vintage"], name="sw_civic_edge_bgv_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="ncesdistrictedgedemographics",
+            index=models.Index(fields=["state_fips", "vintage"], name="sw_civic_edge_sv_idx"),
+        ),
+    ]

--- a/socialwarehouse/civic/models/__init__.py
+++ b/socialwarehouse/civic/models/__init__.py
@@ -1,4 +1,9 @@
 from .nces_district import NCESDistrictAggregate
+from .nces_edge_demographics import NCESDistrictEDGEDemographics
 from .nces_school import NCESSchoolAggregate
 
-__all__ = ["NCESDistrictAggregate", "NCESSchoolAggregate"]
+__all__ = [
+    "NCESDistrictAggregate",
+    "NCESDistrictEDGEDemographics",
+    "NCESSchoolAggregate",
+]

--- a/socialwarehouse/civic/models/nces_edge_demographics.py
+++ b/socialwarehouse/civic/models/nces_edge_demographics.py
@@ -1,0 +1,100 @@
+"""NCES EDGE per-school-district demographic estimates.
+
+Per F design (#210) Q1 = (b) CCD + EDGE both. Phase 1a + 1b shipped
+CCD (district + school aggregates). This is the EDGE half: Census-
+derived per-district demographic snapshots that NCES re-publishes
+on a different release cadence than the warehouse's ACS estimates.
+
+EDGE distributes a per-district summary of ACS estimates for the
+school-age population, computed against district boundaries (which
+ACS itself doesn't directly publish). One row per (vintage, geoid).
+"""
+
+from django.db import models
+
+
+class NCESDistrictEDGEDemographics(models.Model):
+    """One row per LEA per EDGE release; demographics inside district boundaries."""
+
+    vintage = models.ForeignKey(
+        "sw_geo.Vintage",
+        on_delete=models.CASCADE,
+        related_name="nces_edge_demographics",
+        limit_choices_to={"kind": "nces-school-year"},
+        help_text="Polymorphic Vintage parent; should be an NCESSchoolYearVintage row.",
+    )
+    boundary_type = models.CharField(
+        max_length=30, default="school_district", db_index=True,
+    )
+    geoid = models.CharField(
+        max_length=7, db_index=True,
+        help_text="LEAID; joins to NCESDistrictAggregate.geoid.",
+    )
+    state_fips = models.CharField(max_length=2, blank=True, default="", db_index=True)
+
+    # Census-derived source the EDGE release used (e.g. "ACS 2018-2022").
+    source_acs_endpoint = models.CharField(
+        max_length=20, blank=True, default="",
+        help_text="Source ACS 5-year endpoint vintage (e.g. '2018-2022').",
+    )
+
+    # ── Population estimates (within school-district boundary) ───────────
+    total_population = models.PositiveIntegerField(null=True, blank=True)
+    population_5_17 = models.PositiveIntegerField(
+        null=True, blank=True,
+        help_text="School-age population (ages 5-17) within district boundary.",
+    )
+    population_under_5 = models.PositiveIntegerField(null=True, blank=True)
+
+    # ── School-age population by race/ethnicity ──────────────────────────
+    pop_5_17_white_nh = models.PositiveIntegerField(null=True, blank=True)
+    pop_5_17_black_nh = models.PositiveIntegerField(null=True, blank=True)
+    pop_5_17_asian_nh = models.PositiveIntegerField(null=True, blank=True)
+    pop_5_17_aian_nh = models.PositiveIntegerField(
+        null=True, blank=True,
+        help_text="American Indian / Alaska Native, non-Hispanic.",
+    )
+    pop_5_17_nhpi_nh = models.PositiveIntegerField(
+        null=True, blank=True,
+        help_text="Native Hawaiian / Pacific Islander, non-Hispanic.",
+    )
+    pop_5_17_two_or_more_nh = models.PositiveIntegerField(null=True, blank=True)
+    pop_5_17_hispanic = models.PositiveIntegerField(null=True, blank=True)
+
+    # ── School-age poverty ───────────────────────────────────────────────
+    pop_5_17_in_poverty = models.PositiveIntegerField(
+        null=True, blank=True,
+        help_text="School-age (5-17) population with income below poverty.",
+    )
+    pop_5_17_poverty_rate = models.DecimalField(
+        max_digits=6, decimal_places=4, null=True, blank=True,
+        help_text="School-age poverty rate (0.0-1.0).",
+    )
+
+    # ── Households + housing ─────────────────────────────────────────────
+    households_total = models.PositiveIntegerField(null=True, blank=True)
+    households_with_school_age = models.PositiveIntegerField(
+        null=True, blank=True,
+        help_text="Households with at least one child age 5-17.",
+    )
+    median_household_income = models.PositiveIntegerField(null=True, blank=True)
+
+    # ── Language + nativity ──────────────────────────────────────────────
+    pop_5_17_english_at_home = models.PositiveIntegerField(null=True, blank=True)
+    pop_5_17_other_lang_at_home = models.PositiveIntegerField(null=True, blank=True)
+    pop_5_17_foreign_born = models.PositiveIntegerField(null=True, blank=True)
+
+    class Meta:
+        db_table = "sw_civic_nces_edge_demographics"
+        verbose_name = "NCES EDGE District Demographics"
+        unique_together = [["vintage", "geoid"]]
+        indexes = [
+            models.Index(fields=["boundary_type", "geoid", "vintage"]),
+            models.Index(fields=["state_fips", "vintage"]),
+        ]
+
+    def __str__(self):
+        return (
+            f"EDGE demographics {self.geoid} @ {self.vintage.name} "
+            f"(pop_5_17={self.population_5_17})"
+        )

--- a/socialwarehouse/civic/services/nces_files.py
+++ b/socialwarehouse/civic/services/nces_files.py
@@ -62,6 +62,12 @@ CCD_SCHOOL_NONFISCAL_URL = (
     "https://nces.ed.gov/ccd/data/zip/ccd_sch_052_{end_2digit}_l_1a.zip"
 )
 
+# EDGE per-district ACS-derived demographics (Phase 1c).
+# Example: EDGE_ACS_2018-22_DISTRICT.csv
+EDGE_DISTRICT_DEMOGRAPHICS_URL = (
+    "https://nces.ed.gov/programs/edge/data/EDGE_ACS_{acs_endpoint}_DISTRICT.csv"
+)
+
 
 class NCESFiles:
     """Thin wrapper around NCES CCD open data files (Phase 1a)."""
@@ -136,3 +142,26 @@ class NCESFiles:
         url = CCD_SCHOOL_NONFISCAL_URL.format(end_2digit=str(end)[-2:])
         path = self._download_zip(url, f"ccd_sch_nonfiscal_{school_year}")
         return pd.read_csv(path, dtype={"NCESSCH": str, "LEAID": str}, low_memory=False)
+
+    # ── EDGE per-district demographics (Phase 1c) ─────────────────────
+
+    def load_edge_district_demographics(self, acs_endpoint: str) -> pd.DataFrame:
+        """Load EDGE per-school-district demographic estimates.
+
+        `acs_endpoint` is the ACS 5-year endpoint range like "2018-22".
+        Returns a DataFrame with LEAID + the EDGE demographic variables.
+        Unlike CCD files, EDGE is a direct CSV (no zip).
+        """
+        url = EDGE_DISTRICT_DEMOGRAPHICS_URL.format(acs_endpoint=acs_endpoint)
+        cache_name = f"edge_district_{acs_endpoint}"
+        csv_path = self.cache_dir / f"{cache_name}.csv"
+        if not csv_path.exists():
+            logger.info("Downloading EDGE district demographics: %s", url)
+            resp = requests.get(url, timeout=self.timeout)
+            resp.raise_for_status()
+            csv_path.write_bytes(resp.content)
+        return pd.read_csv(
+            csv_path,
+            dtype={"LEAID": str, "STATEFP": str, "STATEFIPS": str},
+            low_memory=False,
+        )

--- a/tests/unit/civic/test_load_nces_edge.py
+++ b/tests/unit/civic/test_load_nces_edge.py
@@ -1,0 +1,166 @@
+"""Tests for F Phase 1c: NCESDistrictEDGEDemographics + load_nces_edge.
+
+Mocks NCESFiles.load_edge_district_demographics. Pins: happy path,
+state filter, poverty rate computation, negative-sentinel handling,
+unknown vintage, dry-run.
+"""
+
+from datetime import date
+from decimal import Decimal
+from io import StringIO
+from unittest.mock import patch
+
+import pandas as pd
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+
+class LoadEDGETestBase(TestCase):
+
+    def setUp(self):
+        from socialwarehouse.geo.models import NCESSchoolYearVintage
+
+        self.vintage = NCESSchoolYearVintage.objects.filter(start_year=2022, end_year=2023).first()
+        if self.vintage is None:
+            self.vintage = NCESSchoolYearVintage.objects.create(
+                start_year=2022, end_year=2023,
+                effective_from=date(2022, 8, 1), effective_to=date(2023, 8, 1),
+            )
+
+
+class TestLoadEDGEHappyPath(LoadEDGETestBase):
+
+    @patch("socialwarehouse.civic.services.nces_files.NCESFiles.load_edge_district_demographics")
+    def test_writes_district_row_with_rate_computed(self, mock_loader):
+        from socialwarehouse.civic.models import NCESDistrictEDGEDemographics
+
+        mock_loader.return_value = pd.DataFrame([
+            {"LEAID": "0600001", "STATEFP": "06",
+             "TOT": 125_000, "CHILD_5_17": 22_500, "CHILD_LT5": 7_500,
+             "WHITE_NH_5_17": 9_000, "BLACK_NH_5_17": 2_500,
+             "ASIAN_NH_5_17": 1_200, "AIAN_NH_5_17": 150,
+             "NHPI_NH_5_17": 90, "TWO_NH_5_17": 1_100,
+             "HISPANIC_5_17": 8_460,
+             "IPR_LT100_5_17": 3_375,  # ~15% poverty
+             "HH_TOT": 45_000, "HH_WITH_CHILDREN": 12_000,
+             "MEDIAN_HH_INC": 78_500,
+             "ENGLISH_5_17": 17_000, "OTHER_LANG_5_17": 5_500,
+             "FOREIGN_BORN_5_17": 1_200},
+        ])
+
+        call_command(
+            "load_nces_edge",
+            f"--vintage={self.vintage.name}",
+            "--acs-endpoint=2018-22",
+            "--state=06",
+            verbosity=0,
+        )
+
+        d = NCESDistrictEDGEDemographics.objects.get(vintage=self.vintage, geoid="0600001")
+        assert d.boundary_type == "school_district"
+        assert d.state_fips == "06"
+        assert d.source_acs_endpoint == "2018-22"
+        assert d.total_population == 125_000
+        assert d.population_5_17 == 22_500
+        assert d.population_under_5 == 7_500
+        assert d.pop_5_17_white_nh == 9_000
+        assert d.pop_5_17_hispanic == 8_460
+        assert d.pop_5_17_in_poverty == 3_375
+        # 3375 / 22500 = 0.15
+        assert d.pop_5_17_poverty_rate == Decimal("0.1500")
+        assert d.median_household_income == 78_500
+
+
+class TestLoadEDGENullsAndZeroDenom(LoadEDGETestBase):
+
+    @patch("socialwarehouse.civic.services.nces_files.NCESFiles.load_edge_district_demographics")
+    def test_poverty_rate_none_when_pop_zero(self, mock_loader):
+        from socialwarehouse.civic.models import NCESDistrictEDGEDemographics
+
+        mock_loader.return_value = pd.DataFrame([
+            {"LEAID": "0600002", "STATEFP": "06",
+             "TOT": 5_000, "CHILD_5_17": 0,
+             "IPR_LT100_5_17": 0},
+        ])
+
+        call_command(
+            "load_nces_edge", f"--vintage={self.vintage.name}",
+            "--acs-endpoint=2018-22", "--state=06", verbosity=0,
+        )
+
+        d = NCESDistrictEDGEDemographics.objects.get(geoid="0600002")
+        assert d.population_5_17 == 0
+        assert d.pop_5_17_in_poverty == 0
+        # Divide-by-zero → None, not exception.
+        assert d.pop_5_17_poverty_rate is None
+
+    @patch("socialwarehouse.civic.services.nces_files.NCESFiles.load_edge_district_demographics")
+    def test_negative_sentinel_becomes_none(self, mock_loader):
+        from socialwarehouse.civic.models import NCESDistrictEDGEDemographics
+
+        mock_loader.return_value = pd.DataFrame([
+            {"LEAID": "0600003", "STATEFP": "06",
+             "TOT": -1, "CHILD_5_17": -9, "MEDIAN_HH_INC": -2},
+        ])
+
+        call_command(
+            "load_nces_edge", f"--vintage={self.vintage.name}",
+            "--acs-endpoint=2018-22", "--state=06", verbosity=0,
+        )
+
+        d = NCESDistrictEDGEDemographics.objects.get(geoid="0600003")
+        assert d.total_population is None
+        assert d.population_5_17 is None
+        assert d.median_household_income is None
+
+
+class TestLoadEDGEStateFilter(LoadEDGETestBase):
+
+    @patch("socialwarehouse.civic.services.nces_files.NCESFiles.load_edge_district_demographics")
+    def test_only_state_rows_written(self, mock_loader):
+        from socialwarehouse.civic.models import NCESDistrictEDGEDemographics
+
+        mock_loader.return_value = pd.DataFrame([
+            {"LEAID": "0600001", "STATEFP": "06", "TOT": 1000, "CHILD_5_17": 100},
+            {"LEAID": "4800001", "STATEFP": "48", "TOT": 2000, "CHILD_5_17": 200},
+        ])
+
+        call_command(
+            "load_nces_edge", f"--vintage={self.vintage.name}",
+            "--acs-endpoint=2018-22", "--state=06", verbosity=0,
+        )
+
+        rows = NCESDistrictEDGEDemographics.objects.filter(vintage=self.vintage)
+        assert rows.count() == 1
+        assert rows.first().geoid == "0600001"
+
+
+class TestLoadEDGEValidation(LoadEDGETestBase):
+
+    def test_unknown_vintage_raises(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command(
+                "load_nces_edge", "--vintage=NOT-A-VINTAGE",
+                "--acs-endpoint=2018-22", "--state=06", verbosity=0,
+            )
+        assert "No NCESSchoolYearVintage" in str(cm.exception)
+
+
+class TestLoadEDGEDryRun(LoadEDGETestBase):
+
+    @patch("socialwarehouse.civic.services.nces_files.NCESFiles.load_edge_district_demographics")
+    def test_dry_run_no_writes(self, mock_loader):
+        from socialwarehouse.civic.models import NCESDistrictEDGEDemographics
+
+        mock_loader.return_value = pd.DataFrame([
+            {"LEAID": "0600001", "STATEFP": "06", "TOT": 1000},
+        ])
+
+        before = NCESDistrictEDGEDemographics.objects.count()
+        call_command(
+            "load_nces_edge", f"--vintage={self.vintage.name}",
+            "--acs-endpoint=2018-22", "--state=06", "--dry-run",
+            verbosity=0, stdout=StringIO(),
+        )
+        assert NCESDistrictEDGEDemographics.objects.count() == before


### PR DESCRIPTION
Closes F Q1 = (b)'s EDGE half. NCESDistrictEDGEDemographics model + load_nces_edge command + NCESFiles.load_edge_district_demographics. Per-district school-age population by race/ethnicity, computed poverty rate, households + median income, language/nativity. Two-key fallback handles EDGE column name evolution.

References: F design #210; F Phase 1a #216 (merged); F Phase 1b #217 (merged); SU#534 (NCESFiles lift, pending).

## Test plan
- [ ] CI green
- [ ] Poverty-rate division-by-zero pinned