### PR TITLE
E/SW#193 Phase 2: QCEW CBSA-level support

### DIFF
--- a/socialwarehouse/economic/management/commands/load_qcew.py
+++ b/socialwarehouse/economic/management/commands/load_qcew.py
@@ -43,6 +43,15 @@ class Command(BaseCommand):
             help="NAICS code length; 2 = sector (default), 3 = subsector, etc.",
         )
         parser.add_argument(
+            "--boundary-type", type=str, default="county",
+            choices=["county", "cbsa", "both"],
+            help=(
+                "Which BLS aggregation levels to load. 'county' (default) keeps "
+                "Phase 1's county-only behavior. 'cbsa' loads MSA-level rows. "
+                "'both' loads county + MSA in one pass."
+            ),
+        )
+        parser.add_argument(
             "--dry-run", action="store_true",
             help="Fetch + report counts without writing.",
         )
@@ -55,6 +64,7 @@ class Command(BaseCommand):
         vintage_name = options["vintage"]
         state_fips = options["state"]
         naics_depth = options["naics_depth"]
+        boundary_type_arg = options["boundary_type"]
         dry_run = options["dry_run"]
 
         # Resolve vintage.
@@ -93,14 +103,16 @@ class Command(BaseCommand):
         written = 0
         with transaction.atomic():
             for _, row in df.iterrows():
-                geoid = str(row["area_fips"])
-                # Phase 1 = county-level only.
-                if len(geoid) != 5:
+                area_fips = str(row["area_fips"])
+                boundary_type, geoid = self._classify_row(area_fips, row.get("agglvl_code"))
+                if boundary_type is None:
+                    continue
+                if boundary_type_arg != "both" and boundary_type != boundary_type_arg:
                     continue
 
                 BLSQCEWAggregate.objects.update_or_create(
                     vintage=vintage,
-                    boundary_type="county",
+                    boundary_type=boundary_type,
                     geoid=geoid,
                     ownership_code=str(row["own_code"]),
                     industry_code=str(row["industry_code"]),
@@ -116,6 +128,34 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS(
             f"Wrote {written} BLSQCEWAggregate rows for {vintage.name} state={state_fips}."
         ))
+
+    @staticmethod
+    def _classify_row(area_fips, agglvl_code):
+        """Classify a QCEW row's boundary_type + geoid.
+
+        BLS convention:
+          - County area_fips: 5 digits, purely numeric (e.g. "06037").
+            agglvl_code starts with '5'.
+          - MSA / CBSA area_fips: "C" prefix + 4 digits (e.g. "C3108"
+            for CBSA 31084 — BLS drops the leading digit). agglvl_code
+            starts with '4'.
+          - National / state / other aggregates: skipped.
+
+        Returns (boundary_type, geoid) or (None, None) to skip.
+        For CBSA rows, the returned geoid is the area_fips as-published
+        ("C3108" etc.) — analysts who want to join against Census CBSA
+        codes can either translate at query time or wait for a future
+        normalization pass.
+        """
+        if not area_fips:
+            return None, None
+        agglvl = str(agglvl_code or "")
+        if agglvl.startswith("5") and len(area_fips) == 5 and area_fips.isdigit():
+            return "county", area_fips
+        if agglvl.startswith("4") and area_fips.startswith("C"):
+            return "cbsa", area_fips
+        # National (agglvl 1x), state (agglvl 2x/3x), or unknown — skip.
+        return None, None
 
     @staticmethod
     def _to_int(raw):

--- a/tests/unit/economic/test_load_qcew.py
+++ b/tests/unit/economic/test_load_qcew.py
@@ -41,13 +41,13 @@ class TestLoadQCEWHappyPath(LoadQCEWTestBase):
         from socialwarehouse.economic.models import BLSQCEWAggregate
 
         mock_load.return_value = self._df([
-            {"area_fips": "06037", "own_code": "5", "industry_code": "10",  # county, private, all-industries total
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5", "industry_code": "10",  # county, private, all-industries total
              "qtrly_estabs": 230_000, "month3_emplvl": 4_125_000,
              "total_qtrly_wages": 87_500_000_000, "avg_wkly_wage": 1_650, "qtr": 3, "year": 2024},
-            {"area_fips": "06037", "own_code": "5", "industry_code": "23",  # construction sector
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5", "industry_code": "23",  # construction sector
              "qtrly_estabs": 18_500, "month3_emplvl": 152_000,
              "total_qtrly_wages": 2_800_000_000, "avg_wkly_wage": 1_420, "qtr": 3, "year": 2024},
-            {"area_fips": "06037", "own_code": "0", "industry_code": "10",  # total covered, all-industries
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "0", "industry_code": "10",  # total covered, all-industries
              "qtrly_estabs": 240_000, "month3_emplvl": 4_400_000,
              "total_qtrly_wages": 90_000_000_000, "avg_wkly_wage": 1_700, "qtr": 3, "year": 2024},
         ])
@@ -80,7 +80,7 @@ class TestLoadQCEWFiltersNonCountyRows(LoadQCEWTestBase):
             {"area_fips": "06", "own_code": "5", "industry_code": "10",  # STATE-level row
              "qtrly_estabs": 0, "month3_emplvl": 0, "total_qtrly_wages": 0, "avg_wkly_wage": 0,
              "qtr": 3, "year": 2024},
-            {"area_fips": "06037", "own_code": "5", "industry_code": "10",
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5", "industry_code": "10",
              "qtrly_estabs": 1, "month3_emplvl": 100, "total_qtrly_wages": 1000, "avg_wkly_wage": 250,
              "qtr": 3, "year": 2024},
         ])
@@ -100,7 +100,7 @@ class TestLoadQCEWIdempotent(LoadQCEWTestBase):
         from socialwarehouse.economic.models import BLSQCEWAggregate
 
         mock_load.return_value = self._df([
-            {"area_fips": "06037", "own_code": "5", "industry_code": "10",
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5", "industry_code": "10",
              "qtrly_estabs": 100, "month3_emplvl": 4_000_000,
              "total_qtrly_wages": 85_000_000_000, "avg_wkly_wage": 1_600,
              "qtr": 3, "year": 2024},
@@ -108,7 +108,7 @@ class TestLoadQCEWIdempotent(LoadQCEWTestBase):
         call_command("load_qcew", f"--vintage={self.vintage.name}", "--state=06", verbosity=0)
 
         mock_load.return_value = self._df([
-            {"area_fips": "06037", "own_code": "5", "industry_code": "10",
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5", "industry_code": "10",
              "qtrly_estabs": 230_000, "month3_emplvl": 4_125_000,
              "total_qtrly_wages": 87_500_000_000, "avg_wkly_wage": 1_650,
              "qtr": 3, "year": 2024},
@@ -118,6 +118,101 @@ class TestLoadQCEWIdempotent(LoadQCEWTestBase):
         rows = BLSQCEWAggregate.objects.filter(geoid="06037", industry_code="10", ownership_code="5")
         assert rows.count() == 1
         assert rows.first().establishment_count == 230_000
+
+
+class TestLoadQCEWBoundaryTypePhase2(LoadQCEWTestBase):
+    """E Phase 2: --boundary-type=cbsa loads MSA-level rows; default
+    stays county-only (Phase 1 backward compat)."""
+
+    @patch("socialwarehouse.economic.services.bls_qcew_files.QCEWFiles.load")
+    def test_default_loads_only_county(self, mock_load):
+        from socialwarehouse.economic.models import BLSQCEWAggregate
+
+        mock_load.return_value = self._df([
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5",
+             "industry_code": "10", "qtrly_estabs": 1, "month3_emplvl": 100,
+             "total_qtrly_wages": 1000, "avg_wkly_wage": 100, "qtr": 3, "year": 2024},
+            {"area_fips": "C3108", "agglvl_code": "40", "own_code": "5",
+             "industry_code": "10", "qtrly_estabs": 10, "month3_emplvl": 10_000,
+             "total_qtrly_wages": 100_000, "avg_wkly_wage": 1500, "qtr": 3, "year": 2024},
+        ])
+        call_command("load_qcew", f"--vintage={self.vintage.name}", "--state=06", verbosity=0)
+
+        rows = BLSQCEWAggregate.objects.filter(vintage=self.vintage)
+        assert rows.count() == 1
+        assert rows.first().boundary_type == "county"
+        assert rows.first().geoid == "06037"
+
+    @patch("socialwarehouse.economic.services.bls_qcew_files.QCEWFiles.load")
+    def test_cbsa_loads_only_msa(self, mock_load):
+        from socialwarehouse.economic.models import BLSQCEWAggregate
+
+        mock_load.return_value = self._df([
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5",
+             "industry_code": "10", "qtrly_estabs": 1, "month3_emplvl": 100,
+             "total_qtrly_wages": 1000, "avg_wkly_wage": 100, "qtr": 3, "year": 2024},
+            {"area_fips": "C3108", "agglvl_code": "40", "own_code": "5",
+             "industry_code": "10", "qtrly_estabs": 10, "month3_emplvl": 10_000,
+             "total_qtrly_wages": 100_000, "avg_wkly_wage": 1500, "qtr": 3, "year": 2024},
+        ])
+        call_command("load_qcew", f"--vintage={self.vintage.name}", "--state=06",
+                     "--boundary-type=cbsa", verbosity=0)
+
+        rows = BLSQCEWAggregate.objects.filter(vintage=self.vintage)
+        assert rows.count() == 1
+        assert rows.first().boundary_type == "cbsa"
+        assert rows.first().geoid == "C3108"
+
+    @patch("socialwarehouse.economic.services.bls_qcew_files.QCEWFiles.load")
+    def test_both_loads_county_and_cbsa(self, mock_load):
+        from socialwarehouse.economic.models import BLSQCEWAggregate
+
+        mock_load.return_value = self._df([
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5",
+             "industry_code": "10", "qtrly_estabs": 1, "month3_emplvl": 100,
+             "total_qtrly_wages": 1000, "avg_wkly_wage": 100, "qtr": 3, "year": 2024},
+            {"area_fips": "C3108", "agglvl_code": "40", "own_code": "5",
+             "industry_code": "10", "qtrly_estabs": 10, "month3_emplvl": 10_000,
+             "total_qtrly_wages": 100_000, "avg_wkly_wage": 1500, "qtr": 3, "year": 2024},
+            {"area_fips": "06000", "agglvl_code": "20", "own_code": "5",
+             "industry_code": "10", "qtrly_estabs": 1000, "month3_emplvl": 1_000_000,
+             "total_qtrly_wages": 10_000_000, "avg_wkly_wage": 2000, "qtr": 3, "year": 2024},
+        ])
+        call_command("load_qcew", f"--vintage={self.vintage.name}", "--state=06",
+                     "--boundary-type=both", verbosity=0)
+
+        rows = BLSQCEWAggregate.objects.filter(vintage=self.vintage)
+        # County + CBSA write; state-level row (agglvl=20) skips.
+        assert rows.count() == 2
+        boundary_types = sorted(r.boundary_type for r in rows)
+        assert boundary_types == ["cbsa", "county"]
+
+
+class TestLoadQCEWClassifyRow(TestCase):
+    """Direct unit tests for the _classify_row helper."""
+
+    def _classify(self, area_fips, agglvl_code):
+        from socialwarehouse.economic.management.commands.load_qcew import Command
+        return Command._classify_row(area_fips, agglvl_code)
+
+    def test_county_5_digit_agglvl_5x(self):
+        assert self._classify("06037", "50") == ("county", "06037")
+        assert self._classify("06037", "54") == ("county", "06037")
+
+    def test_cbsa_c_prefix_agglvl_4x(self):
+        assert self._classify("C3108", "40") == ("cbsa", "C3108")
+        assert self._classify("C3108", "45") == ("cbsa", "C3108")
+
+    def test_state_level_skipped(self):
+        assert self._classify("06000", "20") == (None, None)
+
+    def test_national_skipped(self):
+        assert self._classify("US000", "10") == (None, None)
+
+    def test_missing_agglvl_skipped(self):
+        # A row without agglvl_code can't be classified.
+        assert self._classify("06037", None) == (None, None)
+        assert self._classify("06037", "") == (None, None)
 
 
 class TestLoadQCEWValidation(LoadQCEWTestBase):
@@ -138,7 +233,7 @@ class TestLoadQCEWDryRun(LoadQCEWTestBase):
         from socialwarehouse.economic.models import BLSQCEWAggregate
 
         mock_load.return_value = self._df([
-            {"area_fips": "06037", "own_code": "5", "industry_code": "10",
+            {"area_fips": "06037", "agglvl_code": "50", "own_code": "5", "industry_code": "10",
              "qtrly_estabs": 1, "month3_emplvl": 1, "total_qtrly_wages": 1, "avg_wkly_wage": 1,
              "qtr": 3, "year": 2024},
         ])


### PR DESCRIPTION
Adds --boundary-type=county|cbsa|both to load_qcew. Default stays county (Phase 1 backward compat). Classifier uses BLS agglvl_code (authoritative for aggregate scope), not area_fips parsing.

CBSA rows store BLS's as-published area_fips ('C3108') as geoid; the Census CBSA-code translation is a known asymmetry (follow-up).

## Test plan
- [ ] CI green (5 _classify_row unit tests + 3 --boundary-type integration tests + existing tests retrofitted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * QCEW data loader now supports boundary-type filtering via a new `--boundary-type` command-line option, allowing users to load county-level data, CBSA-level data, or both.

* **Bug Fixes**
  * Improved aggregate classification logic to dynamically determine boundary types instead of relying on hard-coded assumptions, ensuring more accurate data loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->