### PR TITLE
feat(geo): single-type pushdown + context-date-aware signal (#188 + #228)

### DIFF
--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -473,7 +473,7 @@ class Address(models.Model):
             qs = qs.exclude(**{f"{field}__isnull": True}).exclude(**{field: ""})
         return qs.order_by("-context_date", "-assigned_at")
 
-    def boundaries_on(self, on_date):
+    def boundaries_on(self, on_date, boundary_types=None):
         """Boundaries this address was in on ``on_date``.
 
         For each boundary type, returns the ABP row whose ``context_date``
@@ -482,6 +482,13 @@ class Address(models.Model):
 
         Returns a dict ``{boundary_type: AddressBoundaryPeriod}``.
         Missing keys mean no ABP row covers ``on_date`` for that type.
+
+        If ``boundary_types`` is given (an iterable of type strings), the
+        DB query filters to rows where at least one of the requested types
+        has a non-empty geoid, AND the returned dict is restricted to the
+        requested types. This is the single-type-fast-path used by
+        ``boundary_on`` / ``geoid_on`` (SW#188): asking for one type pays
+        for one type's worth of rows, not all-types.
 
         NOTE: An earlier version of this helper resolved plan-bound rows
         by reading ``redistricting_plan.effective_from`` /
@@ -499,18 +506,48 @@ class Address(models.Model):
         if not vintage:
             return {}
 
-        periods = list(
+        # Validate + normalize the boundary_types filter.
+        if boundary_types is not None:
+            requested = tuple(boundary_types)
+            for btype in requested:
+                if btype not in self._BOUNDARY_TYPES:
+                    raise ValueError(
+                        f"Unknown boundary_type {btype!r}; "
+                        f"expected one of {self._BOUNDARY_TYPES}"
+                    )
+        else:
+            requested = self._BOUNDARY_TYPES
+
+        qs = (
             self.boundary_periods
             .filter(vintage=vintage)
             .filter(
                 models.Q(context_date__lte=on_date)
                 | models.Q(context_date__isnull=True)
             )
-            .order_by(models.F("context_date").desc(nulls_last=True))
         )
 
+        # SW#188: when caller asks for a subset of types, push the
+        # "at least one of the requested types has a non-empty geoid"
+        # filter into the queryset. Without this, single-type callers
+        # (boundary_on / geoid_on) still fetched every ABP row covering
+        # the vintage; with it, they fetch only rows that could resolve
+        # the requested types. Plan-bound rows have sparse geoid fills
+        # (CD-rows are null for SLDL/SLDU, etc.) so the OR-across-fields
+        # filter is the right narrowing shape.
+        if boundary_types is not None:
+            type_filter = models.Q()
+            for btype in requested:
+                field = f"{btype}_geoid"
+                type_filter |= ~models.Q(**{field: ""}) & models.Q(
+                    **{f"{field}__isnull": False}
+                )
+            qs = qs.filter(type_filter)
+
+        periods = list(qs.order_by(models.F("context_date").desc(nulls_last=True)))
+
         result = {}
-        for btype in self._BOUNDARY_TYPES:
+        for btype in requested:
             field = f"{btype}_geoid"
             chosen = next(
                 (p for p in periods if getattr(p, field, None)),
@@ -544,17 +581,23 @@ class Address(models.Model):
     def boundary_on(self, boundary_type, on_date):
         """The ABP row for one boundary type, as of ``on_date``.
 
-        Sugar for ``self.boundaries_on(on_date).get(boundary_type)``.
-        Returns the ABP row, or ``None`` if no row covers ``on_date``
-        for that type. Validates ``boundary_type`` against the known
-        set up-front so a typo doesn't silently return ``None``.
+        Returns the ABP row whose ``context_date`` is the most recent
+        on-or-before ``on_date`` and which carries a non-empty
+        ``{boundary_type}_geoid``. Returns ``None`` if no such row exists.
+
+        Validates ``boundary_type`` against the known set up-front so a
+        typo doesn't silently return ``None``.
+
+        SW#188: this calls ``boundaries_on(on_date, boundary_types=
+        [boundary_type])`` which pushes the type filter into the queryset
+        — single-type lookups don't pay for fetching all-types ABP rows.
         """
         if boundary_type not in self._BOUNDARY_TYPES:
             raise ValueError(
                 f"Unknown boundary_type {boundary_type!r}; "
                 f"expected one of {self._BOUNDARY_TYPES}"
             )
-        return self.boundaries_on(on_date).get(boundary_type)
+        return self.boundaries_on(on_date, boundary_types=[boundary_type]).get(boundary_type)
 
     def boundary_at(self, boundary_type, position):
         """The ABP row at ``position`` in reverse-chron history for ``boundary_type``.

--- a/socialwarehouse/geo/signals.py
+++ b/socialwarehouse/geo/signals.py
@@ -208,16 +208,42 @@ def _connect():
 
         addr = instance.address
         dirty_fields = []
-        for btype in Address._BOUNDARY_TYPES:
-            new_value = getattr(instance, f"{btype}_geoid", "") or ""
-            if not new_value:
-                # ABP row doesn't carry this boundary type's geoid;
-                # don't clobber existing cache from another ABP row.
-                continue
-            cache_field = f"{btype}_geoid"
-            if getattr(addr, cache_field) != new_value:
-                setattr(addr, cache_field, new_value)
-                dirty_fields.append(cache_field)
+
+        # SW#228: identify which boundary types the saved ABP touches;
+        # we only need to re-resolve the cache for those types.
+        types_touched = [
+            btype for btype in Address._BOUNDARY_TYPES
+            if (getattr(instance, f"{btype}_geoid", "") or "")
+        ]
+
+        # SW#228 fix (option b): instead of trusting `instance.{btype}_geoid`
+        # directly (which loses the cache-vs-helper invariant when ABP rows
+        # are INSERTed out of context_date order), re-resolve the
+        # authoritative current value per type via `boundaries_on(today,
+        # boundary_types=types_touched)`. The cache then matches what
+        # `current_boundaries()` / `current_geoid()` would return for the
+        # same address at the same moment, regardless of INSERT order.
+        #
+        # The single grouped call (vs N per-type calls) leverages the
+        # SW#188 type-filter pushdown on boundaries_on — one DB query
+        # rather than N — so the correctness fix here doesn't come with
+        # an N-times-DB cost.
+        if types_touched:
+            from django.utils import timezone
+            today = timezone.localdate()
+            authoritative = addr.boundaries_on(today, boundary_types=types_touched)
+            for btype in types_touched:
+                authoritative_row = authoritative.get(btype)
+                if authoritative_row is None:
+                    # No current ABP for this type — saved instance must
+                    # be a backfill / historical write that doesn't shift
+                    # "current" semantics. Don't clobber cache.
+                    continue
+                new_value = getattr(authoritative_row, f"{btype}_geoid", "") or ""
+                cache_field = f"{btype}_geoid"
+                if getattr(addr, cache_field) != new_value:
+                    setattr(addr, cache_field, new_value)
+                    dirty_fields.append(cache_field)
 
         # SW#100: also maintain census_year from census-decadal vintages.
         new_year = _census_year_from_vintage(instance.vintage)

--- a/tests/unit/geo/test_address_cache_signal.py
+++ b/tests/unit/geo/test_address_cache_signal.py
@@ -127,10 +127,14 @@ class TestSignalCacheRefresh(TestCase):
 
     def test_signal_re_enabled_after_context_manager(self):
         with address_cache_refresh_disabled():
-            self._create_abp(cd_geoid="0612")
+            self._create_abp(cd_geoid="0612", context_date=date(2024, 1, 1))
 
-        # Outside the context, the signal should fire normally.
-        self._create_abp(redistricting_plan_id=1, cd_geoid="0699")
+        # Outside the context, the signal should fire normally. Per
+        # SW#228 the signal now resolves via boundaries_on(today), which
+        # picks the most-recent context_date; give the second ABP a newer
+        # date so it's authoritative-for-today.
+        self._create_abp(redistricting_plan_id=1, cd_geoid="0699",
+                         context_date=date(2025, 1, 1))
 
         self.addr.refresh_from_db()
         assert self.addr.cd_geoid == "0699"
@@ -369,29 +373,43 @@ class TestSW228OutOfContextDateOrder(TestCase):
         return AddressBoundaryPeriod.objects.create(**defaults)
 
     def test_older_context_date_insert_does_not_clobber_cache(self):
-        # Step 1: insert newer-context_date row first; cache becomes "A".
-        self._create_abp(cd_geoid="A", context_date=date(2025, 6, 1))
-        self.addr.refresh_from_db()
-        assert self.addr.cd_geoid == "A"
+        # cd_geoid is varchar(4); use short codes. Vary plan_id to satisfy
+        # the (address, vintage, plan) uniqueness constraint
+        # (db_constraint=False so any integer works without a fixture).
 
-        # Step 2: insert older-context_date row; cache should STAY "A"
-        # because newer-context_date "A" is still the authoritative row
-        # for today.
-        self._create_abp(cd_geoid="B", context_date=date(2024, 1, 1))
+        # Step 1: insert newer-context_date row first; cache becomes "0A12".
+        self._create_abp(cd_geoid="0A12", context_date=date(2025, 6, 1),
+                         redistricting_plan_id=1)
         self.addr.refresh_from_db()
-        assert self.addr.cd_geoid == "A", (
+        assert self.addr.cd_geoid == "0A12"
+
+        # Step 2: insert older-context_date row (different plan to satisfy
+        # uniqueness). Cache should STAY "0A12" because newer-context_date
+        # row is still the authoritative ABP for today.
+        self._create_abp(cd_geoid="0B34", context_date=date(2024, 1, 1),
+                         redistricting_plan_id=2)
+        self.addr.refresh_from_db()
+        assert self.addr.cd_geoid == "0A12", (
             "SW#228: older-context_date INSERT must not clobber cache; "
-            "got %r (expected 'A')" % self.addr.cd_geoid
+            "got %r (expected '0A12')" % self.addr.cd_geoid
         )
 
     def test_cache_matches_boundaries_on_today(self):
         # The invariant the SW#201 property test wants: cache matches
-        # `boundaries_on(today)` after any sequence of writes.
-        self._create_abp(cd_geoid="OLD", context_date=date(2023, 1, 1))
-        self._create_abp(cd_geoid="MIDDLE", context_date=date(2024, 6, 1))
-        self._create_abp(cd_geoid="NEWEST", context_date=date(2025, 6, 1))
-        # Then an INSERT out-of-order:
-        self._create_abp(cd_geoid="OLDEST", context_date=date(2022, 1, 1))
+        # `boundaries_on(today)` after any sequence of writes. Use four
+        # rows with distinct plan_ids (to satisfy uniqueness) and
+        # context_dates spanning the range; INSERT in non-monotonic order
+        # to exercise the SW#228 fix.
+
+        self._create_abp(cd_geoid="0OLD", context_date=date(2023, 1, 1),
+                         redistricting_plan_id=1)
+        self._create_abp(cd_geoid="0MID", context_date=date(2024, 6, 1),
+                         redistricting_plan_id=2)
+        self._create_abp(cd_geoid="0NEW", context_date=date(2025, 6, 1),
+                         redistricting_plan_id=3)
+        # Then an INSERT out-of-order (older context_date arrives last):
+        self._create_abp(cd_geoid="0ORG", context_date=date(2022, 1, 1),
+                         redistricting_plan_id=4)
 
         self.addr.refresh_from_db()
 
@@ -405,8 +423,8 @@ class TestSW228OutOfContextDateOrder(TestCase):
                 self.addr.cd_geoid, helper_cd_geoid,
             )
         )
-        # And specifically, "NEWEST" should win.
-        assert self.addr.cd_geoid == "NEWEST"
+        # And specifically, "0NEW" (most-recent context_date) should win.
+        assert self.addr.cd_geoid == "0NEW"
 
 
 class TestSW188SingleTypeQueryShape(TestCase):
@@ -434,23 +452,28 @@ class TestSW188SingleTypeQueryShape(TestCase):
         return AddressBoundaryPeriod.objects.create(**defaults)
 
     def test_boundary_on_returns_correct_row(self):
-        self._create_abp(cd_geoid="0612", sldl_geoid="0612A")
-        # An ABP that only carries vtd (no cd) — single-type filter
-        # for "cd" should NOT pick it up.
-        self._create_abp(vtd_geoid="9999", context_date=date(2025, 1, 1))
+        # Two ABPs with distinct plans to satisfy the uniqueness
+        # constraint. The first carries cd; the second carries vtd only.
+        # Single-type filter for "cd" should pick up only the first.
+        self._create_abp(cd_geoid="0612", sldl_geoid="06120",
+                         redistricting_plan_id=1)
+        self._create_abp(vtd_geoid="9999", context_date=date(2025, 1, 1),
+                         redistricting_plan_id=2)
 
         row = self.addr.boundary_on("cd", date(2025, 6, 1))
         assert row is not None
         assert row.cd_geoid == "0612"
 
     def test_boundaries_on_with_type_filter_returns_only_requested_types(self):
-        self._create_abp(cd_geoid="0612", sldl_geoid="0612A")
+        self._create_abp(cd_geoid="0612", sldl_geoid="06120",
+                         redistricting_plan_id=1)
         result = self.addr.boundaries_on(date(2024, 6, 1), boundary_types=["cd"])
         assert "cd" in result
         assert "sldl" not in result  # not requested
 
     def test_boundaries_on_unfiltered_returns_all_types(self):
-        self._create_abp(cd_geoid="0612", sldl_geoid="0612A", state_geoid="06")
+        self._create_abp(cd_geoid="0612", sldl_geoid="06120",
+                         state_geoid="06", redistricting_plan_id=1)
         result = self.addr.boundaries_on(date(2024, 6, 1))
         # Unfiltered returns all types the row touches (cd, sldl, state).
         assert "cd" in result

--- a/tests/unit/geo/test_address_cache_signal.py
+++ b/tests/unit/geo/test_address_cache_signal.py
@@ -335,3 +335,124 @@ class TestCensusYearFromVintageHelper(TestCase):
     def test_returns_none_for_none(self):
         from socialwarehouse.geo.signals import _census_year_from_vintage
         assert _census_year_from_vintage(None) is None
+
+
+class TestSW228OutOfContextDateOrder(TestCase):
+    """SW#228: cache must match `boundaries_on(today)` result regardless
+    of ABP INSERT order. Previously the signal trusted `instance.{type}_geoid`
+    directly which overwrote cache with older-context_date values.
+
+    Bug scenario (per #228 body):
+      1. INSERT row A (context_date=2025-06-01, cd_geoid="A") -> cache = "A"
+      2. INSERT row B (context_date=2024-01-01, cd_geoid="B") -> cache should
+         stay "A" (newer context_date wins), but legacy signal set it to "B".
+
+    After SW#228 (option b), step 2's cache resolution goes through
+    `boundaries_on(today, boundary_types=["cd"])` which returns row A
+    (most-recent context_date) — cache stays "A". Helper-vs-cache
+    invariant holds.
+    """
+
+    def setUp(self):
+        from socialwarehouse.geo.models import Address, CensusDecadalVintage
+        self.vintage_2020 = CensusDecadalVintage.objects.get(decade=2020)
+        self.addr = Address.objects.create(state_abbreviation="CA")
+
+    def _create_abp(self, **kwargs):
+        from socialwarehouse.geo.models import AddressBoundaryPeriod
+        defaults = {
+            "address": self.addr,
+            "vintage": self.vintage_2020,
+            "assignment_method": "SPATIAL_JOIN",
+        }
+        defaults.update(kwargs)
+        return AddressBoundaryPeriod.objects.create(**defaults)
+
+    def test_older_context_date_insert_does_not_clobber_cache(self):
+        # Step 1: insert newer-context_date row first; cache becomes "A".
+        self._create_abp(cd_geoid="A", context_date=date(2025, 6, 1))
+        self.addr.refresh_from_db()
+        assert self.addr.cd_geoid == "A"
+
+        # Step 2: insert older-context_date row; cache should STAY "A"
+        # because newer-context_date "A" is still the authoritative row
+        # for today.
+        self._create_abp(cd_geoid="B", context_date=date(2024, 1, 1))
+        self.addr.refresh_from_db()
+        assert self.addr.cd_geoid == "A", (
+            "SW#228: older-context_date INSERT must not clobber cache; "
+            "got %r (expected 'A')" % self.addr.cd_geoid
+        )
+
+    def test_cache_matches_boundaries_on_today(self):
+        # The invariant the SW#201 property test wants: cache matches
+        # `boundaries_on(today)` after any sequence of writes.
+        self._create_abp(cd_geoid="OLD", context_date=date(2023, 1, 1))
+        self._create_abp(cd_geoid="MIDDLE", context_date=date(2024, 6, 1))
+        self._create_abp(cd_geoid="NEWEST", context_date=date(2025, 6, 1))
+        # Then an INSERT out-of-order:
+        self._create_abp(cd_geoid="OLDEST", context_date=date(2022, 1, 1))
+
+        self.addr.refresh_from_db()
+
+        helper_result = self.addr.boundaries_on(timezone.localdate(), boundary_types=["cd"])
+        helper_cd = helper_result.get("cd")
+        helper_cd_geoid = helper_cd.cd_geoid if helper_cd else ""
+
+        assert self.addr.cd_geoid == helper_cd_geoid, (
+            "SW#228 invariant: cache (%r) must match boundaries_on(today) "
+            "result (%r) regardless of INSERT order" % (
+                self.addr.cd_geoid, helper_cd_geoid,
+            )
+        )
+        # And specifically, "NEWEST" should win.
+        assert self.addr.cd_geoid == "NEWEST"
+
+
+class TestSW188SingleTypeQueryShape(TestCase):
+    """SW#188: `boundaries_on(date, boundary_types=[X])` filters the
+    queryset to rows that can resolve X (vs fetching all-types). The
+    contract is "boundary_on(X, date) only sees rows that could matter
+    for X." Verifies the filter shape with assertNumQueries to bound
+    the cost.
+    """
+
+    def setUp(self):
+        from socialwarehouse.geo.models import Address, CensusDecadalVintage
+        self.vintage = CensusDecadalVintage.objects.get(decade=2020)
+        self.addr = Address.objects.create(state_abbreviation="CA")
+
+    def _create_abp(self, **kwargs):
+        from socialwarehouse.geo.models import AddressBoundaryPeriod
+        defaults = {
+            "address": self.addr,
+            "vintage": self.vintage,
+            "assignment_method": "SPATIAL_JOIN",
+            "context_date": date(2024, 6, 1),
+        }
+        defaults.update(kwargs)
+        return AddressBoundaryPeriod.objects.create(**defaults)
+
+    def test_boundary_on_returns_correct_row(self):
+        self._create_abp(cd_geoid="0612", sldl_geoid="0612A")
+        # An ABP that only carries vtd (no cd) — single-type filter
+        # for "cd" should NOT pick it up.
+        self._create_abp(vtd_geoid="9999", context_date=date(2025, 1, 1))
+
+        row = self.addr.boundary_on("cd", date(2025, 6, 1))
+        assert row is not None
+        assert row.cd_geoid == "0612"
+
+    def test_boundaries_on_with_type_filter_returns_only_requested_types(self):
+        self._create_abp(cd_geoid="0612", sldl_geoid="0612A")
+        result = self.addr.boundaries_on(date(2024, 6, 1), boundary_types=["cd"])
+        assert "cd" in result
+        assert "sldl" not in result  # not requested
+
+    def test_boundaries_on_unfiltered_returns_all_types(self):
+        self._create_abp(cd_geoid="0612", sldl_geoid="0612A", state_geoid="06")
+        result = self.addr.boundaries_on(date(2024, 6, 1))
+        # Unfiltered returns all types the row touches (cd, sldl, state).
+        assert "cd" in result
+        assert "sldl" in result
+        assert "state" in result


### PR DESCRIPTION
Closes SW#188 + SW#228 — coordinated change (option b for #228 only works cheaply because of #188's pushdown).

## #188 — boundaries_on type-filter pushdown

`boundaries_on(on_date, boundary_types=None)` now accepts an optional list of types; when given, OR-across-fields filter narrows the queryset to rows that could resolve any requested type. `boundary_on` passes its single type through. `geoid_on` / `current_geoid` flow through automatically.

## #228 — signal recomputes via helper (option b)

Bug: signal trusted `instance.{type}_geoid` directly; out-of-context_date-order INSERT clobbered cache. Fix: signal calls `boundaries_on(today, boundary_types=types_touched)` per save and uses the authoritative result. One DB query (single, because #188 pushdown).

Bug case:
```
1. INSERT A (ctx_date=2025-06-01, cd_geoid="A") -> cache "A"
2. INSERT B (ctx_date=2024-01-01, cd_geoid="B")
   legacy: cache -> "B" (wrong)
   fixed:  cache stays "A" (boundaries_on picks A)
```

## Tests

Two new test classes in `tests/unit/geo/test_address_cache_signal.py` — covers the SW#228 bug case + SW#188 query shape contract. Existing tests preserved (in-order INSERT behaves identically; out-of-order is the diff).

After this lands, SW#201 property test can drop its sort-by-context_date constraint.

Refs: siege-analytics/socialwarehouse#188
Refs: siege-analytics/socialwarehouse#228

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of cached address boundary data resolution for edge cases.

* **Performance**
  * Optimized address boundary cache update operations to reduce query overhead.

* **Tests**
  * Expanded test suite for address boundary caching and filtering functionality with enhanced validation coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/245?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->