### PR TITLE
E/SW#193 Phase 3: IRS SOI ZIP-code ingest

### DIFF
--- a/socialwarehouse/economic/management/commands/load_irs_soi.py
+++ b/socialwarehouse/economic/management/commands/load_irs_soi.py
@@ -1,0 +1,157 @@
+"""Load IRS SOI ZIP-code aggregates into IRSSOIAggregate.
+
+Per E Phase 3. Files-only (no API key). Bucket model is per-vintage
+(see seed_irs_soi_buckets). Idempotent via update_or_create on
+(vintage, boundary_type='zcta', geoid, agi_bin).
+
+Usage:
+    python manage.py load_irs_soi --vintage TY2022 --state-abbrev CA
+    python manage.py load_irs_soi --vintage TY2022 --state-abbrev CA --dry-run
+"""
+
+import logging
+from decimal import Decimal, InvalidOperation
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+
+logger = logging.getLogger(__name__)
+
+
+# IRS SOI columns we ingest. Map: model field -> IRS column candidates
+# (tuple; first non-null wins, handles year-over-year header drift).
+FIELD_MAP = {
+    "return_count":         ("N1",),
+    "exemption_count":      ("N2", "NUMDEP"),
+    "agi_total":            ("A00100",),
+    "taxable_income_total": ("A04800",),
+    "total_tax_total":      ("A06500",),
+}
+
+
+class Command(BaseCommand):
+    help = "Load IRS SOI per-ZCTA aggregates via the files-only helper."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--vintage", type=str, required=True,
+            help="IRSSOIVintage name, e.g. 'TY2022'.")
+        parser.add_argument("--state-abbrev", type=str, required=True,
+            help="2-letter state abbreviation (e.g., 'CA').")
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **options):
+        from socialwarehouse.economic.models import (
+            IRSSOIAggregate, IRSSOIIncomeBucket,
+        )
+        from socialwarehouse.economic.services.irs_soi_files import IRSSOIFiles
+        from socialwarehouse.geo.models import IRSSOIVintage
+
+        vintage_name = options["vintage"]
+        state_abbrev = options["state_abbrev"]
+        dry_run = options["dry_run"]
+
+        try:
+            vintage = IRSSOIVintage.objects.get(name=vintage_name)
+        except IRSSOIVintage.DoesNotExist:
+            raise CommandError(
+                f"No IRSSOIVintage with name={vintage_name!r}."
+            )
+
+        bucket_lookup = {
+            b.bucket_code: b for b in
+            IRSSOIIncomeBucket.objects.filter(vintage=vintage)
+        }
+        if not bucket_lookup:
+            raise CommandError(
+                f"No IRSSOIIncomeBucket rows for vintage={vintage.name}. "
+                "Run `seed_irs_soi_buckets --vintage=...` first."
+            )
+
+        self.stdout.write(
+            f"SOI vintage={vintage.name} tax_year={vintage.tax_year} "
+            f"state={state_abbrev}"
+        )
+
+        files = IRSSOIFiles()
+        df = files.load(tax_year=vintage.tax_year, state_abbrev=state_abbrev)
+        if df.empty:
+            self.stdout.write(self.style.WARNING("IRS parse returned no rows."))
+            return
+
+        self.stdout.write(f"Parsed {len(df)} SOI rows; writing to IRSSOIAggregate...")
+
+        if dry_run:
+            self.stdout.write(self.style.SUCCESS(
+                f"[DRY] would write up to {len(df)} IRSSOIAggregate rows."
+            ))
+            return
+
+        written = 0
+        skipped_total = 0
+        with transaction.atomic():
+            for _, row in df.iterrows():
+                zipcode = self._zip(row)
+                if not zipcode:
+                    continue
+                bucket_code = self._int(row.get("agi_stub"))
+                # bucket_code 0 = totals row (across all buckets); skip,
+                # the warehouse holds per-bucket only.
+                if bucket_code in (0, None):
+                    skipped_total += 1
+                    continue
+                bucket = bucket_lookup.get(bucket_code)
+                if bucket is None:
+                    continue
+
+                defaults = {}
+                for model_field, candidates in FIELD_MAP.items():
+                    defaults[model_field] = self._first_int(row, candidates)
+
+                IRSSOIAggregate.objects.update_or_create(
+                    vintage=vintage,
+                    boundary_type="zcta",
+                    geoid=zipcode,
+                    agi_bin=bucket,
+                    defaults=defaults,
+                )
+                written += 1
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Wrote {written} IRSSOIAggregate rows for {vintage.name} "
+            f"state={state_abbrev}. Skipped {skipped_total} totals rows."
+        ))
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _zip(row):
+        raw = row.get("zipcode") or row.get("ZIPCODE") or row.get("zip_code")
+        if raw is None:
+            return ""
+        s = str(int(raw)) if not isinstance(raw, str) else raw.strip()
+        # IRS files sometimes use "00000" for state-rollup. Skip.
+        if not s or s == "00000":
+            return ""
+        return s.zfill(5)
+
+    @staticmethod
+    def _int(raw):
+        if raw is None:
+            return None
+        try:
+            if raw.__class__.__name__ == "float" and raw != raw:
+                return None
+        except Exception:
+            pass
+        try:
+            return int(Decimal(str(raw)))
+        except (InvalidOperation, ValueError):
+            return None
+
+    @classmethod
+    def _first_int(cls, row, candidates):
+        for col in candidates:
+            v = cls._int(row.get(col))
+            if v is not None:
+                return v
+        return None

--- a/socialwarehouse/economic/management/commands/seed_irs_soi_buckets.py
+++ b/socialwarehouse/economic/management/commands/seed_irs_soi_buckets.py
@@ -1,0 +1,66 @@
+"""Seed the standard 6 IRS SOI AGI buckets for an IRSSOIVintage.
+
+Per E Q3 = (a), buckets are vintage-scoped. This command seeds the
+standard 6-bin layout used for recent SOI releases (TY2019+). For
+older / future vintages with different bin boundaries, pass
+--bucket-spec to override.
+
+Idempotent per (vintage, bucket_code).
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+
+# IRS SOI standard 6-bucket layout (TY2019+). (code, label, lower, upper).
+# Open-ended bounds use None.
+STANDARD_BUCKETS = [
+    (1, "Under $25,000",                       None,    25_000),
+    (2, "$25,000 under $50,000",            25_000,    50_000),
+    (3, "$50,000 under $75,000",            50_000,    75_000),
+    (4, "$75,000 under $100,000",           75_000,   100_000),
+    (5, "$100,000 under $200,000",         100_000,   200_000),
+    (6, "$200,000 or more",                200_000,      None),
+]
+
+
+class Command(BaseCommand):
+    help = "Seed standard IRS SOI AGI buckets for a given IRSSOIVintage."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--vintage", type=str, required=True,
+            help="IRSSOIVintage name, e.g. 'TY2022'.")
+        parser.add_argument("--dry-run", action="store_true")
+
+    def handle(self, *args, **options):
+        from socialwarehouse.economic.models import IRSSOIIncomeBucket
+        from socialwarehouse.geo.models import IRSSOIVintage
+
+        vintage_name = options["vintage"]
+        dry_run = options["dry_run"]
+
+        try:
+            vintage = IRSSOIVintage.objects.get(name=vintage_name)
+        except IRSSOIVintage.DoesNotExist:
+            raise CommandError(
+                f"No IRSSOIVintage with name={vintage_name!r}."
+            )
+
+        created = 0
+        with transaction.atomic():
+            for (code, label, lo, hi) in STANDARD_BUCKETS:
+                if IRSSOIIncomeBucket.objects.filter(vintage=vintage, bucket_code=code).exists():
+                    continue
+                if not dry_run:
+                    IRSSOIIncomeBucket.objects.create(
+                        vintage=vintage, bucket_code=code, label=label,
+                        lower_bound=lo, upper_bound=hi,
+                    )
+                created += 1
+            if dry_run:
+                transaction.set_rollback(True)
+
+        verb = "Would create" if dry_run else "Created"
+        self.stdout.write(self.style.SUCCESS(
+            f"{verb} {created} IRS SOI buckets for {vintage.name}."
+        ))

--- a/socialwarehouse/economic/migrations/0002_irs_soi.py
+++ b/socialwarehouse/economic/migrations/0002_irs_soi.py
@@ -1,0 +1,75 @@
+"""E Phase 3 (SW#193): IRSSOIIncomeBucket + IRSSOIAggregate.
+
+Adds per-vintage AGI bucket table + the long-format ZCTA aggregate.
+Depends on sw_geo 0008 (IRSSOIVintage subclass + irs-soi kind).
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_economic", "0001_initial"),
+        ("sw_geo", "0008_irs_soi_vintage"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="IRSSOIIncomeBucket",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("bucket_code", models.PositiveSmallIntegerField()),
+                ("label", models.CharField(max_length=80)),
+                ("lower_bound", models.BigIntegerField(blank=True, null=True)),
+                ("upper_bound", models.BigIntegerField(blank=True, null=True)),
+                ("vintage", models.ForeignKey(
+                    on_delete=models.deletion.CASCADE,
+                    related_name="irs_soi_buckets",
+                    limit_choices_to={"kind": "irs-soi"},
+                    to="sw_geo.vintage",
+                )),
+            ],
+            options={
+                "db_table": "sw_economic_irs_soi_bucket",
+                "verbose_name": "IRS SOI Income Bucket",
+                "unique_together": {("vintage", "bucket_code")},
+                "ordering": ["vintage", "bucket_code"],
+            },
+        ),
+        migrations.CreateModel(
+            name="IRSSOIAggregate",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("boundary_type", models.CharField(db_index=True, default="zcta", max_length=30)),
+                ("geoid", models.CharField(db_index=True, max_length=20)),
+                ("return_count", models.BigIntegerField(blank=True, null=True)),
+                ("exemption_count", models.BigIntegerField(blank=True, null=True)),
+                ("agi_total", models.BigIntegerField(blank=True, null=True)),
+                ("taxable_income_total", models.BigIntegerField(blank=True, null=True)),
+                ("total_tax_total", models.BigIntegerField(blank=True, null=True)),
+                ("agi_bin", models.ForeignKey(
+                    on_delete=models.deletion.CASCADE,
+                    related_name="aggregates",
+                    to="sw_economic.irssoiincomebucket",
+                )),
+                ("vintage", models.ForeignKey(
+                    on_delete=models.deletion.CASCADE,
+                    related_name="irs_soi_aggregates",
+                    limit_choices_to={"kind": "irs-soi"},
+                    to="sw_geo.vintage",
+                )),
+            ],
+            options={
+                "db_table": "sw_economic_irs_soi_aggregate",
+                "verbose_name": "IRS SOI Aggregate",
+                "unique_together": {("vintage", "boundary_type", "geoid", "agi_bin")},
+                "indexes": [
+                    models.Index(fields=["boundary_type", "geoid", "vintage"],
+                                 name="sw_eco_soi_bnd_geo_vnt_idx"),
+                    models.Index(fields=["vintage", "agi_bin"],
+                                 name="sw_eco_soi_vnt_bin_idx"),
+                ],
+            },
+        ),
+    ]

--- a/socialwarehouse/economic/models/__init__.py
+++ b/socialwarehouse/economic/models/__init__.py
@@ -1,3 +1,4 @@
 from .bls_qcew import BLSQCEWAggregate
+from .irs_soi import IRSSOIAggregate, IRSSOIIncomeBucket
 
-__all__ = ["BLSQCEWAggregate"]
+__all__ = ["BLSQCEWAggregate", "IRSSOIAggregate", "IRSSOIIncomeBucket"]

--- a/socialwarehouse/economic/models/irs_soi.py
+++ b/socialwarehouse/economic/models/irs_soi.py
@@ -1,0 +1,118 @@
+"""IRS SOI ZIP-code-level tax statistics.
+
+Per E Phase 3 / E Q2 = (b) new `irs-soi` Vintage kind, Q3 = (a)
+versionable income-bucket model.
+
+IRS publishes ZIP-code-level aggregates each year for individual
+income tax returns, broken out by ~6 AGI buckets (e.g.,
+$0-$25K, $25-$50K, ..., $200K+). The bucket boundaries are
+occasionally re-cut, so a per-vintage `IRSSOIIncomeBucket` keeps
+historic data interpretable.
+
+Keyed long-format consistent with D and E Phase 1:
+(vintage, boundary_type='zcta', geoid, agi_bin) → value columns.
+"""
+
+from django.db import models
+
+
+class IRSSOIIncomeBucket(models.Model):
+    """AGI bucket definition for a given SOI vintage.
+
+    Per Q3, buckets are vintage-scoped so historic shifts in bin
+    boundaries don't corrupt cross-year reads.
+    """
+
+    vintage = models.ForeignKey(
+        "sw_geo.Vintage",
+        on_delete=models.CASCADE,
+        related_name="irs_soi_buckets",
+        limit_choices_to={"kind": "irs-soi"},
+    )
+    bucket_code = models.PositiveSmallIntegerField(
+        help_text="IRS SOI `agi_stub` code, typically 1-6.",
+    )
+    label = models.CharField(
+        max_length=80,
+        help_text="Human label, e.g. '$25,000 under $50,000'.",
+    )
+    lower_bound = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Inclusive lower bound in whole dollars; NULL = open-ended low.",
+    )
+    upper_bound = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Exclusive upper bound in whole dollars; NULL = open-ended high.",
+    )
+
+    class Meta:
+        db_table = "sw_economic_irs_soi_bucket"
+        verbose_name = "IRS SOI Income Bucket"
+        unique_together = [["vintage", "bucket_code"]]
+        ordering = ["vintage", "bucket_code"]
+
+    def __str__(self):
+        return f"{self.vintage.name} bucket {self.bucket_code}: {self.label}"
+
+
+class IRSSOIAggregate(models.Model):
+    """One row per (vintage, ZCTA, AGI bucket).
+
+    Boundary is always zcta in Phase 3 (SOI ZIP-code release). Future
+    phases may add county / state rollups using the same model.
+    """
+
+    vintage = models.ForeignKey(
+        "sw_geo.Vintage",
+        on_delete=models.CASCADE,
+        related_name="irs_soi_aggregates",
+        limit_choices_to={"kind": "irs-soi"},
+    )
+    boundary_type = models.CharField(
+        max_length=30, db_index=True, default="zcta",
+    )
+    geoid = models.CharField(
+        max_length=20, db_index=True,
+        help_text="5-digit ZCTA for zcta rows.",
+    )
+    agi_bin = models.ForeignKey(
+        "sw_economic.IRSSOIIncomeBucket",
+        on_delete=models.CASCADE,
+        related_name="aggregates",
+    )
+
+    return_count = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Number of returns (IRS `N1`).",
+    )
+    exemption_count = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Number of exemptions (IRS `NUMDEP` + filers).",
+    )
+    agi_total = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Total adjusted gross income, whole dollars (IRS `A00100`).",
+    )
+    taxable_income_total = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Total taxable income, whole dollars (IRS `A04800`).",
+    )
+    total_tax_total = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Total tax liability, whole dollars (IRS `A06500`).",
+    )
+
+    class Meta:
+        db_table = "sw_economic_irs_soi_aggregate"
+        verbose_name = "IRS SOI Aggregate"
+        unique_together = [["vintage", "boundary_type", "geoid", "agi_bin"]]
+        indexes = [
+            models.Index(fields=["boundary_type", "geoid", "vintage"]),
+            models.Index(fields=["vintage", "agi_bin"]),
+        ]
+
+    def __str__(self):
+        return (
+            f"{self.vintage.name} {self.boundary_type}:{self.geoid} "
+            f"bucket={self.agi_bin.bucket_code}"
+        )

--- a/socialwarehouse/economic/services/irs_soi_files.py
+++ b/socialwarehouse/economic/services/irs_soi_files.py
@@ -1,0 +1,51 @@
+"""IRS SOI ZIP-code aggregates downloader.
+
+Files-only path (no API key). The IRS publishes per-state CSV/XLSX
+files under irs.gov/statistics/soi-tax-stats-individual-income-tax-
+statistics-zip-code-data-soi each tax year.
+
+TODO(SU#535): lift this to siege_utilities (mirrors SU#533 / #534 for
+BLS QCEW / NCES). Kept SW-local until SU lands an IRS SOI helper.
+"""
+
+import io
+import logging
+
+import pandas as pd
+import requests
+
+
+logger = logging.getLogger(__name__)
+
+
+# Base URL pattern; the IRS occasionally re-publishes under
+# slightly different paths, so callers can override via __init__.
+DEFAULT_BASE_URL = "https://www.irs.gov/pub/irs-soi"
+
+
+class IRSSOIFiles:
+    """Thin wrapper around requests + pandas for SOI ZIP files."""
+
+    def __init__(self, base_url: str = DEFAULT_BASE_URL, session=None):
+        self.base_url = base_url
+        self.session = session or requests.Session()
+
+    def url_for(self, tax_year: int, state_abbrev: str) -> str:
+        # e.g. 2022 -> /22zpallnoagi.csv (national, all AGI) — varies.
+        # Per-state: /22zp06ca.csv style. Convention varies year over year;
+        # callers can override `url_for` if a release deviates.
+        yy = f"{tax_year % 100:02d}"
+        return f"{self.base_url}/{yy}zp{state_abbrev.lower()}.csv"
+
+    def load(self, *, tax_year: int, state_abbrev: str) -> pd.DataFrame:
+        """Download + parse a single per-state SOI release.
+
+        Returns a DataFrame with the IRS column names intact
+        (zipcode, agi_stub, N1, N2, A00100, A04800, A06500, ...).
+        Caller is responsible for re-keying to ZCTA conventions.
+        """
+        url = self.url_for(tax_year, state_abbrev)
+        logger.info("Fetching IRS SOI: %s", url)
+        resp = self.session.get(url, timeout=60)
+        resp.raise_for_status()
+        return pd.read_csv(io.BytesIO(resp.content), low_memory=False)

--- a/socialwarehouse/geo/migrations/0008_irs_soi_vintage.py
+++ b/socialwarehouse/geo/migrations/0008_irs_soi_vintage.py
@@ -1,0 +1,54 @@
+"""Add IRSSOIVintage subclass + irs-soi to KIND_CHOICES.
+
+Per E Phase 3 (SW#193) / E Q2 = (b) new vintage kind. Mirrors the
+BEARegionalVintage shape (annual, integer year) with `tax_year`
+instead of `year` so the column name is unambiguous in joins.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_geo", "0007_c_medium_boundary_caches"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="vintage",
+            name="kind",
+            field=models.CharField(
+                choices=[
+                    ("census-decadal", "Decennial Census"),
+                    ("acs", "American Community Survey"),
+                    ("bls-qcew", "BLS Quarterly Census of Employment and Wages"),
+                    ("bea-regional", "BEA Regional"),
+                    ("nces-school-year", "NCES School Year"),
+                    ("redistricting-plan", "Redistricting Plan"),
+                    ("irs-soi", "IRS SOI Individual Income Tax Statistics"),
+                ],
+                db_index=True, max_length=30,
+                help_text=(
+                    "Discriminator. Set automatically by each subclass's save() "
+                    "method; downstream code can filter by kind without downcasting."
+                ),
+            ),
+        ),
+        migrations.CreateModel(
+            name="IRSSOIVintage",
+            fields=[
+                ("vintage_ptr", models.OneToOneField(
+                    auto_created=True, on_delete=models.deletion.CASCADE,
+                    parent_link=True, primary_key=True, serialize=False,
+                    to="sw_geo.vintage",
+                )),
+                ("tax_year", models.PositiveSmallIntegerField(unique=True)),
+            ],
+            options={
+                "db_table": "sw_geo_vintage_irs_soi",
+                "verbose_name": "IRS SOI Vintage",
+            },
+            bases=("sw_geo.vintage",),
+        ),
+    ]

--- a/socialwarehouse/geo/models/__init__.py
+++ b/socialwarehouse/geo/models/__init__.py
@@ -15,6 +15,7 @@ from .vintages import (
     BEARegionalVintage,
     BLSQCEWVintage,
     CensusDecadalVintage,
+    IRSSOIVintage,
     NCESSchoolYearVintage,
     RedistrictingPlanVintage,
     Vintage,
@@ -37,4 +38,5 @@ __all__ = [
     "BEARegionalVintage",
     "NCESSchoolYearVintage",
     "RedistrictingPlanVintage",
+    "IRSSOIVintage",
 ]

--- a/socialwarehouse/geo/models/vintages.py
+++ b/socialwarehouse/geo/models/vintages.py
@@ -33,6 +33,7 @@ KIND_BLS_QCEW = "bls-qcew"
 KIND_BEA_REGIONAL = "bea-regional"
 KIND_NCES_SCHOOL_YEAR = "nces-school-year"
 KIND_REDISTRICTING_PLAN = "redistricting-plan"
+KIND_IRS_SOI = "irs-soi"
 
 KIND_CHOICES = [
     (KIND_CENSUS_DECADAL, "Decennial Census"),
@@ -41,6 +42,7 @@ KIND_CHOICES = [
     (KIND_BEA_REGIONAL, "BEA Regional"),
     (KIND_NCES_SCHOOL_YEAR, "NCES School Year"),
     (KIND_REDISTRICTING_PLAN, "Redistricting Plan"),
+    (KIND_IRS_SOI, "IRS SOI Individual Income Tax Statistics"),
 ]
 
 
@@ -245,6 +247,25 @@ class NCESSchoolYearVintage(Vintage):
             self.kind = KIND_NCES_SCHOOL_YEAR
         if not self.name:
             self.name = f"{self.start_year}-{str(self.end_year)[-2:]}"
+        super().save(*args, **kwargs)
+
+
+class IRSSOIVintage(Vintage):
+    """IRS Statistics of Income (SOI) ZIP-code-level vintage. Annual,
+    published with ~2-year lag (TY2022 data released late 2024).
+    """
+
+    tax_year = models.PositiveSmallIntegerField(unique=True)
+
+    class Meta:
+        db_table = "sw_geo_vintage_irs_soi"
+        verbose_name = "IRS SOI Vintage"
+
+    def save(self, *args, **kwargs):
+        if not self.kind:
+            self.kind = KIND_IRS_SOI
+        if not self.name:
+            self.name = f"TY{self.tax_year}"
         super().save(*args, **kwargs)
 
 

--- a/tests/unit/economic/test_load_irs_soi.py
+++ b/tests/unit/economic/test_load_irs_soi.py
@@ -1,0 +1,179 @@
+"""Tests for E Phase 3 (SW#193): IRSSOI ingest + bucket model.
+
+Mocks IRSSOIFiles.load so tests don't hit irs.gov. Pins:
+- ZIP padding + 00000 / totals-row skip
+- agi_stub == 0 totals skip
+- bucket lookup via per-vintage IRSSOIIncomeBucket
+- IRS column fallback (N2 / NUMDEP)
+- idempotency, dry-run, unknown vintage
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+import pandas as pd
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+
+class LoadIRSSOITestBase(TestCase):
+
+    def setUp(self):
+        from socialwarehouse.geo.models import IRSSOIVintage
+        from datetime import date
+
+        self.vintage = IRSSOIVintage.objects.filter(tax_year=2022).first()
+        if self.vintage is None:
+            self.vintage = IRSSOIVintage.objects.create(
+                tax_year=2022,
+                effective_from=date(2024, 12, 1),
+            )
+        # Seed buckets for this vintage.
+        call_command(
+            "seed_irs_soi_buckets", f"--vintage={self.vintage.name}",
+            verbosity=0,
+        )
+
+    def _df(self, rows):
+        return pd.DataFrame(rows)
+
+
+class TestLoadIRSSOIHappyPath(LoadIRSSOITestBase):
+
+    @patch("socialwarehouse.economic.services.irs_soi_files.IRSSOIFiles.load")
+    def test_writes_aggregate_per_zcta_per_bucket(self, mock_load):
+        from socialwarehouse.economic.models import (
+            IRSSOIAggregate, IRSSOIIncomeBucket,
+        )
+
+        mock_load.return_value = self._df([
+            {"zipcode": "94110", "agi_stub": 1, "N1": 1500, "N2": 2200,
+             "A00100": 18_000_000, "A04800": 12_000_000, "A06500": 1_200_000},
+            {"zipcode": "94110", "agi_stub": 6, "N1": 80, "N2": 110,
+             "A00100": 65_000_000, "A04800": 55_000_000, "A06500": 16_000_000},
+            {"zipcode": "00000", "agi_stub": 0, "N1": 99999},  # state total — skip
+        ])
+
+        call_command(
+            "load_irs_soi", f"--vintage={self.vintage.name}",
+            "--state-abbrev=CA", verbosity=0,
+        )
+
+        rows = IRSSOIAggregate.objects.filter(vintage=self.vintage)
+        assert rows.count() == 2
+
+        b1 = IRSSOIIncomeBucket.objects.get(vintage=self.vintage, bucket_code=1)
+        low = rows.get(geoid="94110", agi_bin=b1)
+        assert low.return_count == 1500
+        assert low.agi_total == 18_000_000
+
+        b6 = IRSSOIIncomeBucket.objects.get(vintage=self.vintage, bucket_code=6)
+        high = rows.get(geoid="94110", agi_bin=b6)
+        assert high.total_tax_total == 16_000_000
+
+
+class TestLoadIRSSOIColumnFallback(LoadIRSSOITestBase):
+
+    @patch("socialwarehouse.economic.services.irs_soi_files.IRSSOIFiles.load")
+    def test_numdep_used_when_n2_absent(self, mock_load):
+        from socialwarehouse.economic.models import IRSSOIAggregate
+
+        mock_load.return_value = self._df([
+            {"zipcode": "94110", "agi_stub": 1, "N1": 1500, "NUMDEP": 1800,
+             "A00100": 1, "A04800": 1, "A06500": 1},
+        ])
+
+        call_command(
+            "load_irs_soi", f"--vintage={self.vintage.name}",
+            "--state-abbrev=CA", verbosity=0,
+        )
+
+        row = IRSSOIAggregate.objects.get(vintage=self.vintage, geoid="94110")
+        assert row.exemption_count == 1800
+
+
+class TestLoadIRSSOIIdempotent(LoadIRSSOITestBase):
+
+    @patch("socialwarehouse.economic.services.irs_soi_files.IRSSOIFiles.load")
+    def test_rerun_overwrites(self, mock_load):
+        from socialwarehouse.economic.models import IRSSOIAggregate
+
+        mock_load.return_value = self._df([
+            {"zipcode": "94110", "agi_stub": 1, "N1": 100,
+             "A00100": 1, "A04800": 1, "A06500": 1},
+        ])
+        call_command("load_irs_soi", f"--vintage={self.vintage.name}",
+                     "--state-abbrev=CA", verbosity=0)
+
+        mock_load.return_value = self._df([
+            {"zipcode": "94110", "agi_stub": 1, "N1": 1500,
+             "A00100": 1, "A04800": 1, "A06500": 1},
+        ])
+        call_command("load_irs_soi", f"--vintage={self.vintage.name}",
+                     "--state-abbrev=CA", verbosity=0)
+
+        rows = IRSSOIAggregate.objects.filter(geoid="94110")
+        assert rows.count() == 1
+        assert rows.first().return_count == 1500
+
+
+class TestLoadIRSSOIValidation(TestCase):
+
+    def test_unknown_vintage_raises(self):
+        with self.assertRaises(CommandError) as cm:
+            call_command("load_irs_soi", "--vintage=TY9999",
+                         "--state-abbrev=CA", verbosity=0)
+        assert "No IRSSOIVintage" in str(cm.exception)
+
+    def test_missing_buckets_raises(self):
+        """If no IRSSOIIncomeBucket rows are seeded for the vintage,
+        the load command refuses to run rather than silently dropping
+        everything."""
+        from socialwarehouse.geo.models import IRSSOIVintage
+        from datetime import date
+
+        bare = IRSSOIVintage.objects.create(
+            tax_year=2099,
+            effective_from=date(2099, 1, 1),
+        )
+        with self.assertRaises(CommandError) as cm:
+            call_command("load_irs_soi", f"--vintage={bare.name}",
+                         "--state-abbrev=CA", verbosity=0)
+        assert "IRSSOIIncomeBucket" in str(cm.exception)
+
+
+class TestLoadIRSSOIDryRun(LoadIRSSOITestBase):
+
+    @patch("socialwarehouse.economic.services.irs_soi_files.IRSSOIFiles.load")
+    def test_dry_run_no_writes(self, mock_load):
+        from socialwarehouse.economic.models import IRSSOIAggregate
+
+        mock_load.return_value = self._df([
+            {"zipcode": "94110", "agi_stub": 1, "N1": 1,
+             "A00100": 1, "A04800": 1, "A06500": 1},
+        ])
+
+        before = IRSSOIAggregate.objects.count()
+        call_command("load_irs_soi", f"--vintage={self.vintage.name}",
+                     "--state-abbrev=CA", "--dry-run",
+                     verbosity=0, stdout=StringIO())
+        assert IRSSOIAggregate.objects.count() == before
+
+
+class TestSeedIRSSOIBuckets(TestCase):
+
+    def test_creates_six_buckets(self):
+        from socialwarehouse.economic.models import IRSSOIIncomeBucket
+        from socialwarehouse.geo.models import IRSSOIVintage
+        from datetime import date
+
+        v = IRSSOIVintage.objects.create(
+            tax_year=2021,
+            effective_from=date(2023, 12, 1),
+        )
+        call_command("seed_irs_soi_buckets", f"--vintage={v.name}", verbosity=0)
+        assert IRSSOIIncomeBucket.objects.filter(vintage=v).count() == 6
+        # Re-run is idempotent.
+        call_command("seed_irs_soi_buckets", f"--vintage={v.name}", verbosity=0)
+        assert IRSSOIIncomeBucket.objects.filter(vintage=v).count() == 6


### PR DESCRIPTION
## Summary

Closes the E ingest with IRS Statistics of Income (SOI) per-ZCTA tax aggregates.

- New `IRSSOIVintage` subclass + `irs-soi` Vintage kind (per Q2=b).
- `IRSSOIIncomeBucket` per-vintage bucket model (per Q3=a) — IRS occasionally recuts AGI bins; per-vintage keeps historical data interpretable.
- `IRSSOIAggregate` long-format keyed on `(vintage, boundary_type='zcta', geoid, agi_bin)`.
- `seed_irs_soi_buckets` ships the standard 6-bin TY2019+ layout.
- `load_irs_soi` uses files-only path (Q4=a) via `IRSSOIFiles` (TODO SU#535 to lift).
- Tests pin idempotency, header drift (N2/NUMDEP), totals-row skip, and refuse-to-run when buckets aren't seeded.

Two migrations land together: `sw_geo 0008` + `sw_economic 0002`.

## Test plan
- [ ] CI green
- [ ] sw_geo 0008 + sw_economic 0002 apply cleanly in order
- [ ] `seed_irs_soi_buckets --vintage=TY2022` creates 6 rows, idempotent
- [ ] `load_irs_soi --dry-run` writes nothing