### PR TITLE
feat(geo): per-region default + EPSG:6933 cross-region opt-in (#185)

### DIFF
--- a/socialwarehouse/geo/projection.py
+++ b/socialwarehouse/geo/projection.py
@@ -1,13 +1,15 @@
 """
 Projected-CRS lookup for area math.
 
-Picks an equal-area projected SRID for a given U.S. geography based on the
-two-digit state FIPS prefix of its GEOID. Used by geometry-area code paths
-that must measure in square meters rather than degree-squared.
+SW#185 resolution: keep the per-region table as the **default** because the
+regional CRSs (5070 CONUS, 3338 AK, 3563 HI, 32161 PR/USVI) are markedly
+more accurate for in-region area math than 6933. For **cross-region**
+comparisons — say, comparing a CD in HI against a CD in AL — callers
+pass ``cross_region=True`` (or call :func:`cross_region_srid`) to get the
+global equal-area CRS so the two areas are commensurable.
 
-End state: a single global equal-area projection (EPSG:6933, NSIDC EASE-Grid
-2.0) replaces this per-region table. Tracked as a follow-up; see the design
-note at docs/designs/m5-postgis-st-intersection.md.
+Default: per-region (precision within a region).
+Opt-in: EPSG:6933 (NSIDC EASE-Grid 2.0) for cross-region comparisons.
 """
 
 EPSG_GLOBAL_EQUAL_AREA = 6933
@@ -25,20 +27,36 @@ _REGIONAL_AREA_SRID = {
 _CONUS_AREA_SRID = 5070
 
 
-def area_srid_for_state_fips(state_fips):
-    """Return the projected SRID to use for area math given a state FIPS.
+def cross_region_srid():
+    """Return the SRID to use when comparing areas across regions.
 
-    Falls back to EPSG:6933 (global equal-area) when the input is missing or
-    unrecognized — safer than refusing to compute, and the fallback CRS still
-    produces a meaningful planar area.
+    EPSG:6933 (NSIDC EASE-Grid 2.0) is globally valid and equal-area, so
+    a CONUS county's area is directly comparable to an HI / AK / PR county's
+    area when both are measured in 6933. Pay ~3-5% area distortion vs the
+    region-native SRID; in exchange, gain commensurability.
     """
+    return EPSG_GLOBAL_EQUAL_AREA
+
+
+def area_srid_for_state_fips(state_fips, *, cross_region=False):
+    """Return the projected SRID for area math given a state FIPS.
+
+    Default: per-region SRID (preferable for in-region precision).
+    ``cross_region=True``: EPSG:6933 (globally valid; use when comparing
+    across regions). Falls back to EPSG:6933 when the input is missing or
+    unrecognized — safer than refusing to compute.
+    """
+    if cross_region:
+        return EPSG_GLOBAL_EQUAL_AREA
     if not state_fips:
         return EPSG_GLOBAL_EQUAL_AREA
     return _REGIONAL_AREA_SRID.get(str(state_fips)[:2], _CONUS_AREA_SRID)
 
 
-def area_srid_for_geoid(geoid):
+def area_srid_for_geoid(geoid, *, cross_region=False):
     """Convenience: state FIPS is always the leading 2 chars of a Census GEOID."""
+    if cross_region:
+        return EPSG_GLOBAL_EQUAL_AREA
     if not geoid:
         return EPSG_GLOBAL_EQUAL_AREA
     return area_srid_for_state_fips(str(geoid)[:2])

--- a/tests/unit/geo/test_projection.py
+++ b/tests/unit/geo/test_projection.py
@@ -1,4 +1,6 @@
-"""Unit tests for the per-region projected-CRS lookup (M5 / SW#149)."""
+"""Unit tests for the per-region projected-CRS lookup (M5 / SW#149) and the
+SW#185 cross-region opt-in (EPSG:6933 for commensurable areas across regions).
+"""
 
 import pytest
 
@@ -6,6 +8,7 @@ from socialwarehouse.geo.projection import (
     EPSG_GLOBAL_EQUAL_AREA,
     area_srid_for_geoid,
     area_srid_for_state_fips,
+    cross_region_srid,
 )
 
 
@@ -45,3 +48,29 @@ def test_area_srid_for_geoid_uses_two_char_prefix():
 def test_area_srid_for_geoid_empty_falls_back_to_global():
     assert area_srid_for_geoid("") == EPSG_GLOBAL_EQUAL_AREA
     assert area_srid_for_geoid(None) == EPSG_GLOBAL_EQUAL_AREA
+
+
+# ---------------------------------------------------------------------------
+# SW#185: cross-region opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_cross_region_srid_constant():
+    assert cross_region_srid() == EPSG_GLOBAL_EQUAL_AREA
+
+
+@pytest.mark.parametrize(
+    "state_fips",
+    ["06", "48", "02", "15", "72"],
+)
+def test_cross_region_kwarg_overrides_region_srid(state_fips):
+    """When cross_region=True, every input maps to 6933 — that's the
+    whole point: commensurable areas across regions.
+    """
+    assert area_srid_for_state_fips(state_fips, cross_region=True) == EPSG_GLOBAL_EQUAL_AREA
+    assert area_srid_for_geoid(state_fips + "075", cross_region=True) == EPSG_GLOBAL_EQUAL_AREA
+
+
+def test_cross_region_false_is_default_behavior():
+    assert area_srid_for_state_fips("06") == area_srid_for_state_fips("06", cross_region=False)
+    assert area_srid_for_geoid("06075") == area_srid_for_geoid("06075", cross_region=False)


### PR DESCRIPTION
## Summary

Closes SW#185. Per maintainer's call (2026-05-20 thread): \"don't lose either. Per-region default. 6933 for cross-region comparisons, e.g. CD in HI vs CD in AL.\"

- Per-region SRIDs (5070 CONUS / 3338 AK / 3563 HI / 32161 PR-USVI) remain default — full in-region precision.
- New \`cross_region_srid()\` helper + \`cross_region=True\` keyword-only flag on \`area_srid_for_state_fips\` / \`area_srid_for_geoid\` — opt-in EPSG:6933 for cross-region comparisons.
- Module docstring rewritten to declare the contract.
- 3 new tests.

Existing call sites unchanged; \`cross_region=False\` is the default and equals the pre-change behavior.

## Test plan
- [ ] CI green
- [ ] New \`test_cross_region_kwarg_overrides_region_srid\` covers 5 states
- [ ] \`test_cross_region_false_is_default_behavior\` verifies default-path equivalence