### PR TITLE
chore: bump development version to 2.0.1-dev (post-v2.0.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "socialwarehouse"
-version = "2.0.0"
+version = "2.0.1-dev"
 description = "Data warehouse and delta lake for geographic, demographic, and civic data — the DSTK replacement"
 readme = "README.md"
 license = {text = "Proprietary"}

--- a/socialwarehouse/__init__.py
+++ b/socialwarehouse/__init__.py
@@ -11,4 +11,4 @@ Architecture:
                        DSTK REST API, Delta Lake + Spark orchestration
 """
 
-__version__ = "2.0.0"
+__version__ = "2.0.1-dev"


### PR DESCRIPTION
Post-release housekeeping after v2.0.0 (#29). Standard semver pattern: bump development branch to 2.0.1-dev so future commits aren't pinned at the release version.

Two-line bump:
- `pyproject.toml`: `2.0.0` -> `2.0.1-dev`
- `socialwarehouse/__init__.py`: `2.0.0` -> `2.0.1-dev`

Refs: siege-analytics/socialwarehouse#29