### PR TITLE
release: v2.0.0 — template-readiness milestone (#29)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "socialwarehouse"
-version = "2.0.0-dev"
+version = "2.0.0"
 description = "Data warehouse and delta lake for geographic, demographic, and civic data — the DSTK replacement"
 readme = "README.md"
 license = {text = "Proprietary"}

--- a/socialwarehouse/__init__.py
+++ b/socialwarehouse/__init__.py
@@ -11,4 +11,4 @@ Architecture:
                        DSTK REST API, Delta Lake + Spark orchestration
 """
 
-__version__ = "2.0.0-dev"
+__version__ = "2.0.0"


### PR DESCRIPTION
Closes SW#29. Reinterpreted v1.0.0 -> v2.0.0 per pyproject already at 2.0.0-dev (per operator 2026-05-21). Template-readiness initiative (SW#189) completion is the natural release moment.

## What this PR does

Two-line bump (no behavior change):
- `pyproject.toml`: version `2.0.0-dev` -> `2.0.0`
- `socialwarehouse/__init__.py`: `__version__` `2.0.0-dev` -> `2.0.0`

`swh/__init__.py` at `1.0.0` left unchanged (legacy package being phased out; independent versioning).

## Post-merge plan

1. Tag `v2.0.0` on the post-merge main commit
2. Push the tag
3. Create GitHub release with notes (template-readiness shipped; what is in / out; downstream consumer guidance)
4. Follow-up commit bumps to `2.0.1-dev` so development isn't pinned at the release version

Refs: siege-analytics/socialwarehouse#29