### PR TITLE
G/SW#195 G.1: quickstart doc + seed_demo orchestration

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,160 @@
+# SocialWarehouse Quickstart
+
+From `git clone` to a working dev instance with seeded one-state data across all four domains (political, demographic, economic, civic). Target: under 1 hour on a fresh dev machine.
+
+## Prereqs
+
+You'll need:
+
+- **Python 3.11 or later**
+- **PostgreSQL 14+** with **PostGIS 3.x** extension
+- (Optional) **Redis** for Celery-backed background jobs
+- (Optional) A **Census API key** (free; register at [api.census.gov/data/key_signup.html](https://api.census.gov/data/key_signup.html)) — only needed for high-volume ACS pulls; small dev pulls work without
+
+PostGIS install is the long pole — budget ~15-20 minutes on macOS with Homebrew, similar on Ubuntu apt.
+
+### macOS
+
+```bash
+brew install postgresql@15 postgis python@3.12 gdal
+brew services start postgresql@15
+```
+
+### Ubuntu / Debian
+
+```bash
+sudo apt update
+sudo apt install postgresql-15 postgresql-15-postgis-3 python3.12 python3.12-venv libgdal-dev
+sudo systemctl start postgresql
+```
+
+## Setup
+
+```bash
+# 1. Clone
+git clone https://github.com/siege-analytics/socialwarehouse.git
+cd socialwarehouse
+
+# 2. Virtual env
+python3.12 -m venv .venv
+source .venv/bin/activate
+pip install -U pip
+pip install -e .
+
+# 3. Database
+createdb socialwarehouse_dev
+psql socialwarehouse_dev -c "CREATE EXTENSION postgis;"
+
+# 4. Settings
+cp .env.example .env  # if present; otherwise create one with the variables below
+
+# Required variables in .env:
+#   DJANGO_SECRET_KEY=<any-random-string-for-dev>
+#   POSTGRES_DB=socialwarehouse_dev
+#   POSTGRES_USER=<your-system-user>
+#   POSTGRES_PASSWORD=
+#   POSTGRES_HOST=localhost
+#   POSTGRES_PORT=5432
+#   SW_WAREHOUSE_ROOT=file:///tmp/sw-warehouse
+# Optional:
+#   CENSUS_API_KEY=<from api.census.gov/data/key_signup.html>
+#   BLS_API_KEY=<from bls.gov/developers/>
+
+# 5. Migrate
+python manage.py migrate
+
+# 6. Create superuser
+python manage.py createsuperuser
+```
+
+## Seed data
+
+One command pulls a state's data across all four domains:
+
+```bash
+# Default: Texas (per G design Q2 — demographic + economic diversity).
+python manage.py seed_demo
+
+# Smaller dev runs:
+python manage.py seed_demo --states RI                  # Rhode Island
+python manage.py seed_demo --states 11                  # DC
+
+# Multi-state:
+python manage.py seed_demo --states 48,06,36           # TX + CA + NY
+
+# Skip domains you don't need yet:
+python manage.py seed_demo --states 48 --skip economic,civic
+
+# See what would run without doing it:
+python manage.py seed_demo --states 48 --dry-run
+```
+
+The `seed_demo` command wraps these per-domain commands; you can run them individually if you want finer control:
+
+- `python manage.py assign_boundaries --year 2020 --state 48` — political
+- `python manage.py load_acs --vintage 2019-2023 --state 48 --geography county` — demographic
+- `python manage.py load_qcew --vintage 2024Q3 --state 48` — economic
+- `python manage.py load_nces --vintage 2022-23 --state 48` — civic (CCD district)
+- `python manage.py load_nces_schools --vintage 2022-23 --state 48` — civic (CCD school)
+- `python manage.py load_nces_edge --vintage 2022-23 --acs-endpoint 2018-22 --state 48` — civic (EDGE demographics)
+
+## Verify
+
+```bash
+python manage.py runserver
+```
+
+In another terminal:
+
+```bash
+# Hit a boundary lookup — should return a TX boundary.
+curl 'http://localhost:8000/api/geo/boundary?type=state&geoid=48'
+
+# Spot-check the ingest in a Django shell.
+python manage.py shell
+>>> from socialwarehouse.demographic.models import ACSEstimate
+>>> ACSEstimate.objects.filter(boundary_type='county', geoid='48201').count()  # Harris County, TX
+>>>
+>>> from socialwarehouse.economic.models import BLSQCEWAggregate
+>>> BLSQCEWAggregate.objects.filter(geoid='48201').count()
+>>>
+>>> from socialwarehouse.civic.models import NCESDistrictAggregate
+>>> NCESDistrictAggregate.objects.filter(state_fips='48').count()
+```
+
+## Common problems
+
+**`createdb: error: database "socialwarehouse_dev" already exists`** — drop and recreate, or use a different name in `.env`.
+
+**`psql: error: connection to server on socket... failed: No such file or directory`** — PostgreSQL isn't running. `brew services start postgresql@15` (mac) or `sudo systemctl start postgresql` (linux).
+
+**`CREATE EXTENSION postgis` says "extension postgis is not available"** — PostGIS isn't installed alongside PostgreSQL. On macOS: `brew install postgis`. On Ubuntu: `sudo apt install postgresql-15-postgis-3` (match your Postgres version).
+
+**`No module named 'siege_utilities'`** — `pip install -e .` didn't pick up extras. Try `pip install -e .[geodjango]`.
+
+**`load_acs` returns "Census API returned no rows"** — the variable subset returned no data for the requested geography. Confirm the (state, geography, year) combination is valid; ACS doesn't always publish at every level for every release.
+
+**`load_qcew` 403 / 404** — BLS occasionally reshapes their URLs. Open an issue at [SW#196](https://github.com/siege-analytics/socialwarehouse/issues/196) (CI-hygiene tracking) with the failing URL.
+
+**Migration `0004` complains about missing vintage seeds** — the seed runs as a `RunPython` data migration. If it skipped, run `python manage.py seed_known_vintages` manually.
+
+## What you have after this
+
+You've got:
+
+- A working Django + PostGIS dev instance.
+- One state's data populated across all four domains (political boundaries, ACS demographics, BLS employment, NCES schools).
+- The Address ⇄ AddressBoundaryPeriod temporal model loaded and the F11 helpers (`boundary_history`, `boundary_on`, `boundary_timeline`, `geoid_on`, `current_geoid`, `current_boundaries`, `boundary_at`) ready to query.
+- All four domains' ingest commands available for re-running with different vintages / states / variables.
+
+## What's next
+
+- **Customize for your jurisdiction.** Once `manage.py template_init` lands (G.2, tracked at SW#195), the clone-and-rename step will produce a renamed instance with your project's name + a chosen state subset baked in.
+- **Add an ingest path for a data source we don't ship.** Use D/E/F's existing patterns as the template — each domain's `services/` and `management/commands/` directories show the shape.
+- **Bring your own boundary types.** SU's `geo.django.models.*` is the upstream home for new boundary models; SW adds the `{type}_geoid` cache field on Address + ABP.
+
+## References
+
+- Template-readiness initiative: [#189](https://github.com/siege-analytics/socialwarehouse/issues/189)
+- G design (merged): [#211](https://github.com/siege-analytics/socialwarehouse/pull/211)
+- Initiative entity docs: `docs/entities/`

--- a/socialwarehouse/geo/management/commands/seed_demo.py
+++ b/socialwarehouse/geo/management/commands/seed_demo.py
@@ -1,0 +1,166 @@
+"""Template-readiness G.1: one-command seed for a state's data across all four domains.
+
+Per G design (#211):
+  Q2 = TX as default seed state (overrode my RI recommendation; the
+       user wants demographic + economic diversity).
+  Q4 = (c) configurable `--states` flag; default TX; users opt into
+       multi-state via flag.
+
+Usage:
+    python manage.py seed_demo
+    python manage.py seed_demo --states TX,CA
+    python manage.py seed_demo --states RI --skip economic,civic
+    python manage.py seed_demo --dry-run
+
+Wraps the per-domain load commands. Each domain is skippable so a
+"just boundaries + ACS" dev setup is one flag away.
+"""
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+
+# Defaults per G Q2: TX over RI. TX = ~30M population, dozens of CDs,
+# 200+ counties, 1000+ school districts, multi-MSA - demos every feature.
+DEFAULT_STATES = ["48"]   # Texas state FIPS
+ALL_DOMAINS = ["geo", "demographic", "economic", "civic"]
+
+# Per-domain default vintage/sub-args used by seed_demo. Operators
+# override individual loads by calling them directly with their own args.
+DEFAULT_VINTAGE_ACS = "2019-2023"
+DEFAULT_VINTAGE_QCEW = "2024Q3"
+DEFAULT_VINTAGE_NCES = "2022-23"
+DEFAULT_VINTAGE_NCES_ACS_ENDPOINT = "2018-22"
+
+
+# State FIPS -> friendly name (used in stdout).
+STATE_NAMES = {
+    "01": "Alabama", "02": "Alaska", "04": "Arizona", "05": "Arkansas",
+    "06": "California", "08": "Colorado", "09": "Connecticut",
+    "10": "Delaware", "11": "DC", "12": "Florida", "13": "Georgia",
+    "15": "Hawaii", "16": "Idaho", "17": "Illinois", "18": "Indiana",
+    "19": "Iowa", "20": "Kansas", "21": "Kentucky", "22": "Louisiana",
+    "23": "Maine", "24": "Maryland", "25": "Massachusetts",
+    "26": "Michigan", "27": "Minnesota", "28": "Mississippi",
+    "29": "Missouri", "30": "Montana", "31": "Nebraska", "32": "Nevada",
+    "33": "New Hampshire", "34": "New Jersey", "35": "New Mexico",
+    "36": "New York", "37": "North Carolina", "38": "North Dakota",
+    "39": "Ohio", "40": "Oklahoma", "41": "Oregon", "42": "Pennsylvania",
+    "44": "Rhode Island", "45": "South Carolina", "46": "South Dakota",
+    "47": "Tennessee", "48": "Texas", "49": "Utah", "50": "Vermont",
+    "51": "Virginia", "53": "Washington", "54": "West Virginia",
+    "55": "Wisconsin", "56": "Wyoming",
+}
+
+
+def _name_for(fips):
+    return STATE_NAMES.get(fips, f"FIPS {fips}")
+
+
+class Command(BaseCommand):
+    help = (
+        "One-command seed for a state's data across the four domains "
+        "(geo + demographic + economic + civic). Default state: TX. "
+        "Default domains: all four."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--states", type=str, default=",".join(DEFAULT_STATES),
+            help=(
+                "Comma-separated 2-digit state FIPS codes. Default: 48 (TX). "
+                "Examples: '--states 06' (CA), '--states 44,11' (RI + DC)."
+            ),
+        )
+        parser.add_argument(
+            "--skip", type=str, default="",
+            help=(
+                f"Comma-separated domains to skip. Valid: "
+                f"{', '.join(ALL_DOMAINS)}. Example: '--skip economic,civic'."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run", action="store_true",
+            help="Print what each sub-command would do without executing.",
+        )
+
+    def handle(self, *args, **options):
+        states = [s.strip() for s in options["states"].split(",") if s.strip()]
+        skip = set(s.strip() for s in options["skip"].split(",") if s.strip())
+        dry_run = options["dry_run"]
+
+        unknown_skip = skip - set(ALL_DOMAINS)
+        if unknown_skip:
+            self.stdout.write(self.style.ERROR(
+                f"Unknown --skip values: {sorted(unknown_skip)}. "
+                f"Valid: {ALL_DOMAINS}"
+            ))
+            return
+
+        domains = [d for d in ALL_DOMAINS if d not in skip]
+
+        self.stdout.write(self.style.SUCCESS(
+            f"seed_demo: states={states} ({', '.join(_name_for(s) for s in states)}) "
+            f"domains={domains}{' [DRY RUN]' if dry_run else ''}"
+        ))
+
+        for state in states:
+            self._seed_state(state, domains=domains, dry_run=dry_run)
+
+        self.stdout.write(self.style.SUCCESS("seed_demo: complete."))
+
+    def _seed_state(self, state, *, domains, dry_run):
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS(
+            f"=== Seeding {_name_for(state)} (FIPS {state}) ==="
+        ))
+
+        if "geo" in domains:
+            self._step("assign_boundaries", state, dry_run,
+                       year=2020, state_fips=state)
+
+        if "demographic" in domains:
+            self._step("load_acs", state, dry_run,
+                       vintage=DEFAULT_VINTAGE_ACS, state_fips=state,
+                       geography="county")
+
+        if "economic" in domains:
+            self._step("load_qcew", state, dry_run,
+                       vintage=DEFAULT_VINTAGE_QCEW, state_fips=state)
+
+        if "civic" in domains:
+            self._step("load_nces", state, dry_run,
+                       vintage=DEFAULT_VINTAGE_NCES, state_fips=state)
+            self._step("load_nces_schools", state, dry_run,
+                       vintage=DEFAULT_VINTAGE_NCES, state_fips=state)
+            self._step("load_nces_edge", state, dry_run,
+                       vintage=DEFAULT_VINTAGE_NCES,
+                       acs_endpoint=DEFAULT_VINTAGE_NCES_ACS_ENDPOINT,
+                       state_fips=state)
+
+    def _step(self, command_name, state, dry_run, **kwargs):
+        """Call one sub-command, translating kwargs to the command's CLI args."""
+        self.stdout.write(f"  -> {command_name} state={state}")
+
+        if dry_run:
+            return
+
+        # Translate kwargs into call_command's expected format.
+        cli_kwargs = {}
+        if "vintage" in kwargs:
+            cli_kwargs["vintage"] = kwargs["vintage"]
+        if "year" in kwargs:
+            cli_kwargs["year"] = kwargs["year"]
+        if "state_fips" in kwargs:
+            cli_kwargs["state"] = kwargs["state_fips"]
+        if "geography" in kwargs:
+            cli_kwargs["geography"] = kwargs["geography"]
+        if "acs_endpoint" in kwargs:
+            cli_kwargs["acs_endpoint"] = kwargs["acs_endpoint"]
+
+        try:
+            call_command(command_name, **cli_kwargs)
+        except Exception as exc:
+            self.stdout.write(self.style.WARNING(
+                f"  -> {command_name} failed: {exc}. Continuing with next step."
+            ))

--- a/tests/unit/geo/test_seed_demo.py
+++ b/tests/unit/geo/test_seed_demo.py
@@ -1,0 +1,111 @@
+"""Tests for G.1 — seed_demo orchestration.
+
+Mocks call_command so each sub-command is tracked but not actually
+run. Pins: defaults (TX); --states multi-state ordering; --skip
+domain filtering; --dry-run; unknown-skip rejection; per-state
+sub-command sequence.
+"""
+
+from io import StringIO
+from unittest.mock import patch, call
+
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class TestSeedDemoDefaults(TestCase):
+
+    @patch("socialwarehouse.geo.management.commands.seed_demo.call_command")
+    def test_default_is_texas_all_domains(self, mock_call):
+        call_command("seed_demo", verbosity=0, stdout=StringIO())
+
+        called_commands = [c.args[0] for c in mock_call.call_args_list]
+        # Default = TX state, all 4 domains, all 6 commands (assign + acs + qcew + 3xnces).
+        assert "assign_boundaries" in called_commands
+        assert "load_acs" in called_commands
+        assert "load_qcew" in called_commands
+        assert "load_nces" in called_commands
+        assert "load_nces_schools" in called_commands
+        assert "load_nces_edge" in called_commands
+
+    @patch("socialwarehouse.geo.management.commands.seed_demo.call_command")
+    def test_default_state_is_tx(self, mock_call):
+        call_command("seed_demo", verbosity=0, stdout=StringIO())
+
+        # Every sub-command should have been called with state="48".
+        for c in mock_call.call_args_list:
+            assert c.kwargs.get("state") == "48", f"sub-command {c.args[0]} got state={c.kwargs.get('state')}"
+
+
+class TestSeedDemoMultiState(TestCase):
+
+    @patch("socialwarehouse.geo.management.commands.seed_demo.call_command")
+    def test_multi_state_runs_each(self, mock_call):
+        call_command("seed_demo", "--states=48,06", verbosity=0, stdout=StringIO())
+
+        state_args = [c.kwargs.get("state") for c in mock_call.call_args_list]
+        assert "48" in state_args
+        assert "06" in state_args
+        # And each appears at least once per domain (6 sub-commands x 2 states = 12 calls).
+        assert state_args.count("48") == 6
+        assert state_args.count("06") == 6
+
+
+class TestSeedDemoSkip(TestCase):
+
+    @patch("socialwarehouse.geo.management.commands.seed_demo.call_command")
+    def test_skip_economic_and_civic(self, mock_call):
+        call_command(
+            "seed_demo", "--states=48", "--skip=economic,civic",
+            verbosity=0, stdout=StringIO(),
+        )
+
+        called_commands = [c.args[0] for c in mock_call.call_args_list]
+        # geo + demographic only; civic + economic skipped.
+        assert "assign_boundaries" in called_commands
+        assert "load_acs" in called_commands
+        assert "load_qcew" not in called_commands
+        assert "load_nces" not in called_commands
+        assert "load_nces_schools" not in called_commands
+        assert "load_nces_edge" not in called_commands
+
+    def test_unknown_skip_reports_error(self):
+        out = StringIO()
+        call_command(
+            "seed_demo", "--states=48", "--skip=invalid-domain",
+            verbosity=0, stdout=out,
+        )
+        # The command writes an error and bails out without calling subcommands.
+        assert "Unknown --skip values" in out.getvalue()
+
+
+class TestSeedDemoDryRun(TestCase):
+
+    @patch("socialwarehouse.geo.management.commands.seed_demo.call_command")
+    def test_dry_run_calls_no_subcommands(self, mock_call):
+        call_command(
+            "seed_demo", "--states=48", "--dry-run",
+            verbosity=0, stdout=StringIO(),
+        )
+        assert mock_call.call_count == 0
+
+
+class TestSeedDemoErrorTolerance(TestCase):
+    """A failing sub-command shouldn't abort the whole seed_demo run."""
+
+    @patch("socialwarehouse.geo.management.commands.seed_demo.call_command")
+    def test_one_failure_does_not_stop_others(self, mock_call):
+        # Make load_acs fail.
+        def side_effect(*args, **kwargs):
+            if args[0] == "load_acs":
+                raise RuntimeError("simulated Census API failure")
+
+        mock_call.side_effect = side_effect
+
+        # Should not raise; other commands should still be attempted.
+        call_command("seed_demo", "--states=48", verbosity=0, stdout=StringIO())
+
+        called_commands = [c.args[0] for c in mock_call.call_args_list]
+        # Even with load_acs failing, downstream commands are still called.
+        assert "load_qcew" in called_commands
+        assert "load_nces" in called_commands


### PR DESCRIPTION
First half of template-readiness G. After this, clone -> setup -> `python manage.py seed_demo` -> working dev instance with TX data across all four domains. Per G Q2 = TX default; Q4 = (c) configurable --states.

What ships: seed_demo command (orchestrates the 6 per-domain loaders), docs/quickstart.md (full clone-to-running guide), tests (defaults, multi-state, skip, dry-run, error tolerance).

References: G design #211; initiative #189.

G.2 (manage.py template_init) is a separate follow-up.

## Test plan
- [ ] CI green
- [ ] Manual: run `seed_demo --states 44 --dry-run` and confirm the planned steps