### PR TITLE
C/SW#191 medium-priority batch: PUMA, UrbanArea, 7 per-kind special districts

### DIFF
--- a/socialwarehouse/geo/migrations/0007_c_medium_boundary_caches.py
+++ b/socialwarehouse/geo/migrations/0007_c_medium_boundary_caches.py
@@ -1,0 +1,55 @@
+"""Template-readiness C medium-priority batch (SW#191): add cache fields
+for PUMA, UrbanArea, and the 7 per-kind special-district types on
+Address and AddressBoundaryPeriod.
+
+Additive only. The boundary models themselves are tracked upstream
+in SU#535 (UrbanArea already exists; PUMA + 7 special-district kinds
+to be added). These caches don't depend on SU shipping; the geoid
+strings populate once assign_boundaries is updated post-SU.
+
+After this migration, `Address._BOUNDARY_TYPES` includes 9 more
+types so F11 helpers cover them automatically.
+"""
+
+from django.db import migrations, models
+
+
+_NEW_TYPES = [
+    ("puma_geoid", 7),
+    ("urban_area_geoid", 5),
+    ("fire_district_geoid", 10),
+    ("water_district_geoid", 10),
+    ("hospital_district_geoid", 10),
+    ("library_district_geoid", 10),
+    ("cemetery_district_geoid", 10),
+    ("mosquito_district_geoid", 10),
+    ("other_special_district_geoid", 10),
+]
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_geo", "0006_c_high_priority_boundary_caches"),
+    ]
+
+    operations = [
+        # Address: blank-default CharFields.
+        *[
+            migrations.AddField(
+                model_name="address",
+                name=field_name,
+                field=models.CharField(blank=True, default="", max_length=max_len),
+            )
+            for (field_name, max_len) in _NEW_TYPES
+        ],
+        # AddressBoundaryPeriod: nullable CharFields (matches existing ABP convention).
+        *[
+            migrations.AddField(
+                model_name="addressboundaryperiod",
+                name=field_name,
+                field=models.CharField(blank=True, max_length=max_len, null=True),
+            )
+            for (field_name, max_len) in _NEW_TYPES
+        ],
+    ]

--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -203,6 +203,50 @@ class Address(models.Model):
         help_text="NCES Local Education Agency (LEAID); for the district containing this address.",
     )
 
+    # ── Template-readiness C medium-priority batch (SW#191) ──────────────
+    # Per C Q2 = "one model per kind" for special_district. The upstream SU
+    # models are tracked in SU#535; these caches don't depend on SU shipping.
+    puma_geoid = models.CharField(
+        max_length=7, blank=True, default="",
+        help_text="Public Use Microdata Area GEOID (state FIPS + 5-digit PUMA code).",
+    )
+    urban_area_geoid = models.CharField(
+        max_length=5, blank=True, default="",
+        help_text="Census Urban Area GEOID (5-digit).",
+    )
+    fire_district_geoid = models.CharField(
+        max_length=10, blank=True, default="",
+        help_text="Fire protection district GEOID (per Census Special Districts file).",
+    )
+    water_district_geoid = models.CharField(
+        max_length=10, blank=True, default="",
+        help_text="Water supply district GEOID (per Census Special Districts file).",
+    )
+    hospital_district_geoid = models.CharField(
+        max_length=10, blank=True, default="",
+        help_text="Hospital district GEOID (per Census Special Districts file).",
+    )
+    library_district_geoid = models.CharField(
+        max_length=10, blank=True, default="",
+        help_text="Library district GEOID (per Census Special Districts file).",
+    )
+    cemetery_district_geoid = models.CharField(
+        max_length=10, blank=True, default="",
+        help_text="Cemetery district GEOID (per Census Special Districts file).",
+    )
+    mosquito_district_geoid = models.CharField(
+        max_length=10, blank=True, default="",
+        help_text="Mosquito abatement district GEOID (per Census Special Districts file).",
+    )
+    other_special_district_geoid = models.CharField(
+        max_length=10, blank=True, default="",
+        help_text=(
+            "Catch-all 'other' special district GEOID. Addresses can be in multiple "
+            "other-kind districts; this cache holds the most-recent assignment. "
+            "Callers needing the full list use Address.boundary_history(boundary_type='other_special_district')."
+        ),
+    )
+
     census_units_assigned_at = models.DateTimeField(null=True, blank=True)
 
     # ── Address construction timeline (TIGER ADDRFEAT) ──────────────────
@@ -365,6 +409,11 @@ class Address(models.Model):
         "vtd", "cd", "sldl", "sldu",
         # Template-readiness C high-priority batch (SW#191):
         "zcta", "place", "cbsa", "school_district",
+        # Template-readiness C medium-priority batch (SW#191):
+        "puma", "urban_area",
+        "fire_district", "water_district", "hospital_district",
+        "library_district", "cemetery_district", "mosquito_district",
+        "other_special_district",
     )
 
     def boundary_history(self, boundary_type=None):

--- a/socialwarehouse/geo/models/address_boundary.py
+++ b/socialwarehouse/geo/models/address_boundary.py
@@ -92,6 +92,18 @@ class AddressBoundaryPeriod(models.Model):
     cbsa_geoid = models.CharField(max_length=5, null=True, blank=True)
     school_district_geoid = models.CharField(max_length=7, null=True, blank=True)
 
+    # Template-readiness C medium-priority batch (SW#191).
+    # SU#535 tracks the upstream per-kind boundary models.
+    puma_geoid = models.CharField(max_length=7, null=True, blank=True)
+    urban_area_geoid = models.CharField(max_length=5, null=True, blank=True)
+    fire_district_geoid = models.CharField(max_length=10, null=True, blank=True)
+    water_district_geoid = models.CharField(max_length=10, null=True, blank=True)
+    hospital_district_geoid = models.CharField(max_length=10, null=True, blank=True)
+    library_district_geoid = models.CharField(max_length=10, null=True, blank=True)
+    cemetery_district_geoid = models.CharField(max_length=10, null=True, blank=True)
+    mosquito_district_geoid = models.CharField(max_length=10, null=True, blank=True)
+    other_special_district_geoid = models.CharField(max_length=10, null=True, blank=True)
+
     # siege_geo ForeignKeys (optional, for rich queries)
     siege_state = models.ForeignKey(
         "siege_geo.State", on_delete=models.SET_NULL,

--- a/tests/unit/geo/test_c_medium_boundary_types.py
+++ b/tests/unit/geo/test_c_medium_boundary_types.py
@@ -1,0 +1,101 @@
+"""Tests for Template-readiness C medium-priority batch (SW#191):
+Address + ABP carry cache fields for PUMA, UrbanArea, and 7 per-kind
+special districts. Signal-propagation covers them automatically via
+Address._BOUNDARY_TYPES membership.
+"""
+
+from datetime import date
+
+from django.test import TestCase
+
+
+C_MEDIUM_TYPES = [
+    "puma", "urban_area",
+    "fire_district", "water_district", "hospital_district",
+    "library_district", "cemetery_district", "mosquito_district",
+    "other_special_district",
+]
+
+
+class TestAddressCMediumFields(TestCase):
+
+    def test_all_fields_default_empty(self):
+        from socialwarehouse.geo.models import Address
+
+        addr = Address.objects.create(state_abbreviation="CA")
+        for btype in C_MEDIUM_TYPES:
+            assert getattr(addr, f"{btype}_geoid") == ""
+
+    def test_realistic_values_round_trip(self):
+        from socialwarehouse.geo.models import Address
+
+        addr = Address.objects.create(
+            state_abbreviation="CA",
+            puma_geoid="0603701",       # state 06 + PUMA 03701
+            urban_area_geoid="51445",   # Census UA code
+            fire_district_geoid="0612345",
+            water_district_geoid="0654321",
+            hospital_district_geoid="0613579",
+            library_district_geoid="0624680",
+            cemetery_district_geoid="0698765",
+            mosquito_district_geoid="0611111",
+            other_special_district_geoid="0699999",
+        )
+        addr.refresh_from_db()
+        assert addr.puma_geoid == "0603701"
+        assert addr.urban_area_geoid == "51445"
+        assert addr.fire_district_geoid == "0612345"
+        assert addr.water_district_geoid == "0654321"
+        assert addr.hospital_district_geoid == "0613579"
+        assert addr.library_district_geoid == "0624680"
+        assert addr.cemetery_district_geoid == "0698765"
+        assert addr.mosquito_district_geoid == "0611111"
+        assert addr.other_special_district_geoid == "0699999"
+
+
+class TestCMediumBoundaryTypesCoverage(TestCase):
+
+    def test_all_in_boundary_types_tuple(self):
+        from socialwarehouse.geo.models import Address
+
+        for btype in C_MEDIUM_TYPES:
+            assert btype in Address._BOUNDARY_TYPES, f"{btype} missing"
+
+    def test_f11_helpers_recognize_each_type(self):
+        from socialwarehouse.geo.models import Address
+
+        addr = Address.objects.create(state_abbreviation="NY")
+        for btype in C_MEDIUM_TYPES:
+            # All return empty / None for an address with no ABP rows.
+            assert list(addr.boundary_history(boundary_type=btype)) == []
+            assert addr.boundary_on(btype, date(2024, 6, 1)) is None
+            assert addr.geoid_on(btype, date(2024, 6, 1)) is None
+            assert addr.boundary_timeline(btype) == []
+
+
+class TestSignalPropagationCMedium(TestCase):
+
+    def test_signal_updates_c_medium_cache_fields(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod, CensusDecadalVintage,
+        )
+
+        addr = Address.objects.create(state_abbreviation="CA")
+        vintage = CensusDecadalVintage.objects.get(decade=2020)
+
+        AddressBoundaryPeriod.objects.create(
+            address=addr,
+            vintage=vintage,
+            puma_geoid="0603701",
+            fire_district_geoid="0612345",
+            context_date=date(2024, 6, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+
+        addr.refresh_from_db()
+        # vintage_2020 is current; the F11 step-2b signal should refresh the cache.
+        assert addr.puma_geoid == "0603701"
+        assert addr.fire_district_geoid == "0612345"
+        # Unset C-medium fields stay empty.
+        assert addr.water_district_geoid == ""
+        assert addr.library_district_geoid == ""


### PR DESCRIPTION
Closes C-medium per Q1=(b) batched. 9 new cache fields on Address + ABP; F11 helpers cover them automatically via _BOUNDARY_TYPES.

Check-before-blocking applied: UrbanArea exists in SU; PUMA + 7 special-district kinds tracked in SU#535.

References: C design #207; SU#535; initiative #189.

## Test plan
- [ ] CI green (signal-propagation test pins the load-bearing invariant)