### PR TITLE
chore: bump to 2.1.1-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "socialwarehouse"
-version = "2.1.0"
+version = "2.1.1-dev"
 description = "Data warehouse and delta lake for geographic, demographic, and civic data — the DSTK replacement"
 readme = "README.md"
 license = {text = "Proprietary"}

--- a/socialwarehouse/__init__.py
+++ b/socialwarehouse/__init__.py
@@ -11,4 +11,4 @@ Architecture:
                        DSTK REST API, Delta Lake + Spark orchestration
 """
 
-__version__ = "2.1.0"
+__version__ = "2.1.1-dev"


### PR DESCRIPTION
Post-v2.1.0 dev-version bump. Prevents accidental publish of unreleased build between v2.1.0 and the next tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 2.1.1-dev.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->