### PR TITLE
release: v2.1.0 (queue-empty cut)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "socialwarehouse"
-version = "2.0.1-dev"
+version = "2.1.0"
 description = "Data warehouse and delta lake for geographic, demographic, and civic data — the DSTK replacement"
 readme = "README.md"
 license = {text = "Proprietary"}

--- a/socialwarehouse/__init__.py
+++ b/socialwarehouse/__init__.py
@@ -11,4 +11,4 @@ Architecture:
                        DSTK REST API, Delta Lake + Spark orchestration
 """
 
-__version__ = "2.0.1-dev"
+__version__ = "2.1.0"


### PR DESCRIPTION
First release under queue-empty-then-release discipline. SW open-issue queue at zero at tag time.

## What landed since v2.0.0

| Sub-issue | What | PR |
|---|---|---|
| SW#33 | Remove legacy code/ directory | #240 |
| SW#196 | CI baseline snapshot + CONTRIBUTING.md | #243 |
| SW#35 | Unified fetch entry point + source registry | #244 |
| SW#188 + SW#228 | Single-type lookup pushdown + context-date-aware signal | #245 |
| SW#34 | FEC campaign-finance graph + centrality CLI | #246 |
| SW#22 | Self-hosted Nominatim scaffolding + RI demo | #247 |

## Compatibility

Purely additive. No breaking changes since v2.0.0. Existing consumers see no behavior change unless they opt-in to new features.