### PR TITLE
fix(geo): Address.census_year is signal-maintained canonical (#100)

### DIFF
--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -23,11 +23,11 @@ from django.utils import timezone
 # TIGER vintage shifts (next bump: 2030 vintage's general-availability
 # date — TBD, currently expected ~2030-2032).
 #
-# This is INTENTIONALLY a module-level int constant, not a callable
-# default reading Vintage — that path tangles with F11 (#100 —
-# Address.census_year vs Vintage dual source of truth) and is being
-# deferred until the dual-source-of-truth question is settled.
-# Tracked: F6 / SW#95.
+# SW#100 resolution: Address.census_year is canonical (denormalized
+# fast-read year hint) and is signal-maintained from census-decadal
+# ABP writes (see socialwarehouse.geo.signals._census_year_from_vintage).
+# ABP.vintage remains authoritative per-row; Address.census_year is
+# the cached "what decade is this Address's geocoding from" value.
 DEFAULT_CENSUS_YEAR = 2020
 
 
@@ -157,7 +157,12 @@ class Address(models.Model):
     # "bumped manually each decade" rule has a single edit site.
     census_year = models.IntegerField(
         default=DEFAULT_CENSUS_YEAR,
-        help_text="Census year for boundary assignment (2010, 2020)",
+        help_text=(
+            "Census decade for this Address's boundary assignment (2010, "
+            "2020, ...). Denormalized cache, maintained by the F11 step-2b "
+            "signal from census-decadal ABP writes (SW#100). ABP.vintage "
+            "is per-row authoritative; this field is the fast-read decade."
+        ),
     )
 
     # ── Census unit GEOIDs (primary, string-indexed) ─────────────────────

--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -23,11 +23,12 @@ from django.utils import timezone
 # TIGER vintage shifts (next bump: 2030 vintage's general-availability
 # date — TBD, currently expected ~2030-2032).
 #
-# SW#100 resolution: Address.census_year is canonical (denormalized
-# fast-read year hint) and is signal-maintained from census-decadal
-# ABP writes (see socialwarehouse.geo.signals._census_year_from_vintage).
-# ABP.vintage remains authoritative per-row; Address.census_year is
-# the cached "what decade is this Address's geocoding from" value.
+# SW#100 resolution (supersedes F6 / SW#95): Address.census_year is
+# canonical (denormalized fast-read year hint) and is signal-maintained
+# from census-decadal ABP writes (see
+# socialwarehouse.geo.signals._census_year_from_vintage). ABP.vintage
+# remains authoritative per-row; Address.census_year is the cached
+# "what decade is this Address's geocoding from" value.
 DEFAULT_CENSUS_YEAR = 2020
 
 

--- a/socialwarehouse/geo/signals.py
+++ b/socialwarehouse/geo/signals.py
@@ -57,6 +57,28 @@ def address_cache_refresh_disabled():
         _signal_state.disabled = prev
 
 
+def _census_year_from_vintage(vintage):
+    """Return decade int from a census-decadal vintage, else None.
+
+    SW#100: Address.census_year is the canonical denormalized year hint
+    for the address. The signal maintains it from the polymorphic Vintage
+    parent — only census-decadal kinds update census_year (ACS / BLS /
+    redistricting vintages do not represent "the Census decade").
+
+    `vintage` may be either the parent `Vintage` instance (from an ABP
+    FK access) or the `CensusDecadalVintage` subclass directly.
+    """
+    if vintage is None or vintage.kind != "census-decadal":
+        return None
+    # Subclass instance — `decade` is a direct attribute.
+    decade = getattr(vintage, "decade", None)
+    if decade is not None:
+        return decade
+    # Parent Vintage — downcast.
+    decadal = getattr(vintage, "censusdecadalvintage", None)
+    return decadal.decade if decadal is not None else None
+
+
 def _is_current_vintage(vintage, today=None):
     """Return True if `vintage`'s effective window contains today.
 
@@ -107,6 +129,20 @@ def refresh_address_caches(addresses, today=None):
                 setattr(addr, cache_field, new_value)
                 dirty_fields.append(cache_field)
 
+        # SW#100: maintain census_year from the most recent census-decadal
+        # ABP row's vintage. boundaries_on returns the per-type ABP rows
+        # that are active today; any of them tied to a census-decadal
+        # vintage tells us the decade.
+        for row in result.values():
+            if row is None:
+                continue
+            year = _census_year_from_vintage(row.vintage)
+            if year is not None and addr.census_year != year:
+                addr.census_year = year
+                if "census_year" not in dirty_fields:
+                    dirty_fields.append("census_year")
+                break
+
         if dirty_fields:
             addr.save(update_fields=dirty_fields)
             updated_count += 1
@@ -142,6 +178,12 @@ def _connect():
             if getattr(addr, cache_field) != new_value:
                 setattr(addr, cache_field, new_value)
                 dirty_fields.append(cache_field)
+
+        # SW#100: also maintain census_year from census-decadal vintages.
+        new_year = _census_year_from_vintage(instance.vintage)
+        if new_year is not None and addr.census_year != new_year:
+            addr.census_year = new_year
+            dirty_fields.append("census_year")
 
         if dirty_fields:
             addr.save(update_fields=dirty_fields)

--- a/tests/unit/geo/test_address_cache_signal.py
+++ b/tests/unit/geo/test_address_cache_signal.py
@@ -244,3 +244,94 @@ class TestMultiWriteIntegration(TestCase):
         )
         addr.refresh_from_db()
         assert addr.cd_geoid == "0103"
+
+
+class TestSignalMaintainsCensusYear(TestCase):
+    """SW#100: census_year is signal-maintained from census-decadal vintages.
+
+    Pins:
+    - census-decadal ABP writes update Address.census_year to the
+      vintage's decade.
+    - Other vintage kinds (ACS / BLS / redistricting) do NOT update
+      census_year.
+    - Historical (non-current) census-decadal vintages do NOT update
+      census_year (the cache is current-by-construction).
+    """
+
+    def setUp(self):
+        from datetime import date
+        from socialwarehouse.geo.models import (
+            Address, ACSVintage, CensusDecadalVintage,
+        )
+        self.vintage_2020 = CensusDecadalVintage.objects.get(decade=2020)
+        self.vintage_2010 = CensusDecadalVintage.objects.get(decade=2010)
+        # Address starts at the module-default (2020); force to 2010 so
+        # the test detects the signal-driven bump explicitly.
+        self.addr = Address.objects.create(
+            state_abbreviation="CA", census_year=2010,
+        )
+        self.acs_vintage = ACSVintage.objects.filter(
+            span_years=5,
+        ).order_by("-end_year").first()
+        assert self.acs_vintage is not None
+
+    def test_current_decadal_write_bumps_census_year(self):
+        from socialwarehouse.geo.models import AddressBoundaryPeriod
+
+        AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2020,
+            cd_geoid="0610",
+            assignment_method="SPATIAL_JOIN",
+        )
+        self.addr.refresh_from_db()
+        assert self.addr.census_year == 2020
+
+    def test_historical_decadal_write_does_not_touch_census_year(self):
+        from socialwarehouse.geo.models import AddressBoundaryPeriod
+
+        AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.vintage_2010,
+            cd_geoid="0610",
+            assignment_method="SPATIAL_JOIN",
+        )
+        self.addr.refresh_from_db()
+        # Historical write — signal bails out before any cache update.
+        assert self.addr.census_year == 2010
+
+    def test_acs_vintage_write_does_not_touch_census_year(self):
+        """ACSVintage is current but is not a census-decadal kind;
+        census_year stays put."""
+        from socialwarehouse.geo.models import AddressBoundaryPeriod
+
+        AddressBoundaryPeriod.objects.create(
+            address=self.addr,
+            vintage=self.acs_vintage,
+            cd_geoid="0610",
+            assignment_method="SPATIAL_JOIN",
+        )
+        self.addr.refresh_from_db()
+        assert self.addr.census_year == 2010
+
+
+class TestCensusYearFromVintageHelper(TestCase):
+    """Direct unit tests on the kind-discriminating helper."""
+
+    def test_returns_decade_for_census_decadal(self):
+        from socialwarehouse.geo.models import CensusDecadalVintage
+        from socialwarehouse.geo.signals import _census_year_from_vintage
+
+        v = CensusDecadalVintage.objects.get(decade=2020)
+        assert _census_year_from_vintage(v) == 2020
+
+    def test_returns_none_for_acs(self):
+        from socialwarehouse.geo.models import ACSVintage
+        from socialwarehouse.geo.signals import _census_year_from_vintage
+
+        v = ACSVintage.objects.filter(span_years=5).first()
+        assert _census_year_from_vintage(v) is None
+
+    def test_returns_none_for_none(self):
+        from socialwarehouse.geo.signals import _census_year_from_vintage
+        assert _census_year_from_vintage(None) is None


### PR DESCRIPTION
## Summary

Closes SW#100. Maintainer's call (2026-05-20 thread): \"rederiving could get expensive\" → keep \`Address.census_year\` as the denormalized fast-read cache; have the F11 step-2b signal maintain it on census-decadal ABP writes.

- New helper \`_census_year_from_vintage(vintage)\` returns the decade for census-decadal vintages, None otherwise. Handles both parent-Vintage FK access and direct CensusDecadalVintage subclass.
- \`refresh_address_cache_on_abp_write\` and the bulk \`refresh_address_caches\` helper both extended to update \`census_year\` alongside \`{type}_geoid\` (still a single UPDATE per address).
- Negative branches pinned: historical decadal backfills, ACS / BLS / redistricting writes do NOT mutate \`census_year\`.
- DEFAULT_CENSUS_YEAR + field \`help_text\` rewritten to declare the contract.
- 6 new tests.

No migration — the field already exists with the right type.

## Test plan
- [ ] CI green (full test suite + the 6 new tests)
- [ ] Test class \`TestSignalMaintainsCensusYear\` exercises the three branches
- [ ] Test class \`TestCensusYearFromVintageHelper\` covers the helper directly