### PR TITLE
chore: correct SU lift TODO to SU#539

### DIFF
--- a/socialwarehouse/economic/services/irs_soi_files.py
+++ b/socialwarehouse/economic/services/irs_soi_files.py
@@ -4,7 +4,7 @@ Files-only path (no API key). The IRS publishes per-state CSV/XLSX
 files under irs.gov/statistics/soi-tax-stats-individual-income-tax-
 statistics-zip-code-data-soi each tax year.
 
-TODO(SU#535): lift this to siege_utilities (mirrors SU#533 / #534 for
+TODO(SU#539): lift this to siege_utilities (mirrors SU#533 / #534 for
 BLS QCEW / NCES). Kept SW-local until SU lands an IRS SOI helper.
 """
 


### PR DESCRIPTION
One-line fix. E Phase 3 PR #224 shipped with \`TODO(SU#535)\` as a guess at the IRSSOIFiles-lift ticket number; the actual ticket is siege-analytics/siege_utilities#539.