### PR TITLE
D/SW#192 Phase 3: decennial Census ingest (PL 94-171)

### DIFF
--- a/socialwarehouse/demographic/management/commands/load_decennial.py
+++ b/socialwarehouse/demographic/management/commands/load_decennial.py
@@ -1,0 +1,180 @@
+"""Load decennial Census counts via siege_utilities.geo.census.api.CensusAPI.
+
+Per D Phase 3 — full count, no MOE. Mirrors load_acs but targets
+DecennialCount + DecennialVariable and uses `dec/pl` (or `dec/dhc`) as
+the API dataset.
+
+Usage:
+    python manage.py load_decennial --vintage 2020 --state 06 \\
+        --geography county
+    python manage.py load_decennial --vintage 2020 --state 06 \\
+        --geography tract --dataset pl --variables P1_001N,P2_001N
+"""
+
+import logging
+from decimal import Decimal, InvalidOperation
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+
+logger = logging.getLogger(__name__)
+
+
+GEOGRAPHY_TO_BOUNDARY_TYPE = {
+    "state": "state",
+    "county": "county",
+    "tract": "tract",
+    "block group": "block_group",
+    "block": "block",
+    "place": "place",
+    "zcta": "zcta",
+    "zip code tabulation area": "zcta",
+}
+
+
+class Command(BaseCommand):
+    help = "Load decennial Census counts into DecennialCount via siege_utilities CensusAPI."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--vintage", type=str, required=True,
+            help="Vintage name like '2020'. Must match a CensusDecadalVintage row.")
+        parser.add_argument("--state", type=str, required=True,
+            help="2-digit state FIPS.")
+        parser.add_argument("--geography", type=str, default="county")
+        parser.add_argument("--county", type=str, default=None)
+        parser.add_argument("--dataset", type=str, default="pl",
+            help="Decennial sub-dataset: 'pl' (default) or 'dhc'.")
+        parser.add_argument("--variables", type=str, default=None,
+            help="Comma-separated decennial variable codes; default = all in catalog "
+                 "matching --dataset.")
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **options):
+        from socialwarehouse.demographic.models import DecennialCount, DecennialVariable
+        from socialwarehouse.geo.models import CensusDecadalVintage
+
+        vintage_name = options["vintage"]
+        state_fips = options["state"]
+        geography = options["geography"]
+        county_fips = options["county"]
+        dataset = options["dataset"]
+        variables_arg = options["variables"]
+        dry_run = options["dry_run"]
+
+        try:
+            vintage = CensusDecadalVintage.objects.get(name=vintage_name)
+        except CensusDecadalVintage.DoesNotExist:
+            raise CommandError(
+                f"No CensusDecadalVintage with name={vintage_name!r}. "
+                f"Available: "
+                f"{list(CensusDecadalVintage.objects.values_list('name', flat=True))}"
+            )
+
+        if variables_arg:
+            var_codes = [v.strip() for v in variables_arg.split(",") if v.strip()]
+        else:
+            var_codes = list(
+                DecennialVariable.objects.filter(dataset=dataset)
+                .values_list("variable_code", flat=True).order_by("variable_code")
+            )
+            if not var_codes:
+                raise CommandError(
+                    f"No DecennialVariable rows for dataset={dataset!r}. "
+                    "Run `seed_decennial_variables` first or pass --variables."
+                )
+
+        boundary_type = GEOGRAPHY_TO_BOUNDARY_TYPE.get(
+            geography.lower(), geography.lower().replace(" ", "_")
+        )
+
+        api_dataset = f"dec/{dataset}"
+        self.stdout.write(
+            f"Fetching {api_dataset} year={vintage.year} state={state_fips} "
+            f"geography={geography} variables={len(var_codes)}"
+        )
+
+        df = self._fetch_via_su(
+            variables=var_codes, year=vintage.year, dataset=api_dataset,
+            geography=geography, state_fips=state_fips, county_fips=county_fips,
+        )
+        if df is None or df.empty:
+            self.stdout.write(self.style.WARNING("Census API returned no rows."))
+            return
+
+        self.stdout.write(f"Census returned {len(df)} rows; writing to DecennialCount...")
+
+        if dry_run:
+            self.stdout.write(self.style.SUCCESS(
+                f"[DRY] would write up to {len(df) * len(var_codes)} DecennialCount rows."
+            ))
+            return
+
+        var_lookup = {
+            v.variable_code: v for v in
+            DecennialVariable.objects.filter(variable_code__in=var_codes)
+        }
+        unknown = set(var_codes) - set(var_lookup)
+        if unknown:
+            self.stdout.write(self.style.WARNING(
+                f"Skipping {len(unknown)} unknown variable codes: "
+                f"{sorted(unknown)[:5]}{'...' if len(unknown) > 5 else ''}"
+            ))
+
+        written = 0
+        with transaction.atomic():
+            for _, row in df.iterrows():
+                geoid = row.get("GEOID") or ""
+                if not geoid:
+                    continue
+                for var_code in var_codes:
+                    var = var_lookup.get(var_code)
+                    if var is None:
+                        continue
+                    value, annotation = self._to_int_or_annotation(row.get(var_code))
+                    DecennialCount.objects.update_or_create(
+                        vintage=vintage,
+                        variable=var,
+                        boundary_type=boundary_type,
+                        geoid=geoid,
+                        defaults={"value": value, "annotation": annotation},
+                    )
+                    written += 1
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Wrote {written} DecennialCount rows for vintage={vintage.name} "
+            f"boundary_type={boundary_type} state={state_fips}."
+        ))
+
+    def _fetch_via_su(self, *, variables, year, dataset, geography, state_fips, county_fips):
+        try:
+            from siege_utilities.geo.census import CensusAPI
+        except ImportError as exc:
+            raise CommandError(
+                f"siege_utilities.geo.census.CensusAPI not importable: {exc}."
+            )
+        client = CensusAPI()
+        try:
+            return client.fetch_data(
+                variables=variables, year=year, dataset=dataset,
+                geography=geography, state_fips=state_fips, county_fips=county_fips,
+                include_moe=False,
+            )
+        except Exception as exc:
+            logger.exception("Census API fetch failed: %s", exc)
+            self.stdout.write(self.style.ERROR(f"Census API fetch failed: {exc}"))
+            return None
+
+    @staticmethod
+    def _to_int_or_annotation(raw):
+        if raw is None:
+            return None, ""
+        try:
+            if raw.__class__.__name__ == "float" and raw != raw:
+                return None, ""
+        except Exception:
+            pass
+        try:
+            return int(Decimal(str(raw))), ""
+        except (InvalidOperation, ValueError):
+            return None, str(raw)[:10]

--- a/socialwarehouse/demographic/management/commands/load_decennial.py
+++ b/socialwarehouse/demographic/management/commands/load_decennial.py
@@ -90,12 +90,12 @@ class Command(BaseCommand):
 
         api_dataset = f"dec/{dataset}"
         self.stdout.write(
-            f"Fetching {api_dataset} year={vintage.year} state={state_fips} "
+            f"Fetching {api_dataset} year={vintage.decade} state={state_fips} "
             f"geography={geography} variables={len(var_codes)}"
         )
 
         df = self._fetch_via_su(
-            variables=var_codes, year=vintage.year, dataset=api_dataset,
+            variables=var_codes, year=vintage.decade, dataset=api_dataset,
             geography=geography, state_fips=state_fips, county_fips=county_fips,
         )
         if df is None or df.empty:

--- a/socialwarehouse/demographic/management/commands/seed_decennial_variables.py
+++ b/socialwarehouse/demographic/management/commands/seed_decennial_variables.py
@@ -1,0 +1,74 @@
+"""Seed the curated PL 94-171 (redistricting) decennial variable catalog.
+
+Per D Phase 3, ship a small subset of the PL file that's the most-asked-for
+in electoral contexts. The DHC follow-up will fold in additional curated
+DHC variables later.
+
+Idempotent. Rerunnable.
+"""
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+
+# (variable_code, table_code, concept, label, universe, dataset)
+CURATED_VARIABLES = [
+    ("P1_001N", "P1", "RACE", "Total:", "Total population", "pl"),
+    ("P1_003N", "P1", "RACE", "Total:!!Population of one race:!!White alone",
+     "Total population", "pl"),
+    ("P1_004N", "P1", "RACE",
+     "Total:!!Population of one race:!!Black or African American alone",
+     "Total population", "pl"),
+    ("P1_005N", "P1", "RACE",
+     "Total:!!Population of one race:!!American Indian and Alaska Native alone",
+     "Total population", "pl"),
+    ("P1_006N", "P1", "RACE", "Total:!!Population of one race:!!Asian alone",
+     "Total population", "pl"),
+    ("P2_001N", "P2", "HISPANIC OR LATINO, AND NOT HISPANIC OR LATINO BY RACE",
+     "Total:", "Total population", "pl"),
+    ("P2_002N", "P2", "HISPANIC OR LATINO, AND NOT HISPANIC OR LATINO BY RACE",
+     "Total:!!Hispanic or Latino", "Total population", "pl"),
+    ("P2_005N", "P2", "HISPANIC OR LATINO, AND NOT HISPANIC OR LATINO BY RACE",
+     "Total:!!Not Hispanic or Latino:!!Population of one race:!!White alone",
+     "Total population", "pl"),
+    ("P3_001N", "P3", "RACE FOR THE POPULATION 18 YEARS AND OVER",
+     "Total:", "Population 18 years and over", "pl"),
+    ("P4_001N", "P4",
+     "HISPANIC OR LATINO, AND NOT HISPANIC OR LATINO BY RACE "
+     "FOR THE POPULATION 18 YEARS AND OVER",
+     "Total:", "Population 18 years and over", "pl"),
+    ("H1_001N", "H1", "OCCUPANCY STATUS", "Total:", "Housing units", "pl"),
+    ("H1_002N", "H1", "OCCUPANCY STATUS", "Total:!!Occupied",
+     "Housing units", "pl"),
+    ("H1_003N", "H1", "OCCUPANCY STATUS", "Total:!!Vacant",
+     "Housing units", "pl"),
+]
+
+
+class Command(BaseCommand):
+    help = "Seed the curated PL 94-171 decennial variable catalog."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **options):
+        from socialwarehouse.demographic.models import DecennialVariable
+
+        dry_run = options["dry_run"]
+        created = 0
+        with transaction.atomic():
+            for (code, table, concept, label, universe, dataset) in CURATED_VARIABLES:
+                if DecennialVariable.objects.filter(variable_code=code).exists():
+                    continue
+                if not dry_run:
+                    DecennialVariable.objects.create(
+                        variable_code=code, table_code=table,
+                        concept=concept, label=label,
+                        universe=universe, dataset=dataset,
+                    )
+                created += 1
+            if dry_run:
+                transaction.set_rollback(True)
+
+        verb = "Would create" if dry_run else "Created"
+        self.stdout.write(self.style.SUCCESS(f"{verb} {created} decennial variables."))

--- a/socialwarehouse/demographic/migrations/0002_decennial.py
+++ b/socialwarehouse/demographic/migrations/0002_decennial.py
@@ -1,0 +1,79 @@
+"""D Phase 3 (SW#192): DecennialVariable + DecennialCount.
+
+Adds the PL 94-171 redistricting variable catalog and the long-format
+count table. Seeds the curated PL catalog as part of the migration so
+load_decennial can run immediately after migrate.
+"""
+
+from django.db import migrations, models
+
+
+def _run_seed(apps, schema_editor):
+    from django.core.management import call_command
+    call_command("seed_decennial_variables", verbosity=0)
+
+
+def _reverse_seed(apps, schema_editor):
+    DecennialVariable = apps.get_model("sw_demographic", "DecennialVariable")
+    DecennialVariable.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_demographic", "0001_initial"),
+        ("sw_geo", "0007_c_medium_boundary_caches"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DecennialVariable",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("variable_code", models.CharField(db_index=True, max_length=20, unique=True)),
+                ("label", models.TextField()),
+                ("concept", models.CharField(blank=True, default="", max_length=255)),
+                ("table_code", models.CharField(db_index=True, max_length=20)),
+                ("universe", models.CharField(blank=True, default="", max_length=255)),
+                ("dataset", models.CharField(db_index=True, max_length=20)),
+            ],
+            options={
+                "db_table": "sw_demographic_decennial_variable",
+                "verbose_name": "Decennial Variable",
+                "ordering": ["table_code", "variable_code"],
+            },
+        ),
+        migrations.CreateModel(
+            name="DecennialCount",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("boundary_type", models.CharField(db_index=True, max_length=30)),
+                ("geoid", models.CharField(db_index=True, max_length=20)),
+                ("value", models.BigIntegerField(blank=True, null=True)),
+                ("annotation", models.CharField(blank=True, default="", max_length=10)),
+                ("variable", models.ForeignKey(
+                    on_delete=models.deletion.CASCADE,
+                    related_name="counts",
+                    to="sw_demographic.decennialvariable",
+                )),
+                ("vintage", models.ForeignKey(
+                    limit_choices_to={"kind": "census-decadal"},
+                    on_delete=models.deletion.CASCADE,
+                    related_name="decennial_counts",
+                    to="sw_geo.vintage",
+                )),
+            ],
+            options={
+                "db_table": "sw_demographic_decennial_count",
+                "verbose_name": "Decennial Count",
+                "unique_together": {("vintage", "variable", "boundary_type", "geoid")},
+                "indexes": [
+                    models.Index(fields=["boundary_type", "geoid", "vintage"],
+                                 name="sw_dem_dec_bnd_geo_vnt_idx"),
+                    models.Index(fields=["variable", "vintage", "boundary_type"],
+                                 name="sw_dem_dec_var_vnt_bnd_idx"),
+                ],
+            },
+        ),
+        migrations.RunPython(_run_seed, _reverse_seed),
+    ]

--- a/socialwarehouse/demographic/models/__init__.py
+++ b/socialwarehouse/demographic/models/__init__.py
@@ -1,4 +1,5 @@
 from .acs_variable import ACSVariable
 from .acs_estimate import ACSEstimate
+from .decennial import DecennialVariable, DecennialCount
 
-__all__ = ["ACSVariable", "ACSEstimate"]
+__all__ = ["ACSVariable", "ACSEstimate", "DecennialVariable", "DecennialCount"]

--- a/socialwarehouse/demographic/models/decennial.py
+++ b/socialwarehouse/demographic/models/decennial.py
@@ -1,0 +1,92 @@
+"""Decennial Census per-boundary per-vintage per-variable value.
+
+Per D design (#208) Phase 3: decennial Census tables. Same long-format
+keying as ACSEstimate ((vintage, variable, boundary_type, geoid)), but
+decennial is a full count (no MOE).
+
+Phase 3a ships the PL 94-171 (redistricting data) variables — a small
+curated subset that's the most-asked-for in electoral contexts. The
+broader DHC (Demographic and Housing Characteristics) file is a
+follow-up.
+"""
+
+from django.db import models
+
+
+class DecennialVariable(models.Model):
+    """Decennial Census variable catalog.
+
+    Decennial variable codes are different from ACS (P/H prefixes
+    instead of B). E.g., P1_001N = total population in 2020 PL.
+    """
+
+    variable_code = models.CharField(
+        max_length=20, unique=True, db_index=True,
+        help_text="Decennial variable code, e.g. 'P1_001N' (2020 PL total population).",
+    )
+    label = models.TextField()
+    concept = models.CharField(max_length=255, blank=True, default="")
+    table_code = models.CharField(
+        max_length=20, db_index=True,
+        help_text="Table prefix, e.g. 'P1', 'P2', 'H1'.",
+    )
+    universe = models.CharField(max_length=255, blank=True, default="")
+    dataset = models.CharField(
+        max_length=20, db_index=True,
+        help_text="Decennial dataset: 'pl' (redistricting), 'dhc', etc.",
+    )
+
+    class Meta:
+        db_table = "sw_demographic_decennial_variable"
+        verbose_name = "Decennial Variable"
+        ordering = ["table_code", "variable_code"]
+
+    def __str__(self):
+        return f"{self.variable_code}: {self.concept or self.label[:60]}"
+
+
+class DecennialCount(models.Model):
+    """One row per (vintage, variable, boundary_type, geoid). Full count;
+    no MOE.
+
+    Vintage FK targets the polymorphic Vintage parent with
+    limit_choices_to={"kind": "census-decadal"}.
+    """
+
+    vintage = models.ForeignKey(
+        "sw_geo.Vintage",
+        on_delete=models.CASCADE,
+        related_name="decennial_counts",
+        limit_choices_to={"kind": "census-decadal"},
+        help_text="Polymorphic Vintage parent; should be a CensusDecadalVintage row.",
+    )
+    variable = models.ForeignKey(
+        "sw_demographic.DecennialVariable",
+        on_delete=models.CASCADE,
+        related_name="counts",
+    )
+    boundary_type = models.CharField(max_length=30, db_index=True)
+    geoid = models.CharField(max_length=20, db_index=True)
+    value = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Count value. NULL means Census annotation (suppressed, etc.).",
+    )
+    annotation = models.CharField(
+        max_length=10, blank=True, default="",
+        help_text="Census annotation for non-numeric values.",
+    )
+
+    class Meta:
+        db_table = "sw_demographic_decennial_count"
+        verbose_name = "Decennial Count"
+        unique_together = [["vintage", "variable", "boundary_type", "geoid"]]
+        indexes = [
+            models.Index(fields=["boundary_type", "geoid", "vintage"]),
+            models.Index(fields=["variable", "vintage", "boundary_type"]),
+        ]
+
+    def __str__(self):
+        return (
+            f"{self.variable.variable_code} @ {self.boundary_type}:{self.geoid} "
+            f"({self.vintage.name}) = {self.value}"
+        )

--- a/tests/unit/demographic/test_load_decennial.py
+++ b/tests/unit/demographic/test_load_decennial.py
@@ -24,11 +24,11 @@ class LoadDecennialTestBase(TestCase):
         from socialwarehouse.demographic.models import DecennialVariable
         from socialwarehouse.geo.models import CensusDecadalVintage
 
-        self.vintage = CensusDecadalVintage.objects.filter(year=2020).first()
+        self.vintage = CensusDecadalVintage.objects.filter(decade=2020).first()
         if self.vintage is None:
             from datetime import date
             self.vintage = CensusDecadalVintage.objects.create(
-                year=2020,
+                decade=2020,
                 effective_from=date(2020, 4, 1),
                 effective_to=date(2030, 4, 1),
             )

--- a/tests/unit/demographic/test_load_decennial.py
+++ b/tests/unit/demographic/test_load_decennial.py
@@ -1,0 +1,176 @@
+"""Tests for D Phase 3 (SW#192): load_decennial.
+
+Mocks siege_utilities.geo.census.CensusAPI. Pins:
+- Default-variables path (uses curated PL catalog when --variables omitted)
+- Happy-path row-to-DecennialCount conversion
+- Jam-value annotation
+- update_or_create idempotency
+- Unknown-vintage CommandError
+- --dry-run no-write
+"""
+
+from io import StringIO
+from unittest.mock import patch, MagicMock
+
+import pandas as pd
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+
+class LoadDecennialTestBase(TestCase):
+
+    def setUp(self):
+        from socialwarehouse.demographic.models import DecennialVariable
+        from socialwarehouse.geo.models import CensusDecadalVintage
+
+        self.vintage = CensusDecadalVintage.objects.filter(year=2020).first()
+        if self.vintage is None:
+            from datetime import date
+            self.vintage = CensusDecadalVintage.objects.create(
+                year=2020,
+                effective_from=date(2020, 4, 1),
+                effective_to=date(2030, 4, 1),
+            )
+        self.var_total = DecennialVariable.objects.get(variable_code="P1_001N")
+        self.var_white = DecennialVariable.objects.get(variable_code="P1_003N")
+
+    def _df(self, rows):
+        return pd.DataFrame(rows)
+
+
+class TestLoadDecennialHappyPath(LoadDecennialTestBase):
+
+    @patch("siege_utilities.geo.census.CensusAPI")
+    def test_writes_count_per_row_per_variable(self, mock_api_class):
+        from socialwarehouse.demographic.models import DecennialCount
+
+        mock_api = MagicMock()
+        mock_api.fetch_data.return_value = self._df([
+            {"GEOID": "06037", "NAME": "Los Angeles County",
+             "P1_001N": "10014009", "P1_003N": "2616720"},
+            {"GEOID": "06075", "NAME": "San Francisco County",
+             "P1_001N": "873965", "P1_003N": "354935"},
+        ])
+        mock_api_class.return_value = mock_api
+
+        call_command(
+            "load_decennial",
+            f"--vintage={self.vintage.name}",
+            "--state=06", "--geography=county",
+            "--variables=P1_001N,P1_003N",
+            verbosity=0,
+        )
+
+        rows = DecennialCount.objects.filter(vintage=self.vintage)
+        assert rows.count() == 4
+        la_total = rows.get(variable=self.var_total, geoid="06037")
+        assert la_total.value == 10014009
+        assert la_total.annotation == ""
+        sf_white = rows.get(variable=self.var_white, geoid="06075")
+        assert sf_white.value == 354935
+
+
+class TestLoadDecennialAnnotations(LoadDecennialTestBase):
+
+    @patch("siege_utilities.geo.census.CensusAPI")
+    def test_jam_value_stored_in_annotation(self, mock_api_class):
+        from socialwarehouse.demographic.models import DecennialCount
+
+        mock_api = MagicMock()
+        mock_api.fetch_data.return_value = self._df([
+            {"GEOID": "06037", "P1_001N": "*"},
+        ])
+        mock_api_class.return_value = mock_api
+
+        call_command(
+            "load_decennial", f"--vintage={self.vintage.name}",
+            "--state=06", "--geography=county", "--variables=P1_001N",
+            verbosity=0,
+        )
+
+        c = DecennialCount.objects.get(variable=self.var_total, geoid="06037")
+        assert c.value is None
+        assert c.annotation == "*"
+
+
+class TestLoadDecennialDefaultVariables(LoadDecennialTestBase):
+
+    @patch("siege_utilities.geo.census.CensusAPI")
+    def test_default_uses_pl_catalog(self, mock_api_class):
+        from socialwarehouse.demographic.models import DecennialVariable
+
+        mock_api = MagicMock()
+        mock_api.fetch_data.return_value = self._df([{"GEOID": "06"}])
+        mock_api_class.return_value = mock_api
+
+        call_command(
+            "load_decennial", f"--vintage={self.vintage.name}",
+            "--state=06", "--geography=state", verbosity=0,
+        )
+
+        called = mock_api.fetch_data.call_args.kwargs["variables"]
+        pl_codes = set(
+            DecennialVariable.objects.filter(dataset="pl")
+            .values_list("variable_code", flat=True)
+        )
+        assert set(called) == pl_codes
+        # PL dataset is requested by full path, not just 'pl'.
+        assert mock_api.fetch_data.call_args.kwargs["dataset"] == "dec/pl"
+
+
+class TestLoadDecennialIdempotent(LoadDecennialTestBase):
+
+    @patch("siege_utilities.geo.census.CensusAPI")
+    def test_rerun_overwrites(self, mock_api_class):
+        from socialwarehouse.demographic.models import DecennialCount
+
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+
+        mock_api.fetch_data.return_value = self._df([
+            {"GEOID": "06037", "P1_001N": "10000000"},
+        ])
+        call_command("load_decennial", f"--vintage={self.vintage.name}",
+                     "--state=06", "--geography=county",
+                     "--variables=P1_001N", verbosity=0)
+
+        mock_api.fetch_data.return_value = self._df([
+            {"GEOID": "06037", "P1_001N": "10014009"},
+        ])
+        call_command("load_decennial", f"--vintage={self.vintage.name}",
+                     "--state=06", "--geography=county",
+                     "--variables=P1_001N", verbosity=0)
+
+        rows = DecennialCount.objects.filter(variable=self.var_total, geoid="06037")
+        assert rows.count() == 1
+        assert rows.first().value == 10014009
+
+
+class TestLoadDecennialValidation(LoadDecennialTestBase):
+
+    def test_unknown_vintage_raises(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command("load_decennial", "--vintage=NOT-A-VINTAGE",
+                         "--state=06", "--geography=county", verbosity=0)
+        assert "No CensusDecadalVintage" in str(cm.exception)
+
+
+class TestLoadDecennialDryRun(LoadDecennialTestBase):
+
+    @patch("siege_utilities.geo.census.CensusAPI")
+    def test_dry_run_no_writes(self, mock_api_class):
+        from socialwarehouse.demographic.models import DecennialCount
+
+        mock_api = MagicMock()
+        mock_api.fetch_data.return_value = self._df([
+            {"GEOID": "06037", "P1_001N": "10014009"},
+        ])
+        mock_api_class.return_value = mock_api
+
+        before = DecennialCount.objects.count()
+        call_command("load_decennial", f"--vintage={self.vintage.name}",
+                     "--state=06", "--geography=county",
+                     "--variables=P1_001N", "--dry-run",
+                     verbosity=0, stdout=StringIO())
+        assert DecennialCount.objects.count() == before


### PR DESCRIPTION
## Summary

D Phase 3 of the template-readiness initiative: decennial Census ingest using the PL 94-171 redistricting file. Mirrors ACS Phase 1 but drops MOE (full count) and adds a `dataset` discriminator (`pl` / `dhc`).

- `DecennialVariable` + `DecennialCount` models, long-format keyed on `(vintage, variable, boundary_type, geoid)` — same shape as `ACSEstimate` so cross-domain queries stay consistent.
- `seed_decennial_variables` ships a curated PL subset (P1/P2/P3/P4 totals + race breakdowns, H1 housing) — the most-asked-for in electoral contexts. DHC is a follow-up.
- `load_decennial` uses `siege_utilities.geo.census.CensusAPI` with `dataset='dec/pl'`. `update_or_create` keeps re-runs idempotent.
- Migration `0002_decennial` hand-written (no local Django runtime) cross-checked against `0001_initial`.
- Tests mirror `test_load_acs.py` test classes 1:1.

## Test plan
- [ ] CI green
- [ ] Migration applies cleanly on fresh DB
- [ ] `python manage.py seed_decennial_variables` is idempotent
- [ ] `load_decennial --dry-run` writes nothing