### PR TITLE
feat(civic): F Phase 2 — SpecialDistrictAttributes schema (#194)

### DIFF
--- a/socialwarehouse/civic/migrations/0004_special_district_attributes.py
+++ b/socialwarehouse/civic/migrations/0004_special_district_attributes.py
@@ -1,0 +1,55 @@
+"""F Phase 2 (SW#194): SpecialDistrictAttributes — COG-style attributes.
+
+Per maintainer's call (2026-05-20 thread): ship the warehouse-side
+schema; defer auto-ingest. The FEC analysis project (or any custom
+loader) writes against this table directly.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_civic", "0003_nces_edge_demographics"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SpecialDistrictAttributes",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ("boundary_type", models.CharField(
+                    choices=[
+                        ("fire_district", "fire_district"),
+                        ("water_district", "water_district"),
+                        ("hospital_district", "hospital_district"),
+                        ("library_district", "library_district"),
+                        ("cemetery_district", "cemetery_district"),
+                        ("mosquito_district", "mosquito_district"),
+                        ("other_special_district", "other_special_district"),
+                    ],
+                    db_index=True, max_length=30,
+                )),
+                ("geoid", models.CharField(db_index=True, max_length=20)),
+                ("source_year", models.PositiveSmallIntegerField(db_index=True)),
+                ("function", models.CharField(blank=True, default="", max_length=80)),
+                ("governing_body", models.CharField(blank=True, default="", max_length=255)),
+                ("annual_revenue", models.BigIntegerField(blank=True, null=True)),
+                ("source_url", models.URLField(blank=True, default="")),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "sw_civic_special_district_attributes",
+                "verbose_name": "Special District Attributes",
+                "verbose_name_plural": "Special District Attributes",
+                "unique_together": {("boundary_type", "geoid", "source_year")},
+                "indexes": [
+                    models.Index(fields=["boundary_type", "source_year"],
+                                 name="sw_civ_spdist_bnd_yr_idx"),
+                ],
+                "ordering": ["boundary_type", "geoid", "source_year"],
+            },
+        ),
+    ]

--- a/socialwarehouse/civic/models/__init__.py
+++ b/socialwarehouse/civic/models/__init__.py
@@ -1,9 +1,11 @@
 from .nces_district import NCESDistrictAggregate
 from .nces_edge_demographics import NCESDistrictEDGEDemographics
 from .nces_school import NCESSchoolAggregate
+from .special_district import SpecialDistrictAttributes
 
 __all__ = [
     "NCESDistrictAggregate",
     "NCESDistrictEDGEDemographics",
     "NCESSchoolAggregate",
+    "SpecialDistrictAttributes",
 ]

--- a/socialwarehouse/civic/models/special_district.py
+++ b/socialwarehouse/civic/models/special_district.py
@@ -1,0 +1,111 @@
+"""Census special-district attribute records.
+
+F Phase 2 (SW#194): per maintainer's call (2026-05-20 thread): ship
+the warehouse-side schema now so the FEC analysis project has a place
+to write attributes against; defer auto-ingest from the Census of
+Governments (COG) file until a real consumer surfaces with format
+requirements.
+
+Boundary geometry + canonical names live upstream in siege_utilities
+per-kind special-district models (FireDistrict, WaterDistrict, ...)
+delivered by C / SU#535. This table adds the COG-style attributes on
+top: governing body, annual revenue, source URL, source year.
+
+Long-format keying — `(boundary_type, geoid, source_year)` — matches
+the cross-source pattern used by ACSEstimate, BLSQCEWAggregate, and
+IRSSOIAggregate. The `boundary_type` discriminator carries the per-
+kind value (one of `_SPECIAL_DISTRICT_BOUNDARY_TYPES`) so a single
+table can serve every special-district subkind C ships.
+"""
+
+from django.db import models
+
+
+# The set of special-district boundary types that this table can carry
+# attributes for. Matches Address._BOUNDARY_TYPES special-district
+# entries and SU#535's per-kind models.
+_SPECIAL_DISTRICT_BOUNDARY_TYPES = (
+    "fire_district",
+    "water_district",
+    "hospital_district",
+    "library_district",
+    "cemetery_district",
+    "mosquito_district",
+    "other_special_district",
+)
+
+BOUNDARY_TYPE_CHOICES = [(t, t) for t in _SPECIAL_DISTRICT_BOUNDARY_TYPES]
+
+
+class SpecialDistrictAttributes(models.Model):
+    """COG-style attributes for one Census special district.
+
+    No auto-ingest shipped — populate via your own loader (manual
+    fixture, COG file parser, FEC project, etc.). The unique key
+    `(boundary_type, geoid, source_year)` lets a single district
+    carry multiple years of attribute history.
+    """
+
+    boundary_type = models.CharField(
+        max_length=30,
+        db_index=True,
+        choices=BOUNDARY_TYPE_CHOICES,
+        help_text=(
+            "Special-district kind. Must match one of SW's special-"
+            "district boundary types (matches SU#535's per-kind models)."
+        ),
+    )
+    geoid = models.CharField(
+        max_length=20,
+        db_index=True,
+        help_text="TIGER GEOID for the district's boundary row.",
+    )
+    source_year = models.PositiveSmallIntegerField(
+        db_index=True,
+        help_text=(
+            "Year the attribute snapshot applies to. Census of "
+            "Governments runs every 5 years (2017, 2022, ...); a one-"
+            "off custom load might use any year. Required for the "
+            "unique-together key so multiple snapshots can coexist."
+        ),
+    )
+
+    function = models.CharField(
+        max_length=80, blank=True, default="",
+        help_text=(
+            "Census COG `function` description, e.g. 'Fire Protection', "
+            "'Water Supply'. Free-text; not validated against a fixed "
+            "set because COG categories shift release-to-release."
+        ),
+    )
+    governing_body = models.CharField(
+        max_length=255, blank=True, default="",
+        help_text="Name of the governing board / commission / authority.",
+    )
+    annual_revenue = models.BigIntegerField(
+        null=True, blank=True,
+        help_text="Annual revenue in whole dollars; nullable when unreported.",
+    )
+    source_url = models.URLField(
+        blank=True, default="",
+        help_text=(
+            "URL the attributes were sourced from (COG release page, "
+            "state register, district's own site)."
+        ),
+    )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "sw_civic_special_district_attributes"
+        verbose_name = "Special District Attributes"
+        verbose_name_plural = "Special District Attributes"
+        unique_together = [["boundary_type", "geoid", "source_year"]]
+        indexes = [
+            models.Index(fields=["boundary_type", "source_year"]),
+        ]
+        ordering = ["boundary_type", "geoid", "source_year"]
+
+    def __str__(self):
+        return f"{self.boundary_type}:{self.geoid} ({self.source_year})"

--- a/tests/unit/civic/test_special_district_attributes.py
+++ b/tests/unit/civic/test_special_district_attributes.py
@@ -1,0 +1,92 @@
+"""Tests for SW#194 F Phase 2: SpecialDistrictAttributes.
+
+Schema-only PR — no auto-ingest. These tests pin the schema contract
+(unique key, choices, multi-year coexistence) so future loaders can
+write against a stable shape.
+"""
+
+from django.db import IntegrityError
+from django.test import TestCase
+
+
+class TestSpecialDistrictAttributesSchema(TestCase):
+
+    def test_create_minimal_row(self):
+        from socialwarehouse.civic.models import SpecialDistrictAttributes
+
+        row = SpecialDistrictAttributes.objects.create(
+            boundary_type="fire_district",
+            geoid="0612345",
+            source_year=2022,
+        )
+        assert row.pk is not None
+        assert row.function == ""  # default
+        assert row.annual_revenue is None
+
+    def test_unique_per_boundary_geoid_year(self):
+        from socialwarehouse.civic.models import SpecialDistrictAttributes
+
+        SpecialDistrictAttributes.objects.create(
+            boundary_type="fire_district",
+            geoid="0612345",
+            source_year=2022,
+            governing_body="First Board",
+        )
+        with self.assertRaises(IntegrityError):
+            SpecialDistrictAttributes.objects.create(
+                boundary_type="fire_district",
+                geoid="0612345",
+                source_year=2022,
+                governing_body="Duplicate",
+            )
+
+    def test_same_geoid_different_year_allowed(self):
+        """Multiple snapshots of the same district across years."""
+        from socialwarehouse.civic.models import SpecialDistrictAttributes
+
+        SpecialDistrictAttributes.objects.create(
+            boundary_type="fire_district",
+            geoid="0612345",
+            source_year=2017,
+        )
+        SpecialDistrictAttributes.objects.create(
+            boundary_type="fire_district",
+            geoid="0612345",
+            source_year=2022,
+        )
+        assert SpecialDistrictAttributes.objects.filter(geoid="0612345").count() == 2
+
+    def test_same_geoid_different_boundary_type_allowed(self):
+        """Same TIGER GEOID for two different special-district kinds
+        is allowed (and theoretically possible since each kind has its
+        own TIGER table)."""
+        from socialwarehouse.civic.models import SpecialDistrictAttributes
+
+        SpecialDistrictAttributes.objects.create(
+            boundary_type="fire_district",
+            geoid="0612345",
+            source_year=2022,
+        )
+        SpecialDistrictAttributes.objects.create(
+            boundary_type="water_district",
+            geoid="0612345",
+            source_year=2022,
+        )
+        assert SpecialDistrictAttributes.objects.filter(geoid="0612345").count() == 2
+
+    def test_all_seven_kinds_accepted(self):
+        from socialwarehouse.civic.models import SpecialDistrictAttributes
+        from socialwarehouse.civic.models.special_district import (
+            _SPECIAL_DISTRICT_BOUNDARY_TYPES,
+        )
+
+        for kind in _SPECIAL_DISTRICT_BOUNDARY_TYPES:
+            SpecialDistrictAttributes.objects.create(
+                boundary_type=kind,
+                geoid="9999999",
+                source_year=2022,
+            )
+        assert (
+            SpecialDistrictAttributes.objects.filter(geoid="9999999").count()
+            == len(_SPECIAL_DISTRICT_BOUNDARY_TYPES)
+        )


### PR DESCRIPTION
## Summary

Closes the F Phase 2 piece of SW#194. Per maintainer's call (2026-05-20 thread): ship (a) — warehouse-side schema now; defer auto-ingest until a real consumer (FEC analysis project, etc.) surfaces.

- New \`SpecialDistrictAttributes\` model in \`socialwarehouse.civic\`, unified across all 7 special-district kinds via a \`boundary_type\` discriminator.
- Long-format key: \`(boundary_type, geoid, source_year)\` — multiple snapshots per district allowed (COG runs every 5 years).
- COG-style columns: \`function\`, \`governing_body\`, \`annual_revenue\`, \`source_url\`.
- Migration 0004.
- 5 schema-contract tests.

## Why unified vs per-kind

C made the opposite call for BOUNDARY records (per-kind FireDistrict / WaterDistrict / ... — SU#535/#537) because the per-kind TIGER files have different shapes. Attributes don't: every special district has governing-body / revenue / source URL. Discriminator + 7-row choices is cheaper than 7 tables, and cross-kind queries (\"all districts in state X regardless of function\") become trivial.

## No load command

The FEC project (or any ad-hoc loader) writes against this table directly. If/when COG-format auto-ingest is wanted, file a separate ticket with format research — the COG file's GIDID-to-TIGER-GEOID match is fuzzy and warrants its own design conversation.

## Test plan
- [ ] CI green
- [ ] Migration 0004 applies cleanly on fresh DB
- [ ] Unique key enforces; multi-year + cross-kind coexistence works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added special district attribute storage with tracking for boundary type, geographic identifier, source year, function, governing body, annual revenue, and source attribution
  * Automatic timestamp tracking for record creation and updates
  * Built-in data integrity constraints ensuring uniqueness across boundary type, identifier, and year combinations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->