### PR TITLE
feat(geo): address_boundary_cache_changed cascade signal (#200)

### DIFF
--- a/socialwarehouse/geo/signals.py
+++ b/socialwarehouse/geo/signals.py
@@ -32,11 +32,45 @@ import threading
 from datetime import date
 
 from django.db.models.signals import post_save
-from django.dispatch import receiver
+from django.dispatch import Signal, receiver
 
 logger = logging.getLogger(__name__)
 
 _signal_state = threading.local()
+
+
+# SW#200: downstream cascade event.
+#
+# Fires after the F11 step-2b cache-coherence handler updates one or
+# more `Address.{type}_geoid` (or `Address.census_year`) fields. Lets
+# downstream consumers — e.g. the FEC analysis project's fact tables —
+# react to a coherent change without F11 needing to know about them.
+#
+# Kwargs:
+#   sender         — Address (the model class)
+#   instance       — Address (the row whose cache changed)
+#   dirty_fields   — list[str] of the field names that were updated
+#   source_abp     — AddressBoundaryPeriod | None — the ABP whose save
+#                    triggered the update; None when fired from the
+#                    bulk `refresh_address_caches` path.
+#
+# Contract:
+#   - In-process synchronous: subscribers run in the same DB transaction
+#     as the originating ABP write. Raise to roll back the originating
+#     write; return cleanly to commit.
+#   - Subscribers MUST be idempotent. The signal may fire on a no-op
+#     cache rewrite if a future refactor changes the dirty-detection.
+#   - Subscribers MUST NOT do slow I/O on the dispatch thread (HTTP
+#     calls, large batch DB writes). Enqueue background work and return.
+#
+# Runtime evolution note:
+#   When the FEC analysis project (or any subscriber) needs cross-process
+#   notification — Celery workers, Airflow DAG triggers — replace this
+#   in-process Django Signal with a Celery `send_task` (or equivalent
+#   broker dispatch) inside the same handler. Airflow can subscribe to
+#   the broker via a sensor task. The kwargs contract above is the
+#   stable interface; only the transport changes.
+address_boundary_cache_changed = Signal()
 
 
 @contextlib.contextmanager
@@ -146,6 +180,12 @@ def refresh_address_caches(addresses, today=None):
         if dirty_fields:
             addr.save(update_fields=dirty_fields)
             updated_count += 1
+            address_boundary_cache_changed.send(
+                sender=Address,
+                instance=addr,
+                dirty_fields=list(dirty_fields),
+                source_abp=None,
+            )
 
     return updated_count
 
@@ -190,4 +230,10 @@ def _connect():
             logger.debug(
                 "F11 step-2b: refreshed Address %s cache fields %s from ABP %s",
                 addr.pk, dirty_fields, instance.pk,
+            )
+            address_boundary_cache_changed.send(
+                sender=Address,
+                instance=addr,
+                dirty_fields=list(dirty_fields),
+                source_abp=instance,
             )

--- a/tests/unit/geo/test_cache_change_signal.py
+++ b/tests/unit/geo/test_cache_change_signal.py
@@ -1,0 +1,127 @@
+"""Tests for SW#200: the address_boundary_cache_changed cascade signal.
+
+Pins the contract: signal fires after F11 step-2b updates cache, with
+the documented kwargs. Doesn't ship a subscriber — the FEC analysis
+project (or whoever surfaces first) ships theirs.
+"""
+
+from datetime import date
+
+from django.dispatch import receiver
+from django.test import TestCase
+
+from socialwarehouse.geo.signals import (
+    address_boundary_cache_changed,
+    address_cache_refresh_disabled,
+    refresh_address_caches,
+)
+
+
+class _CaptureBase(TestCase):
+    """Subscribe to the cascade signal and stash received kwargs for
+    assertions; cleanly disconnect on teardown."""
+
+    def setUp(self):
+        from socialwarehouse.geo.models import (
+            Address, CensusDecadalVintage,
+        )
+        self.vintage = CensusDecadalVintage.objects.get(decade=2020)
+        self.addr = Address.objects.create(state_abbreviation="CA")
+        self._received = []
+
+        @receiver(address_boundary_cache_changed, weak=False,
+                  dispatch_uid="test_cache_change_signal_capture")
+        def _capture(sender, instance, dirty_fields, source_abp, **kw):
+            self._received.append({
+                "sender": sender,
+                "instance": instance,
+                "dirty_fields": list(dirty_fields),
+                "source_abp": source_abp,
+            })
+
+        self._capture = _capture
+
+    def tearDown(self):
+        address_boundary_cache_changed.disconnect(
+            self._capture,
+            dispatch_uid="test_cache_change_signal_capture",
+        )
+
+
+class TestSignalFiresOnCurrentVintageWrite(_CaptureBase):
+
+    def test_fires_with_documented_kwargs(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod,
+        )
+
+        abp = AddressBoundaryPeriod.objects.create(
+            address=self.addr, vintage=self.vintage,
+            cd_geoid="0612", assignment_method="SPATIAL_JOIN",
+        )
+
+        assert len(self._received) == 1
+        event = self._received[0]
+        assert event["sender"] is Address
+        assert event["instance"].pk == self.addr.pk
+        assert "cd_geoid" in event["dirty_fields"]
+        assert event["source_abp"].pk == abp.pk
+
+
+class TestSignalDoesNotFireForBackfill(_CaptureBase):
+    """No cache update → no signal."""
+
+    def test_historical_vintage_does_not_fire(self):
+        from socialwarehouse.geo.models import (
+            AddressBoundaryPeriod, CensusDecadalVintage,
+        )
+        old = CensusDecadalVintage.objects.get(decade=2010)
+        AddressBoundaryPeriod.objects.create(
+            address=self.addr, vintage=old,
+            cd_geoid="0107", context_date=date(2015, 1, 1),
+            assignment_method="SPATIAL_JOIN",
+        )
+        assert self._received == []
+
+    def test_no_change_does_not_fire(self):
+        from socialwarehouse.geo.models import AddressBoundaryPeriod
+
+        # Pre-populate the cache.
+        self.addr.cd_geoid = "0612"
+        self.addr.save()
+
+        # ABP write that matches the cache → no dirty_fields → no signal.
+        AddressBoundaryPeriod.objects.create(
+            address=self.addr, vintage=self.vintage,
+            cd_geoid="0612", assignment_method="SPATIAL_JOIN",
+        )
+        assert self._received == []
+
+
+class TestSignalFiresFromBulkHelper(_CaptureBase):
+
+    def test_bulk_refresh_fires_with_source_abp_none(self):
+        from socialwarehouse.geo.models import (
+            Address, AddressBoundaryPeriod,
+        )
+
+        with address_cache_refresh_disabled():
+            AddressBoundaryPeriod.objects.create(
+                address=self.addr, vintage=self.vintage,
+                cd_geoid="0612", context_date=date(2024, 1, 1),
+                assignment_method="SPATIAL_JOIN",
+            )
+        # Per-write signal suppressed — nothing received yet.
+        assert self._received == []
+
+        refresh_address_caches(
+            Address.objects.filter(pk=self.addr.pk),
+            today=date(2024, 6, 1),
+        )
+
+        assert len(self._received) == 1
+        event = self._received[0]
+        assert event["instance"].pk == self.addr.pk
+        assert "cd_geoid" in event["dirty_fields"]
+        # source_abp=None signals "bulk path, not a single triggering write."
+        assert event["source_abp"] is None


### PR DESCRIPTION
## Summary

Closes SW#200. Ships (c) event-bus shape via Django signals — the simplest in-codebase mechanism that preserves layering (geo emits; downstream subscribes from its own modules; F11 doesn't grow knowledge of consumers).

- New \`address_boundary_cache_changed = Signal()\` from \`socialwarehouse.geo.signals\`
- Dispatched from both the F11 step-2b \`post_save\` handler and the bulk \`refresh_address_caches\` helper
- Kwargs: \`(sender=Address, instance, dirty_fields, source_abp)\` — \`source_abp\` is \`None\` for the bulk path
- 4 tests pin the contract

## Why event bus, not chained signals

Chained signals would make F11 import-and-call each downstream consumer (FEC analysis fact tables, etc.), violating layering. Event bus inverts the dependency — geo emits; consumers subscribe from their own modules.

## Why Django signals, not Celery / custom registry

Django signals are already in the codebase (F11 step-2b uses them), zero new dependency, in-process. Celery's operational cost (broker, workers, dead-letters) is justified only when async + cross-process is required — an FK-change cascade isn't slow.

**Documented future-evolution path:** when a subscriber needs cross-process notification (Celery workers, Airflow DAG triggers), swap the in-process dispatch for a broker call inside the same handler. The kwargs contract stays stable; only the transport changes. Note in the signal docstring + this PR body.

## First consumer

The FEC analysis project (per maintainer's note) will be the first subscriber. It ships its own subscriber when it lands; this PR makes the surface area available without speculating on its shape.

## Test plan
- [ ] CI green
- [ ] Fires on current-vintage ABP write with documented kwargs
- [ ] Doesn't fire on historical / no-change writes
- [ ] Fires from bulk helper path with \`source_abp=None\`