### PR TITLE
feat(warehouse): canonical Person + score + vote-history (#251)

### DIFF
--- a/docs/entities/dim-person.md
+++ b/docs/entities/dim-person.md
@@ -1,0 +1,75 @@
+# DimPerson
+
+Canonical voter dimension in the PostGIS star schema. The Django ORM-facing projection of the Delta `silver.persons` table.
+
+## Position in the warehouse
+
+```
+Vendor file (PDI / L2 / Catalist / TS)
+    ↓
+bronze.voter_file_<vendor>  (Delta; raw row as JSON string)
+    ↓ silver-build Spark job
+silver.persons              (Delta; canonical, typed, vendor-neutral)
+    ↓ Spark→PostGIS materialization
+DimPerson                   (PostGIS; this model)
+    ↓ Django ORM
+Web app, admin, DRF API
+```
+
+Per [`docs/architecture.md`](../architecture.md): warehouse first, web app last. Silver is canonical; DimPerson is the serving-tier projection.
+
+## Natural key
+
+`(vendor, vendor_voter_id)` — `unique_together`.
+
+Same physical voter loaded from two vendors yields TWO DimPerson rows. Cross-vendor probabilistic matching is a follow-on sub-issue of #250; the schema permits the addition of a `canonical_person_id` column linking the rows when the matcher ships.
+
+## Current-only, not SCD2
+
+Vendor voter files are themselves point-in-time snapshots. The effective-dated semantics that `DimGeography` uses (SCD Type 2) do not apply: a vendor doesn't ship "this voter was at this address from 2022-01-01 to 2024-03-15"; it ships "as of the file's load date, here's the voter."
+
+Historical truth lives in `silver.persons` (append/upsert), where each load preserves the prior state. DimPerson is always the latest snapshot. Promote to SCD2 only if a concrete consumer asks for effective-dated person history and accepts the maintenance cost.
+
+## Vendor mapping checklist
+
+When implementing an importer (sub-issues B-E of #250), map each TS-equivalent vendor field to the canonical DimPerson column. Fields that don't map go in the `<vendor>_extras` JSONField.
+
+| Canonical column | TS field | L2 field | Catalist field | PDI field |
+|---|---|---|---|---|
+| `vendor_voter_id` | `vb.voterbase_id` | `LALVOTERID` | `dwid` | `pdi_id` |
+| `first_name` | `vb.tsmart_first_name` | `Voters_FirstName` | `first_name` | `first_name` |
+| `last_name` | `vb.tsmart_last_name` | `Voters_LastName` | `last_name` | `last_name` |
+| `dob` | `vb.voterbase_dob` | `Voters_BirthDate` | `birthdate` | `dob` |
+| `registration_status` | `vb.vf_voter_status` | `Voters_Active` | `registration_status` | `voter_status` |
+| `registration_state` | `vb.vf_source_state` | `Voters_StateVoterID` first 2 | `state` | `state` |
+| `party_registration` | `vb.vf_party` | `Parties_Description` | `party_affiliation` | `party` |
+| `address_line1` | `vb.vf_reg_address_1` | `Residence_Addresses_AddressLine` | `residence_street` | `address_line_1` |
+| `city` | `vb.vf_reg_city` | `Residence_Addresses_City` | `residence_city` | `city` |
+| `zip5` | `vb.vf_reg_zip` | `Residence_Addresses_Zip` | `residence_zip` | `zip` |
+| `latitude` | `vb.tsmart_latitude` | `Residence_Addresses_Latitude` | `latitude` | `latitude` |
+| `longitude` | `vb.tsmart_longitude` | `Residence_Addresses_Longitude` | `longitude` | `longitude` |
+| `cd_geoid` | `vb.vf_cd` | `US_Congressional_District` | `cd` | `congressional_district` |
+| `sldu_geoid` | `vb.vf_sd` | `State_Senate_District` | `sd` | `state_senate` |
+| `sldl_geoid` | `vb.vf_hd` | `State_House_District` | `hd` | `state_house` |
+| `household_id` | `vb.tsmart_household_id` | `Household_Composition` | `household_id` | `household_id` |
+| `general_election_count` | `vb.vf_g_*` aggregated | `General_<year>` aggregated | `general_voted_*` aggregated | `general_*` aggregated |
+
+This is a starter map; importer PRs (B-E of #250) fill in the rest. Unmapped vendor fields go in `<vendor>_extras`.
+
+## Schema evolution
+
+If a vendor extra becomes load-bearing — queried often, present across vendors, type-stable — promote it to a canonical column via [`docs/warehouse-schema-evolution.md`](../warehouse-schema-evolution.md).
+
+## Aggregate refresh cadence
+
+`general_election_count`, `primary_election_count`, `total_vote_count`, `last_voted_at`, `vote_frequency_category` are denormalized for query speed. They are computed by the silver-build Spark job from `silver.vote_history` and materialized onto DimPerson via the same Spark→PostGIS path.
+
+The cadence is "per ingest run." Django signals are NOT used; signal-driven refresh would couple too tightly to ingest order in a bulk-load context. If a consumer needs sub-ingest-cadence aggregates, query `FactVoteHistory` directly.
+
+## See also
+
+- [`docs/architecture.md`](../architecture.md) — warehouse-first principle.
+- [`docs/entities/fact-person-score.md`](fact-person-score.md) — score vocabulary.
+- [`docs/entities/fact-vote-history.md`](fact-vote-history.md) — vote-event semantics.
+- [`docs/warehouse-schema-evolution.md`](../warehouse-schema-evolution.md) — promotion playbook.
+- Refs: SW#250 (initiative), SW#251 (this sub-issue).

--- a/docs/entities/fact-person-score.md
+++ b/docs/entities/fact-person-score.md
@@ -1,0 +1,62 @@
+# FactPersonScore
+
+Per-person score events: partisan scores, turnout propensity, issue-stance models, anything vendors ship that is a numeric value attached to a voter.
+
+## Tall format
+
+One row per `(person, score_type, source_vendor, methodology_version)`. The `score_type` is a free string, not an enum. Adding a new score type is a new row, not a migration.
+
+This is intentional: vendor scoring vocabularies grow every cycle (new issue-stance models, refreshed turnout models, etc.). A wide-format table with a column per score type would be a migration treadmill.
+
+## Vendor scores are not interchangeable
+
+A TS partisan score and an L2 partisan score are not the same number even when both are normalized to `[0, 1]`. Each carries its `source_vendor` and `methodology_version`. Querying "give me the partisan score for this person" requires picking a source explicitly:
+
+```python
+person.scores.filter(
+    score_type="partisan_score",
+    source_vendor="ts",
+).latest("scored_at")
+```
+
+Don't average across vendors; don't pick "whichever vendor has the most recent." That silently introduces methodology mixing.
+
+## Score-type vocabulary (registered)
+
+Importers must use these strings for the listed concepts. Add new strings as new score types — but if a vendor's score maps cleanly to one of these, use the registered string, not a vendor-specific alias.
+
+| `score_type` | Meaning | Range | Vendors known to ship |
+|---|---|---|---|
+| `partisan_score` | Probability the person votes D (or supports D); higher = more D | 0.0 – 1.0 | TS, L2, Catalist, PDI |
+| `turnout_propensity_general` | Probability the person votes in a general | 0.0 – 1.0 | TS, L2, Catalist, PDI |
+| `turnout_propensity_primary` | Probability the person votes in a primary | 0.0 – 1.0 | TS, L2, Catalist |
+| `ideology_score` | Liberal-conservative axis; higher = more conservative | 0.0 – 1.0 | TS, L2 |
+| `issue_<topic>` | Issue-specific stance (e.g. `issue_abortion`, `issue_climate`, `issue_gun_safety`) | 0.0 – 1.0 typical | TS, L2 (varies) |
+| `engagement_score` | Likelihood of responding to outreach | 0.0 – 1.0 | TS, Catalist |
+| `persuadability_score` | Likelihood of being moved by persuasion contact | 0.0 – 1.0 | TS |
+
+Importers writing new score types should:
+
+1. Check the registered list above; use the existing string if it fits.
+2. Add the new string to this document AND to the importer's docstring.
+3. Name the methodology version explicitly: cycle year + vendor revision (e.g. `2024Q4`).
+
+## Methodology version semantics
+
+`methodology_version` is a free string but should follow the pattern `<cycle><quarter>` or `<vendor>-<version>` so consumers can compare versions chronologically. Examples:
+
+- `2024Q4`, `2026Q1` — for cycle-aligned refreshes
+- `ts-v3.2`, `l2-2024.11` — for vendor-versioned refreshes
+- `manual-2026-05-22` — for one-off bespoke scoring
+
+The `unique_together = (person, score_type, source_vendor, methodology_version)` constraint means re-running an importer with the same methodology version is idempotent. Bumping the methodology version creates a parallel row; both are queryable.
+
+## Schema evolution
+
+`score_type` and `methodology_version` evolve freely (new strings, no migrations). The columns themselves are stable; if a fundamentally new score shape appears (e.g. multi-dimensional scores), file a follow-on sub-issue.
+
+## See also
+
+- [`docs/architecture.md`](../architecture.md) — warehouse-first principle.
+- [`docs/entities/dim-person.md`](dim-person.md) — Person model.
+- Refs: SW#250 (initiative), SW#251 (this sub-issue).

--- a/docs/entities/fact-vote-history.md
+++ b/docs/entities/fact-vote-history.md
@@ -1,0 +1,61 @@
+# FactVoteHistory
+
+Per-person per-election vote events. The truth-of-record for who voted when and how, sourced from voter file vote history sections.
+
+## Natural key
+
+`unique_together = (person, election_date, election_type, source_vendor)`.
+
+The inclusion of `source_vendor` means two vendors reporting the same vote both land in the table — neither is masked. Cross-vendor reconciliation (when two vendors disagree on `voted_method`) is a consumer-side decision; the data preserves both observations.
+
+## Election types
+
+| `election_type` | Meaning |
+|---|---|
+| `general` | November general election (federal + state) |
+| `primary` | Party primary (open or closed) |
+| `runoff` | Runoff following a non-decisive election |
+| `special` | Special election (mid-cycle, single-office) |
+| `local` | Municipal / school board / non-partisan local |
+| `other` | Anything that doesn't fit the above |
+
+`other` should be rare; if a vendor consistently ships an election type not in this list, file a sub-issue to add it.
+
+## Voted methods
+
+| `voted_method` | Meaning |
+|---|---|
+| `in_person` | In-person on election day |
+| `absentee` | Absentee ballot (excuse-required) |
+| `mail` | Vote-by-mail / no-excuse absentee |
+| `early` | Early in-person |
+| `provisional` | Provisional ballot (resolution status not tracked here) |
+| `unknown` | Vendor did not report the method |
+
+Default is `unknown`. Importers that have method data must populate it.
+
+## Aggregate denormalization
+
+`DimPerson.general_election_count`, `primary_election_count`, `total_vote_count`, `last_voted_at`, and `vote_frequency_category` are computed FROM this table by the silver-build Spark job and materialized onto DimPerson for query speed.
+
+If a consumer query needs sub-ingest-cadence aggregates (e.g. mid-load partial counts), query FactVoteHistory directly with `aggregate(Count('id'))`. Don't rely on DimPerson's denormalized values mid-load.
+
+## Cross-vendor disagreement
+
+When two vendors report the same vote with different `voted_method`:
+
+- Both rows are preserved (`unique_together` includes `source_vendor`).
+- DimPerson aggregates count the vote once per `(election_date, election_type)` to avoid double-counting. The Spark job handles this; see the silver-build doc when it ships.
+- Consumer queries that want "give me this person's method" must pick a vendor; querying across both without picking is ambiguous.
+
+## Why we don't store more election metadata
+
+`FactElectionResult` (existing) holds vote tallies, candidates, offices, parties at the geography level. `FactVoteHistory` is the per-person counterpart: "did this person vote?", not "what did they vote for?" (voter privacy means the latter is not in the file at all).
+
+The two facts are joinable via `(election_date)` if a consumer needs to ask "of the people who voted in this election, what was the overall result?" — but that's a join, not a denormalization.
+
+## See also
+
+- [`docs/architecture.md`](../architecture.md) — warehouse-first principle.
+- [`docs/entities/dim-person.md`](dim-person.md) — Person model + aggregate refresh cadence.
+- Refs: SW#250 (initiative), SW#251 (this sub-issue).

--- a/docs/warehouse-schema-evolution.md
+++ b/docs/warehouse-schema-evolution.md
@@ -1,0 +1,123 @@
+# Warehouse schema evolution
+
+How to evolve the warehouse schema safely, end-to-end across both warehouse tiers (Delta Lake + PostGIS star schema). Mirrors the `Warehouse first, web app last` design order from [`docs/architecture.md`](architecture.md).
+
+## When to evolve
+
+Two common evolution shapes:
+
+1. **Promoting a vendor-extras map key to a canonical column** — a key that started life in a `vendor_extras` map (Delta) / `*_extras` JSONField (PostGIS) is now stable enough to deserve type safety.
+2. **Adding a new canonical column directly** — a new field appears in vendor data that we want to canonicalize from day one.
+
+This document covers (1). Pattern (2) is a subset (skip the backfill step).
+
+## Promotion playbook
+
+### 1. Establish the case
+
+Cite evidence in the design note for the promoting PR:
+
+- The key appears in N≥3 importers (or is queried often enough to justify type safety despite single-vendor source).
+- The key's value semantics are stable across importers (not "TS calls it foo and L2 calls it bar but they mean different things").
+- A consumer is asking for typed queries that the Map<String,String> shape doesn't support cleanly.
+
+If the evidence chain is empty, leave the key in the map.
+
+### 2. Update the silver Delta schema
+
+Edit the relevant `StructType` in `socialwarehouse/delta/tables.py`:
+
+```python
+SILVER_PERSONS = StructType([
+    # ... existing fields ...
+    StructField("new_canonical_field", StringType(), True),  # or appropriate type
+    # vendor_extras remains; key removal happens at importer level.
+])
+```
+
+Apply to the live table:
+
+```sql
+ALTER TABLE delta.`silver.persons` ADD COLUMNS (new_canonical_field STRING)
+```
+
+(Delta SQL via `spark.sql(...)`.)
+
+### 3. Backfill from existing rows
+
+```sql
+UPDATE delta.`silver.persons`
+SET new_canonical_field = vendor_extras['old_key_name']
+WHERE vendor_extras['old_key_name'] IS NOT NULL
+  AND new_canonical_field IS NULL
+```
+
+The `AND new_canonical_field IS NULL` clause makes the backfill idempotent — re-running it does not stomp on fresh writes.
+
+### 4. Update each importer
+
+Each vendor's silver-build job now writes the new column going forward. Two policy choices for the map key:
+
+- **Retain the map key.** Storage cost is small; provenance is preserved; downstream code that read from `vendor_extras['old_key_name']` keeps working. Default choice.
+- **Remove the map key on next ingest.** Cleaner; requires a deprecation period and importer migration.
+
+Default to retain. Pivot to remove only if the map storage cost is real.
+
+### 5. Add the Django field
+
+Edit `socialwarehouse/warehouse/models/dimensions.py` (or `facts.py`):
+
+```python
+class DimPerson(models.Model):
+    # ... existing fields ...
+    new_canonical_field = models.CharField(max_length=128, blank=True, default="")
+```
+
+Generate and run the migration:
+
+```bash
+python manage.py makemigrations warehouse --name add_new_canonical_field
+python manage.py migrate warehouse
+```
+
+Forward-only. Never edit an existing migration once it has landed on `main`.
+
+### 6. Update the materialization job
+
+The Spark→PostGIS materialization that reads from `silver.persons` and upserts into `sw_warehouse_dimperson` now populates the new PostGIS column from the new silver column.
+
+If the materialization job uses an explicit column list, add the new column there. If it uses `df.write.jdbc(...)` over the full DataFrame, the addition is automatic.
+
+### 7. Record the promotion
+
+Append an entry to the table below in this document.
+
+## Promotion log
+
+| Date | Field promoted | From map key | Evidence-of-need | PR | Backfill date |
+|---|---|---|---|---|---|
+| _(no promotions yet)_ | | | | | |
+
+## What does NOT need this playbook
+
+- **Adding a new `score_type` value to `FactPersonScore`.** `score_type` is a free string field; new values are new rows, no schema change.
+- **Adding a new entry to a `*_extras` JSONField.** That's exactly what the map is for. No coordination needed.
+- **A vendor renaming a field on its side.** Importer change only; canonical column name does not move.
+
+## What this playbook does NOT permit
+
+- **Removing a canonical column** without a deprecation period. Removing breaks downstream queries; the right response is "deprecate, document, give consumers N releases to migrate, then remove."
+- **Renaming a canonical column** in-place. Add the new name; deprecate the old; remove after a release.
+- **Type changes on a canonical column.** Type narrowing breaks consumers; type widening confuses analytics. Add a new column at the new type; deprecate the old.
+- **Editing the Django migration after it has landed.** Forward-only is the project rule.
+
+## Why this lives in repo docs and not just in tribal knowledge
+
+The `Map<String,String>` extension bag works only if there is a credible way to escape it. Without a documented promotion path, every "should this be in the bag?" question reopens the design debate. With this playbook, the answer is "yes for now, promote when the case is made per the steps above."
+
+## Cross-references
+
+- [`docs/architecture.md`](architecture.md) — warehouse-first, web-app-last design order.
+- [`docs/entities/dim-person.md`](entities/dim-person.md) — the canonical Person model.
+- [`docs/entities/fact-person-score.md`](entities/fact-person-score.md) — score vocabulary registry.
+- [`docs/entities/fact-vote-history.md`](entities/fact-vote-history.md) — vote-event semantics.

--- a/socialwarehouse/delta/tables.py
+++ b/socialwarehouse/delta/tables.py
@@ -11,10 +11,12 @@ Each table is defined as a schema + path + partitioning strategy.
 
 from pyspark.sql.types import (
     BooleanType,
+    DateType,
     DecimalType,
     DoubleType,
     IntegerType,
     LongType,
+    MapType,
     StringType,
     StructField,
     StructType,
@@ -40,6 +42,33 @@ BRONZE_ADDRESSES = StructType([
     StructField("source_row", IntegerType(), True),
     StructField("ingested_at", TimestampType(), False),
 ])
+
+## Per-vendor voter-file bronze (SW#251).
+##
+## Bronze stores the full vendor row as JSON in the `raw` column. The
+## four supported vendors (PDI, L2, Catalist, TargetSmart) have
+## hundreds of mostly-non-overlapping columns each — a union'd table
+## would be 1000+ nullable columns with poor column-prune behavior.
+## Per-vendor bronze keeps each importer schema close to its native
+## shape. Silver does the canonical unification.
+##
+## Schema-evolution: bronze is JSON-stringified, so vendor-side
+## column changes do not require bronze schema migrations. Bronze
+## evolution is restricted to the metadata fields below.
+_BRONZE_VOTER_FILE_FIELDS = [
+    StructField("vendor_voter_id", StringType(), False),
+    StructField("state_abbreviation", StringType(), False),
+    StructField("raw", StringType(), False),
+    StructField("source_file", StringType(), True),
+    StructField("source_row", LongType(), True),
+    StructField("ingested_at", TimestampType(), False),
+]
+
+BRONZE_VOTER_FILE_TS = StructType(_BRONZE_VOTER_FILE_FIELDS)
+BRONZE_VOTER_FILE_L2 = StructType(_BRONZE_VOTER_FILE_FIELDS)
+BRONZE_VOTER_FILE_CATALIST = StructType(_BRONZE_VOTER_FILE_FIELDS)
+BRONZE_VOTER_FILE_PDI = StructType(_BRONZE_VOTER_FILE_FIELDS)
+
 
 BRONZE_BOUNDARIES = StructType([
     StructField("geoid", StringType(), False),
@@ -106,6 +135,100 @@ SILVER_DEMOGRAPHICS = StructType([
 ])
 
 
+## Silver Person / score / vote-history (SW#251).
+##
+## Canonical, typed, vendor-neutral. One row per (vendor, vendor_voter_id):
+## same physical voter from two vendors yields two silver rows. Cross-
+## vendor probabilistic matching is a follow-on; the schema permits it
+## without rewrites by adding a `canonical_person_id` column later.
+##
+## `vendor_extras` Map<String, String> holds vendor-divergent fields
+## that have not been promoted to canonical columns. See
+## docs/warehouse-schema-evolution.md for the promotion playbook.
+
+SILVER_PERSONS = StructType([
+    # Natural key
+    StructField("vendor", StringType(), False),
+    StructField("vendor_voter_id", StringType(), False),
+    StructField("person_key", StringType(), False),
+    # Identity
+    StructField("first_name", StringType(), True),
+    StructField("middle_name", StringType(), True),
+    StructField("last_name", StringType(), True),
+    StructField("name_suffix", StringType(), True),
+    StructField("dob", DateType(), True),
+    StructField("gender", StringType(), True),
+    StructField("ethnicity", StringType(), True),
+    StructField("language", StringType(), True),
+    # Registration
+    StructField("registration_status", StringType(), True),
+    StructField("registration_state", StringType(), False),
+    StructField("registration_date", DateType(), True),
+    StructField("party_registration", StringType(), True),
+    StructField("voter_status_reason", StringType(), True),
+    # Address (resolved to canonical via geo pipeline)
+    StructField("address_id", LongType(), True),
+    StructField("address_line1", StringType(), True),
+    StructField("address_line2", StringType(), True),
+    StructField("city", StringType(), True),
+    StructField("zip5", StringType(), True),
+    StructField("zip4", StringType(), True),
+    StructField("latitude", DoubleType(), True),
+    StructField("longitude", DoubleType(), True),
+    # Pre-joined geoids (vendor pre-joins trusted on ingest; refreshed
+    # on redistricting-plan change)
+    StructField("census_year", IntegerType(), True),
+    StructField("state_geoid", StringType(), True),
+    StructField("county_geoid", StringType(), True),
+    StructField("tract_geoid", StringType(), True),
+    StructField("block_group_geoid", StringType(), True),
+    StructField("vtd_geoid", StringType(), True),
+    StructField("cd_geoid", StringType(), True),
+    StructField("sldl_geoid", StringType(), True),
+    StructField("sldu_geoid", StringType(), True),
+    StructField("zcta_geoid", StringType(), True),
+    # Household
+    StructField("household_id", StringType(), True),
+    StructField("household_size", IntegerType(), True),
+    StructField("is_head_of_household", BooleanType(), True),
+    # Vote-history aggregates (computed by silver build from
+    # silver.vote_history; denormalized for query speed)
+    StructField("general_election_count", IntegerType(), True),
+    StructField("primary_election_count", IntegerType(), True),
+    StructField("total_vote_count", IntegerType(), True),
+    StructField("last_voted_at", DateType(), True),
+    StructField("vote_frequency_category", StringType(), True),
+    # Evolvable vendor extension bag (see schema-evolution doc)
+    StructField("vendor_extras", MapType(StringType(), StringType()), True),
+    # Provenance
+    StructField("source_file", StringType(), True),
+    StructField("ingested_at", TimestampType(), False),
+    StructField("silver_built_at", TimestampType(), False),
+])
+
+
+SILVER_PERSON_SCORES = StructType([
+    StructField("person_key", StringType(), False),
+    StructField("score_type", StringType(), False),
+    StructField("value", DoubleType(), False),
+    StructField("source_vendor", StringType(), False),
+    StructField("methodology_version", StringType(), False),
+    StructField("scored_at", TimestampType(), True),
+    StructField("loaded_at", TimestampType(), False),
+])
+
+
+SILVER_VOTE_HISTORY = StructType([
+    StructField("person_key", StringType(), False),
+    StructField("election_date", DateType(), False),
+    StructField("election_year", IntegerType(), False),
+    StructField("election_type", StringType(), False),
+    StructField("voted_method", StringType(), True),
+    StructField("source_vendor", StringType(), False),
+    StructField("loaded_at", TimestampType(), False),
+])
+
+
 # ── Gold schemas ─────────────────────────────────────────────────────────
 
 GOLD_ENRICHED_ADDRESSES = StructType([
@@ -153,6 +276,30 @@ TABLES = {
         "partition_by": ["summary_level", "vintage_year"],
         "description": "Raw Census TIGER/Line boundary data",
     },
+    "bronze.voter_file_ts": {
+        "schema": BRONZE_VOTER_FILE_TS,
+        "path": get_table_path("bronze", "voter_file_ts"),
+        "partition_by": ["state_abbreviation"],
+        "description": "Raw TargetSmart voter-file rows (JSON-stringified)",
+    },
+    "bronze.voter_file_l2": {
+        "schema": BRONZE_VOTER_FILE_L2,
+        "path": get_table_path("bronze", "voter_file_l2"),
+        "partition_by": ["state_abbreviation"],
+        "description": "Raw L2 voter-file rows (JSON-stringified)",
+    },
+    "bronze.voter_file_catalist": {
+        "schema": BRONZE_VOTER_FILE_CATALIST,
+        "path": get_table_path("bronze", "voter_file_catalist"),
+        "partition_by": ["state_abbreviation"],
+        "description": "Raw Catalist voter-file rows (JSON-stringified)",
+    },
+    "bronze.voter_file_pdi": {
+        "schema": BRONZE_VOTER_FILE_PDI,
+        "path": get_table_path("bronze", "voter_file_pdi"),
+        "partition_by": ["state_abbreviation"],
+        "description": "Raw PDI voter-file rows (JSON-stringified)",
+    },
     # Silver
     "silver.addresses": {
         "schema": SILVER_ADDRESSES,
@@ -165,6 +312,24 @@ TABLES = {
         "path": get_table_path("silver", "demographics"),
         "partition_by": ["summary_level", "vintage_year"],
         "description": "Census ACS/Decennial estimates by geography",
+    },
+    "silver.persons": {
+        "schema": SILVER_PERSONS,
+        "path": get_table_path("silver", "persons"),
+        "partition_by": ["registration_state", "vendor"],
+        "description": "Canonical voter records, vendor-neutral, address-resolved",
+    },
+    "silver.person_scores": {
+        "schema": SILVER_PERSON_SCORES,
+        "path": get_table_path("silver", "person_scores"),
+        "partition_by": ["source_vendor", "score_type"],
+        "description": "Temporal-versioned scores per person, source-vendor-tagged",
+    },
+    "silver.vote_history": {
+        "schema": SILVER_VOTE_HISTORY,
+        "path": get_table_path("silver", "vote_history"),
+        "partition_by": ["election_year", "source_vendor"],
+        "description": "Per-person per-election vote events",
     },
     # Gold
     "gold.enriched_addresses": {

--- a/socialwarehouse/warehouse/admin.py
+++ b/socialwarehouse/warehouse/admin.py
@@ -1,0 +1,40 @@
+from django.contrib import admin
+
+from .models import DimPerson, FactPersonScore, FactVoteHistory
+
+
+@admin.register(DimPerson)
+class DimPersonAdmin(admin.ModelAdmin):
+    list_display = (
+        "id",
+        "vendor",
+        "vendor_voter_id",
+        "last_name",
+        "first_name",
+        "registration_state",
+        "registration_status",
+        "is_head_of_household",
+    )
+    list_filter = ("vendor", "registration_state", "registration_status")
+    search_fields = ("vendor_voter_id", "last_name", "first_name", "household_id")
+    readonly_fields = ("created_at", "updated_at", "last_loaded_at", "silver_source_path")
+    raw_id_fields = ("address",)
+
+
+@admin.register(FactPersonScore)
+class FactPersonScoreAdmin(admin.ModelAdmin):
+    list_display = ("id", "person", "score_type", "value", "source_vendor", "methodology_version", "scored_at")
+    list_filter = ("source_vendor", "score_type")
+    search_fields = ("person__vendor_voter_id", "person__last_name")
+    raw_id_fields = ("person",)
+    readonly_fields = ("loaded_at",)
+
+
+@admin.register(FactVoteHistory)
+class FactVoteHistoryAdmin(admin.ModelAdmin):
+    list_display = ("id", "person", "election_date", "election_type", "voted_method", "source_vendor")
+    list_filter = ("election_type", "voted_method", "source_vendor")
+    search_fields = ("person__vendor_voter_id", "person__last_name")
+    raw_id_fields = ("person",)
+    readonly_fields = ("loaded_at",)
+    date_hierarchy = "election_date"

--- a/socialwarehouse/warehouse/migrations/0003_person_score_vote_history.py
+++ b/socialwarehouse/warehouse/migrations/0003_person_score_vote_history.py
@@ -1,0 +1,119 @@
+# Hand-authored migration for SW#251 (Person + score + vote history).
+# Generated locally without makemigrations because the local dev env
+# does not have a GDAL version Django can detect; CI / docker env will.
+# Mirrors what `manage.py makemigrations warehouse` would produce.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_warehouse", "0002_remove_dimredistrictingcycle_decennial_census_year_and_more"),
+        ("sw_geo", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DimPerson",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("vendor", models.CharField(choices=[("pdi", "PDI"), ("l2", "L2"), ("catalist", "Catalist"), ("ts", "TargetSmart")], db_index=True, max_length=16)),
+                ("vendor_voter_id", models.CharField(db_index=True, max_length=128)),
+                ("first_name", models.CharField(blank=True, default="", max_length=128)),
+                ("middle_name", models.CharField(blank=True, default="", max_length=128)),
+                ("last_name", models.CharField(blank=True, default="", max_length=128)),
+                ("name_suffix", models.CharField(blank=True, default="", max_length=32)),
+                ("dob", models.DateField(blank=True, null=True)),
+                ("gender", models.CharField(blank=True, default="", max_length=32)),
+                ("ethnicity", models.CharField(blank=True, default="", max_length=64)),
+                ("language", models.CharField(blank=True, default="", max_length=64)),
+                ("registration_status", models.CharField(choices=[("active", "Active"), ("inactive", "Inactive"), ("purged", "Purged"), ("pending", "Pending"), ("not_registered", "Not registered"), ("deceased", "Deceased")], db_index=True, default="not_registered", max_length=32)),
+                ("registration_state", models.CharField(db_index=True, max_length=2)),
+                ("registration_date", models.DateField(blank=True, null=True)),
+                ("party_registration", models.CharField(blank=True, default="", max_length=64)),
+                ("voter_status_reason", models.CharField(blank=True, default="", max_length=128)),
+                ("vendor_address_line1", models.CharField(blank=True, default="", max_length=255)),
+                ("vendor_address_line2", models.CharField(blank=True, default="", max_length=255)),
+                ("vendor_city", models.CharField(blank=True, default="", max_length=128)),
+                ("vendor_state", models.CharField(blank=True, default="", max_length=2)),
+                ("vendor_zip", models.CharField(blank=True, default="", max_length=5)),
+                ("vendor_zip4", models.CharField(blank=True, default="", max_length=4)),
+                ("vendor_address_supplied_at", models.DateField(blank=True, null=True)),
+                ("household_id", models.CharField(blank=True, db_index=True, default="", max_length=64)),
+                ("household_size", models.PositiveSmallIntegerField(blank=True, null=True)),
+                ("is_head_of_household", models.BooleanField(default=False)),
+                ("general_election_count", models.PositiveIntegerField(default=0)),
+                ("primary_election_count", models.PositiveIntegerField(default=0)),
+                ("total_vote_count", models.PositiveIntegerField(default=0)),
+                ("last_voted_at", models.DateField(blank=True, null=True)),
+                ("vote_frequency_category", models.CharField(blank=True, default="", max_length=32)),
+                ("pdi_extras", models.JSONField(blank=True, default=dict)),
+                ("l2_extras", models.JSONField(blank=True, default=dict)),
+                ("catalist_extras", models.JSONField(blank=True, default=dict)),
+                ("ts_extras", models.JSONField(blank=True, default=dict)),
+                ("last_loaded_from_vendor", models.CharField(blank=True, choices=[("pdi", "PDI"), ("l2", "L2"), ("catalist", "Catalist"), ("ts", "TargetSmart")], default="", max_length=16)),
+                ("last_loaded_at", models.DateTimeField(blank=True, null=True)),
+                ("silver_source_path", models.CharField(blank=True, default="", max_length=512)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("address", models.ForeignKey(blank=True, help_text="Canonical address (resolved via geo pipeline). Importers that cannot resolve an address may set null; consumer policy decides.", null=True, on_delete=django.db.models.deletion.PROTECT, related_name="people", to="sw_geo.address")),
+            ],
+            options={
+                "verbose_name": "Person Dimension",
+                "verbose_name_plural": "Person Dimensions",
+                "unique_together": {("vendor", "vendor_voter_id")},
+                "indexes": [
+                    models.Index(fields=["registration_state", "registration_status"], name="sw_warehous_registr_d63afa_idx"),
+                    models.Index(fields=["last_name", "first_name"], name="sw_warehous_last_na_69cb1f_idx"),
+                    models.Index(fields=["dob"], name="sw_warehous_dob_d3ec57_idx"),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="FactPersonScore",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("score_type", models.CharField(db_index=True, max_length=128)),
+                ("value", models.FloatField()),
+                ("source_vendor", models.CharField(choices=[("pdi", "PDI"), ("l2", "L2"), ("catalist", "Catalist"), ("ts", "TargetSmart")], max_length=16)),
+                ("methodology_version", models.CharField(blank=True, default="", max_length=64)),
+                ("scored_at", models.DateTimeField()),
+                ("loaded_at", models.DateTimeField(auto_now_add=True)),
+                ("person", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="scores", to="sw_warehouse.dimperson")),
+            ],
+            options={
+                "db_table": "sw_fact_person_score",
+                "verbose_name": "Person Score Fact",
+                "verbose_name_plural": "Person Score Facts",
+                "unique_together": {("person", "score_type", "source_vendor", "methodology_version")},
+                "indexes": [
+                    models.Index(fields=["score_type", "source_vendor"], name="sw_fact_per_score_t_3b9a02_idx"),
+                    models.Index(fields=["person", "score_type"], name="sw_fact_per_person__9c4d4f_idx"),
+                ],
+            },
+        ),
+        migrations.CreateModel(
+            name="FactVoteHistory",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("election_date", models.DateField(db_index=True)),
+                ("election_type", models.CharField(choices=[("general", "General"), ("primary", "Primary"), ("runoff", "Runoff"), ("special", "Special"), ("local", "Local"), ("other", "Other")], max_length=16)),
+                ("voted_method", models.CharField(choices=[("in_person", "In person"), ("absentee", "Absentee"), ("mail", "Mail"), ("early", "Early"), ("provisional", "Provisional"), ("unknown", "Unknown")], default="unknown", max_length=16)),
+                ("source_vendor", models.CharField(choices=[("pdi", "PDI"), ("l2", "L2"), ("catalist", "Catalist"), ("ts", "TargetSmart")], max_length=16)),
+                ("loaded_at", models.DateTimeField(auto_now_add=True)),
+                ("person", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="vote_history", to="sw_warehouse.dimperson")),
+            ],
+            options={
+                "db_table": "sw_fact_vote_history",
+                "verbose_name": "Vote History Fact",
+                "verbose_name_plural": "Vote History Facts",
+                "unique_together": {("person", "election_date", "election_type", "source_vendor")},
+                "indexes": [
+                    models.Index(fields=["person", "election_date"], name="sw_fact_vot_person__a8c1d3_idx"),
+                    models.Index(fields=["election_date", "election_type"], name="sw_fact_vot_electio_4e2f78_idx"),
+                ],
+            },
+        ),
+    ]

--- a/socialwarehouse/warehouse/models/__init__.py
+++ b/socialwarehouse/warehouse/models/__init__.py
@@ -1,17 +1,24 @@
 from .dimensions import (
+    REGISTRATION_STATUS_CHOICES,
+    VENDOR_CHOICES,
     DimCensusVariable,
     DimGeography,
+    DimPerson,
     DimRedistrictingCycle,
     DimSurvey,
     DimTime,
 )
 from .facts import (
+    ELECTION_TYPE_CHOICES,
+    VOTED_METHOD_CHOICES,
     FactACSEstimate,
     FactDecennialCount,
     FactElectionResult,
+    FactPersonScore,
     FactPrecinctResult,
     FactRedistrictingPlan,
     FactUrbanicity,
+    FactVoteHistory,
 )
 
 __all__ = [
@@ -20,10 +27,17 @@ __all__ = [
     "DimCensusVariable",
     "DimTime",
     "DimRedistrictingCycle",
+    "DimPerson",
     "FactACSEstimate",
     "FactDecennialCount",
     "FactUrbanicity",
     "FactElectionResult",
     "FactPrecinctResult",
     "FactRedistrictingPlan",
+    "FactPersonScore",
+    "FactVoteHistory",
+    "VENDOR_CHOICES",
+    "REGISTRATION_STATUS_CHOICES",
+    "ELECTION_TYPE_CHOICES",
+    "VOTED_METHOD_CHOICES",
 ]

--- a/socialwarehouse/warehouse/models/dimensions.py
+++ b/socialwarehouse/warehouse/models/dimensions.py
@@ -406,7 +406,7 @@ class DimPerson(models.Model):
     voter_status_reason = models.CharField(max_length=128, blank=True, default="")
 
     address = models.ForeignKey(
-        "geo.Address",
+        "sw_geo.Address",
         on_delete=models.PROTECT,
         related_name="people",
         null=True,

--- a/socialwarehouse/warehouse/models/dimensions.py
+++ b/socialwarehouse/warehouse/models/dimensions.py
@@ -342,3 +342,131 @@ class DimRedistrictingCycle(models.Model):
 
     def __str__(self):
         return f"Redistricting Cycle {self.cycle_year}"
+
+
+VENDOR_CHOICES = [
+    ("pdi", "PDI"),
+    ("l2", "L2"),
+    ("catalist", "Catalist"),
+    ("ts", "TargetSmart"),
+]
+
+
+REGISTRATION_STATUS_CHOICES = [
+    ("active", "Active"),
+    ("inactive", "Inactive"),
+    ("purged", "Purged"),
+    ("pending", "Pending"),
+    ("not_registered", "Not registered"),
+    ("deceased", "Deceased"),
+]
+
+
+class DimPerson(models.Model):
+    """Person dimension — canonical voter record.
+
+    Natural key: (vendor, vendor_voter_id). Same physical voter loaded
+    from two vendors yields two DimPerson rows; cross-vendor
+    probabilistic matching is a follow-on (#250 sub-issue), and the
+    schema permits it via a `canonical_person_id` column addition
+    later.
+
+    Current-only (not SCD Type 2). Vendor voter files are themselves
+    point-in-time snapshots; the effective-dated semantics SCD2
+    captures do not apply cleanly. Historical truth lives in the
+    Delta silver.persons table (append/upsert; full history preserved
+    there). Promote to SCD2 if a concrete consumer asks.
+
+    Vendor-divergent fields live in `*_extras` JSONFields. Promote a
+    map key to a canonical column when a stable pattern emerges; see
+    `docs/warehouse-schema-evolution.md`.
+    """
+
+    vendor = models.CharField(max_length=16, choices=VENDOR_CHOICES, db_index=True)
+    vendor_voter_id = models.CharField(max_length=128, db_index=True)
+
+    first_name = models.CharField(max_length=128, blank=True, default="")
+    middle_name = models.CharField(max_length=128, blank=True, default="")
+    last_name = models.CharField(max_length=128, blank=True, default="")
+    name_suffix = models.CharField(max_length=32, blank=True, default="")
+    dob = models.DateField(null=True, blank=True)
+    gender = models.CharField(max_length=32, blank=True, default="")
+    ethnicity = models.CharField(max_length=64, blank=True, default="")
+    language = models.CharField(max_length=64, blank=True, default="")
+
+    registration_status = models.CharField(
+        max_length=32,
+        choices=REGISTRATION_STATUS_CHOICES,
+        default="not_registered",
+        db_index=True,
+    )
+    registration_state = models.CharField(max_length=2, db_index=True)
+    registration_date = models.DateField(null=True, blank=True)
+    party_registration = models.CharField(max_length=64, blank=True, default="")
+    voter_status_reason = models.CharField(max_length=128, blank=True, default="")
+
+    address = models.ForeignKey(
+        "geo.Address",
+        on_delete=models.PROTECT,
+        related_name="people",
+        null=True,
+        blank=True,
+        help_text="Canonical address (resolved via geo pipeline). Importers that cannot resolve an address may set null; consumer policy decides.",
+    )
+    # Vendor-supplied raw address preserved for audit / diff trail
+    # against what canonical resolution produced.
+    vendor_address_line1 = models.CharField(max_length=255, blank=True, default="")
+    vendor_address_line2 = models.CharField(max_length=255, blank=True, default="")
+    vendor_city = models.CharField(max_length=128, blank=True, default="")
+    vendor_state = models.CharField(max_length=2, blank=True, default="")
+    vendor_zip = models.CharField(max_length=5, blank=True, default="")
+    vendor_zip4 = models.CharField(max_length=4, blank=True, default="")
+    vendor_address_supplied_at = models.DateField(null=True, blank=True)
+
+    household_id = models.CharField(max_length=64, blank=True, default="", db_index=True)
+    household_size = models.PositiveSmallIntegerField(null=True, blank=True)
+    is_head_of_household = models.BooleanField(default=False)
+
+    # Vote-history aggregates materialized from FactVoteHistory.
+    # Updated by a Spark-side recompute on the silver build (not by
+    # Django signal); see docs/entities/dim-person.md for cadence.
+    general_election_count = models.PositiveIntegerField(default=0)
+    primary_election_count = models.PositiveIntegerField(default=0)
+    total_vote_count = models.PositiveIntegerField(default=0)
+    last_voted_at = models.DateField(null=True, blank=True)
+    vote_frequency_category = models.CharField(max_length=32, blank=True, default="")
+
+    pdi_extras = models.JSONField(default=dict, blank=True)
+    l2_extras = models.JSONField(default=dict, blank=True)
+    catalist_extras = models.JSONField(default=dict, blank=True)
+    ts_extras = models.JSONField(default=dict, blank=True)
+
+    last_loaded_from_vendor = models.CharField(
+        max_length=16,
+        choices=VENDOR_CHOICES,
+        blank=True,
+        default="",
+    )
+    last_loaded_at = models.DateTimeField(null=True, blank=True)
+    silver_source_path = models.CharField(max_length=512, blank=True, default="")
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = "Person Dimension"
+        verbose_name_plural = "Person Dimensions"
+        unique_together = [("vendor", "vendor_voter_id")]
+        indexes = [
+            models.Index(fields=["registration_state", "registration_status"]),
+            models.Index(fields=["last_name", "first_name"]),
+            models.Index(fields=["dob"]),
+        ]
+
+    @property
+    def is_registered_voter(self):
+        return self.registration_status in {"active", "inactive", "pending"}
+
+    def __str__(self):
+        name = " ".join(part for part in (self.first_name, self.last_name) if part)
+        return f"{name or '(no name)'} [{self.vendor}:{self.vendor_voter_id}]"

--- a/socialwarehouse/warehouse/models/facts.py
+++ b/socialwarehouse/warehouse/models/facts.py
@@ -13,12 +13,34 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 
 from .dimensions import (
+    VENDOR_CHOICES,
     DimCensusVariable,
     DimGeography,
+    DimPerson,
     DimRedistrictingCycle,
     DimSurvey,
     DimTime,
 )
+
+
+ELECTION_TYPE_CHOICES = [
+    ("general", "General"),
+    ("primary", "Primary"),
+    ("runoff", "Runoff"),
+    ("special", "Special"),
+    ("local", "Local"),
+    ("other", "Other"),
+]
+
+
+VOTED_METHOD_CHOICES = [
+    ("in_person", "In person"),
+    ("absentee", "Absentee"),
+    ("mail", "Mail"),
+    ("early", "Early"),
+    ("provisional", "Provisional"),
+    ("unknown", "Unknown"),
+]
 
 
 # Census Bureau coefficient-of-variation reliability thresholds. Drawn
@@ -263,3 +285,72 @@ class FactRedistrictingPlan(models.Model):
 
     def __str__(self):
         return f"{self.chamber} District {self.district_number} ({self.cycle.cycle_year})"
+
+
+class FactPersonScore(models.Model):
+    """Per-person score event (partisan, turnout propensity, issue stance, etc.).
+
+    Tall format: one row per (person, score_type, source_vendor,
+    methodology_version). Vendor scoring systems are NOT interchangeable
+    even when score_type matches — each score carries its source_vendor
+    and methodology_version. Consumers querying "give me a partisan
+    score" must pick a source explicitly.
+
+    `score_type` is a free string (not a choices enum). Vendor scoring
+    vocabularies grow over time; a migration-per-cycle is not viable.
+    Common types: 'partisan_score', 'turnout_propensity_general',
+    'turnout_propensity_primary', 'issue_<topic>'. See
+    docs/entities/fact-person-score.md for the registered vocabulary.
+    """
+
+    person = models.ForeignKey(DimPerson, on_delete=models.CASCADE, related_name="scores")
+    score_type = models.CharField(max_length=128, db_index=True)
+    value = models.FloatField()
+    source_vendor = models.CharField(max_length=16, choices=VENDOR_CHOICES)
+    methodology_version = models.CharField(max_length=64, blank=True, default="")
+    scored_at = models.DateTimeField()
+    loaded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "sw_fact_person_score"
+        verbose_name = "Person Score Fact"
+        verbose_name_plural = "Person Score Facts"
+        unique_together = [("person", "score_type", "source_vendor", "methodology_version")]
+        indexes = [
+            models.Index(fields=["score_type", "source_vendor"]),
+            models.Index(fields=["person", "score_type"]),
+        ]
+
+    def __str__(self):
+        return f"{self.score_type}={self.value} ({self.source_vendor}) for {self.person_id}"
+
+
+class FactVoteHistory(models.Model):
+    """Per-person per-election vote event.
+
+    `unique_together` on (person, election_date, election_type,
+    source_vendor) preserves both vendors' reports of the same vote
+    while preventing duplicate-load. Cross-vendor reconciliation
+    (when two vendors disagree on voted_method) is a consumer
+    decision; both rows are kept.
+    """
+
+    person = models.ForeignKey(DimPerson, on_delete=models.CASCADE, related_name="vote_history")
+    election_date = models.DateField(db_index=True)
+    election_type = models.CharField(max_length=16, choices=ELECTION_TYPE_CHOICES)
+    voted_method = models.CharField(max_length=16, choices=VOTED_METHOD_CHOICES, default="unknown")
+    source_vendor = models.CharField(max_length=16, choices=VENDOR_CHOICES)
+    loaded_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "sw_fact_vote_history"
+        verbose_name = "Vote History Fact"
+        verbose_name_plural = "Vote History Facts"
+        unique_together = [("person", "election_date", "election_type", "source_vendor")]
+        indexes = [
+            models.Index(fields=["person", "election_date"]),
+            models.Index(fields=["election_date", "election_type"]),
+        ]
+
+    def __str__(self):
+        return f"{self.election_type} {self.election_date} ({self.source_vendor}) for {self.person_id}"

--- a/tests/unit/warehouse/test_person_models.py
+++ b/tests/unit/warehouse/test_person_models.py
@@ -176,6 +176,9 @@ class TestFactVoteHistory:
         FactVoteHistory.objects.create(source_vendor="l2", **common)
 
 
+pyspark = pytest.importorskip("pyspark", reason="pyspark not installed in this env; Delta-schema tests run in CI docker-build job")
+
+
 class TestDeltaSchemas:
     """Schemas must be importable + registered. Pyspark import-only test;
     no Spark session required."""

--- a/tests/unit/warehouse/test_person_models.py
+++ b/tests/unit/warehouse/test_person_models.py
@@ -1,0 +1,221 @@
+"""
+Tests for SW#251 — DimPerson, FactPersonScore, FactVoteHistory.
+
+Per writing-tests:1, each test fails on revert of the named feature.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+from django.db import IntegrityError
+from django.db.models import ProtectedError
+
+
+@pytest.mark.django_db
+class TestDimPerson:
+    def _person_kwargs(self, **overrides):
+        defaults = {
+            "vendor": "ts",
+            "vendor_voter_id": "TS-100",
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "registration_state": "TX",
+            "registration_status": "active",
+        }
+        defaults.update(overrides)
+        return defaults
+
+    def test_create_minimum_required(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        p = DimPerson.objects.create(**self._person_kwargs())
+        assert p.id is not None
+        assert p.is_registered_voter is True
+        assert p.pdi_extras == {}
+        assert p.ts_extras == {}
+
+    def test_unique_vendor_voter_id(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        DimPerson.objects.create(**self._person_kwargs())
+        with pytest.raises(IntegrityError):
+            DimPerson.objects.create(**self._person_kwargs())
+
+    def test_same_voter_id_different_vendor_allowed(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        DimPerson.objects.create(**self._person_kwargs(vendor="ts", vendor_voter_id="100"))
+        # Should not raise — natural key includes vendor.
+        DimPerson.objects.create(**self._person_kwargs(vendor="l2", vendor_voter_id="100"))
+
+    def test_is_registered_voter_property(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        cases = [
+            ("active", True),
+            ("inactive", True),
+            ("pending", True),
+            ("purged", False),
+            ("not_registered", False),
+            ("deceased", False),
+        ]
+        for i, (status, expected) in enumerate(cases):
+            p = DimPerson.objects.create(**self._person_kwargs(
+                vendor_voter_id=f"REG-{i}", registration_status=status,
+            ))
+            assert p.is_registered_voter is expected, status
+
+    def test_jsonfield_roundtrip(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        p = DimPerson.objects.create(**self._person_kwargs(
+            ts_extras={"tsmart_partisan_score": "55", "tsmart_segment": "X1"},
+            l2_extras={"l2_internal_id": "LX-9"},
+        ))
+        p.refresh_from_db()
+        assert p.ts_extras == {"tsmart_partisan_score": "55", "tsmart_segment": "X1"}
+        assert p.l2_extras == {"l2_internal_id": "LX-9"}
+        assert p.pdi_extras == {}
+
+    def test_address_protect(self):
+        from socialwarehouse.geo.models import Address
+        from socialwarehouse.warehouse.models import DimPerson
+        addr = Address.objects.create(state_abbreviation="TX")
+        DimPerson.objects.create(**self._person_kwargs(address=addr))
+        with pytest.raises(ProtectedError):
+            addr.delete()
+
+
+@pytest.mark.django_db
+class TestFactPersonScore:
+    def _person(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        return DimPerson.objects.create(
+            vendor="ts", vendor_voter_id="SCORE-1",
+            registration_state="TX", registration_status="active",
+        )
+
+    def test_create(self):
+        from socialwarehouse.warehouse.models import FactPersonScore
+        p = self._person()
+        s = FactPersonScore.objects.create(
+            person=p, score_type="partisan_score",
+            value=0.72, source_vendor="ts",
+            methodology_version="2024Q4",
+            scored_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        assert s.id is not None
+
+    def test_unique_per_methodology(self):
+        from socialwarehouse.warehouse.models import FactPersonScore
+        p = self._person()
+        kwargs = dict(
+            person=p, score_type="partisan_score", value=0.5,
+            source_vendor="ts", methodology_version="v1",
+            scored_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        FactPersonScore.objects.create(**kwargs)
+        with pytest.raises(IntegrityError):
+            FactPersonScore.objects.create(**kwargs)
+
+    def test_same_score_type_different_vendor_allowed(self):
+        from socialwarehouse.warehouse.models import FactPersonScore
+        p = self._person()
+        common = dict(
+            person=p, score_type="partisan_score", value=0.5,
+            methodology_version="v1",
+            scored_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        FactPersonScore.objects.create(source_vendor="ts", **common)
+        FactPersonScore.objects.create(source_vendor="l2", **common)
+
+    def test_cascade_on_person_delete(self):
+        from socialwarehouse.warehouse.models import DimPerson, FactPersonScore
+        p = self._person()
+        FactPersonScore.objects.create(
+            person=p, score_type="x", value=1.0, source_vendor="ts",
+            scored_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        DimPerson.objects.filter(pk=p.pk).delete()
+        assert FactPersonScore.objects.count() == 0
+
+
+@pytest.mark.django_db
+class TestFactVoteHistory:
+    def _person(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        return DimPerson.objects.create(
+            vendor="ts", vendor_voter_id="VH-1",
+            registration_state="TX", registration_status="active",
+        )
+
+    def test_create(self):
+        from socialwarehouse.warehouse.models import FactVoteHistory
+        p = self._person()
+        v = FactVoteHistory.objects.create(
+            person=p, election_date=date(2024, 11, 5),
+            election_type="general", voted_method="in_person",
+            source_vendor="ts",
+        )
+        assert v.id is not None
+
+    def test_unique_per_vendor(self):
+        from socialwarehouse.warehouse.models import FactVoteHistory
+        p = self._person()
+        kwargs = dict(
+            person=p, election_date=date(2024, 11, 5),
+            election_type="general", source_vendor="ts",
+        )
+        FactVoteHistory.objects.create(**kwargs)
+        with pytest.raises(IntegrityError):
+            FactVoteHistory.objects.create(**kwargs)
+
+    def test_two_vendors_same_vote_allowed(self):
+        from socialwarehouse.warehouse.models import FactVoteHistory
+        p = self._person()
+        common = dict(
+            person=p, election_date=date(2024, 11, 5),
+            election_type="general",
+        )
+        FactVoteHistory.objects.create(source_vendor="ts", **common)
+        FactVoteHistory.objects.create(source_vendor="l2", **common)
+
+
+class TestDeltaSchemas:
+    """Schemas must be importable + registered. Pyspark import-only test;
+    no Spark session required."""
+
+    def test_silver_persons_imports(self):
+        from socialwarehouse.delta.tables import SILVER_PERSONS
+        names = {f.name for f in SILVER_PERSONS.fields}
+        # Natural key columns
+        assert "vendor" in names
+        assert "vendor_voter_id" in names
+        assert "person_key" in names
+        # Map-typed extension bag
+        assert "vendor_extras" in names
+
+    def test_silver_person_scores_tall(self):
+        from socialwarehouse.delta.tables import SILVER_PERSON_SCORES
+        names = {f.name for f in SILVER_PERSON_SCORES.fields}
+        assert {"person_key", "score_type", "value", "source_vendor", "methodology_version"} <= names
+
+    def test_silver_vote_history(self):
+        from socialwarehouse.delta.tables import SILVER_VOTE_HISTORY
+        names = {f.name for f in SILVER_VOTE_HISTORY.fields}
+        assert {"person_key", "election_date", "election_type", "source_vendor"} <= names
+
+    def test_registry_entries(self):
+        from socialwarehouse.delta.tables import TABLES
+        for key in (
+            "bronze.voter_file_ts",
+            "bronze.voter_file_l2",
+            "bronze.voter_file_catalist",
+            "bronze.voter_file_pdi",
+            "silver.persons",
+            "silver.person_scores",
+            "silver.vote_history",
+        ):
+            assert key in TABLES, key
+            assert "schema" in TABLES[key]
+            assert "path" in TABLES[key]
+            assert "partition_by" in TABLES[key]
+
+    def test_silver_persons_partitioned_by_state_vendor(self):
+        from socialwarehouse.delta.tables import TABLES
+        assert TABLES["silver.persons"]["partition_by"] == ["registration_state", "vendor"]


### PR DESCRIPTION
Closes #251 (sub-issue A of #250).

Schema-only delivery. No importer wiring (sub-issues B-E of #250). Honors the warehouse-first principle ([`docs/architecture.md`](https://github.com/siege-analytics/socialwarehouse/blob/main/docs/architecture.md)).

## What lands

**Delta Lake medallion** (`socialwarehouse/delta/tables.py`):
- `bronze.voter_file_{ts,l2,catalist,pdi}` — raw vendor row as JSON string
- `silver.persons` — canonical, vendor-neutral, address-resolved
- `silver.person_scores` — tall, source-vendor-tagged
- `silver.vote_history` — per-person per-election events

**PostGIS star schema** (`socialwarehouse/warehouse/models/`):
- `DimPerson` — current-only dimension, FK to `geo.Address` (PROTECT), four `*_extras` JSONFields
- `FactPersonScore` — tall format
- `FactVoteHistory` — preserves both vendors' reports of the same vote

**Schema-evolution mechanism** (operator add-on): [`docs/warehouse-schema-evolution.md`](https://github.com/siege-analytics/socialwarehouse/blob/main/docs/warehouse-schema-evolution.md) documents how to promote a `vendor_extras` key to a canonical column.

**Docs**: per-entity reference for DimPerson, FactPersonScore, FactVoteHistory + the schema-evolution playbook.

**Tests**: unique-constraint enforcement, JSONField roundtrip, FK PROTECT/CASCADE, `is_registered_voter` property, Delta schema registry presence. Per writing-tests:1.

## Six structural decisions (operator-approved 2026-05-22)

1. No new `electoral` app — Person joins existing star schema
2. Bronze = four per-vendor tables, raw row as JSON string
3. Silver = one row per `(vendor, vendor_voter_id)`
4. DimPerson is current-only (not SCD2)
5. Vote history materialized to both Delta and PostGIS
6. Vendor extras as Map<String,String> in Delta + JSONField in PostGIS, with a documented promotion playbook

## Out of scope

- Importers (sub-issues B-E of #250)
- Silver-build Spark job
- Spark→PostGIS materialization
- Cross-vendor probabilistic Person matching
- Web-app surfaces (sub-issues G-K of #250)

Refs: #251, #250