### PR TITLE
feat(electoral): TS score extraction -> silver.person_scores (#259)

### DIFF
--- a/docs/entities/fact-person-score.md
+++ b/docs/entities/fact-person-score.md
@@ -51,6 +51,27 @@ Importers writing new score types should:
 
 The `unique_together = (person, score_type, source_vendor, methodology_version)` constraint means re-running an importer with the same methodology version is idempotent. Bumping the methodology version creates a parallel row; both are queryable.
 
+## TargetSmart importer mapping (SW#259)
+
+Defined in `swh/voters/ts/score_mappings.py`. Static (non-cycle) TS scores take the operator-supplied `--methodology` flag (default `ts-2024`). Cycle-aligned TS scores embed the year from the column name as `ts-<year>`.
+
+| TS column | Canonical `score_type` | Methodology |
+|---|---|---|
+| `vb.tsmart_partisan_score` | `partisan_score` | `ts-<vintage>` |
+| `vb.tsmart_ideology_score` | `ideology_score` | `ts-<vintage>` |
+| `vb.tsmart_engagement_score` | `engagement_score` | `ts-<vintage>` |
+| `vb.tsmart_persuadability_score` | `persuadability_score` | `ts-<vintage>` |
+| `vb.tsmart_climate_score` | `issue_climate` | `ts-<vintage>` |
+| `vb.tsmart_abortion_score` | `issue_abortion` | `ts-<vintage>` |
+| `vb.tsmart_gun_safety_score` | `issue_gun_safety` | `ts-<vintage>` |
+| `vb.tsmart_healthcare_score` | `issue_healthcare` | `ts-<vintage>` |
+| `vb.tsmart_economy_score` | `issue_economy` | `ts-<vintage>` |
+| `vb.tsmart_immigration_score` | `issue_immigration` | `ts-<vintage>` |
+| `vb.tsmart_turnout_score_general_<year>` | `turnout_propensity_general` | `ts-<year>` |
+| `vb.tsmart_turnout_score_primary_<year>` | `turnout_propensity_primary` | `ts-<year>` |
+
+Unmapped score-shaped columns (`*_score`) stay in `vendor_extras` until they earn promotion per [`docs/warehouse-schema-evolution.md`](../warehouse-schema-evolution.md). To promote: add the mapping to `score_mappings.py`, add the row above, document in the next PR.
+
 ## Schema evolution
 
 `score_type` and `methodology_version` evolve freely (new strings, no migrations). The columns themselves are stable; if a fundamentally new score shape appears (e.g. multi-dimensional scores), file a follow-on sub-issue.

--- a/swh/cli.py
+++ b/swh/cli.py
@@ -316,7 +316,9 @@ def fec_centrality(graph_input_path, party):
 @click.option("--file", "csv_path", type=click.Path(exists=True), required=True, help="Path to the vendor's voter-file CSV")
 @click.option("--state", required=True, help="2-char USPS state code (e.g. TX); becomes the bronze partition key")
 @click.option("--skip-silver", is_flag=True, default=False, help="Run bronze ingest only; skip the silver.persons build (for staged loads)")
-def ingest_voter_file(vendor, csv_path, state, skip_silver):
+@click.option("--include-scores", is_flag=True, default=False, help="Also extract silver.person_scores from the bronze rows (B.2 of #250)")
+@click.option("--methodology", default="ts-2024", show_default=True, help="Methodology label for static TS scores (cycle-aligned scores embed their cycle year)")
+def ingest_voter_file(vendor, csv_path, state, skip_silver, include_scores, methodology):
     """Ingest a vendor voter file through the medallion pipeline.
 
     Currently supports TargetSmart format. Vendor CSV -> bronze.voter_file_<vendor>
@@ -332,7 +334,7 @@ def ingest_voter_file(vendor, csv_path, state, skip_silver):
     if vendor != "ts":
         raise click.UsageError(f"Vendor {vendor!r} is not yet supported; only 'ts' ships in #257.")
 
-    from swh.voters.ts import build_silver_persons, ingest_bronze
+    from swh.voters.ts import build_silver_persons, extract_scores, ingest_bronze
 
     click.echo(f"Bronze ingest: vendor={vendor} file={csv_path} state={state}")
     spark = settings.spark.build_session()
@@ -341,7 +343,10 @@ def ingest_voter_file(vendor, csv_path, state, skip_silver):
         click.echo(f"Bronze rows appended: {n_bronze}")
         if not skip_silver:
             n_silver = build_silver_persons(spark)
-            click.echo(f"Silver rows upserted: {n_silver}")
+            click.echo(f"Silver persons upserted: {n_silver}")
+            if include_scores:
+                n_scores = extract_scores(spark, default_methodology=methodology)
+                click.echo(f"Silver scores upserted: {n_scores}")
     finally:
         spark.stop()
 

--- a/swh/voters/ts/__init__.py
+++ b/swh/voters/ts/__init__.py
@@ -17,6 +17,7 @@ See `docs/electoral/targetsmart-importer.md` for the operator runbook.
 """
 
 from swh.voters.ts.bronze import ingest_bronze
+from swh.voters.ts.scores import extract_scores
 from swh.voters.ts.silver import build_silver_persons
 
-__all__ = ["ingest_bronze", "build_silver_persons"]
+__all__ = ["ingest_bronze", "build_silver_persons", "extract_scores"]

--- a/swh/voters/ts/score_mappings.py
+++ b/swh/voters/ts/score_mappings.py
@@ -1,0 +1,74 @@
+"""
+TS score-column -> canonical (score_type, methodology_version) mapping.
+
+The right-hand side is a (score_type, methodology_version_template) tuple
+where the template is a Python format string supporting `{cycle}` if the
+TS column embeds a cycle year.
+
+Static (non-cycle-aligned) TS scores get an empty cycle placeholder and
+take the operator-supplied default methodology version (e.g. 'ts-2024').
+
+The score_type vocabulary aligns with `docs/entities/fact-person-score.md`
+registered values. Adding a new TS score means picking the matching
+registered score_type or adding a new one to that doc.
+"""
+
+# Static scores: methodology version is the importer's default ('ts-<vintage>').
+# Format-string here uses {default} which the caller fills in.
+_STATIC: dict[str, tuple[str, str]] = {
+    "vb.tsmart_partisan_score": ("partisan_score", "{default}"),
+    "vb.tsmart_ideology_score": ("ideology_score", "{default}"),
+    "vb.tsmart_engagement_score": ("engagement_score", "{default}"),
+    "vb.tsmart_persuadability_score": ("persuadability_score", "{default}"),
+    "vb.tsmart_climate_score": ("issue_climate", "{default}"),
+    "vb.tsmart_abortion_score": ("issue_abortion", "{default}"),
+    "vb.tsmart_gun_safety_score": ("issue_gun_safety", "{default}"),
+    "vb.tsmart_healthcare_score": ("issue_healthcare", "{default}"),
+    "vb.tsmart_economy_score": ("issue_economy", "{default}"),
+    "vb.tsmart_immigration_score": ("issue_immigration", "{default}"),
+}
+
+# Cycle-aligned scores: methodology version embeds the cycle year extracted
+# from the TS column name. The score_type strips the year so it's stable
+# across cycles. The pattern is `vb.tsmart_turnout_score_<scope>_<year>`.
+# The cycle key in the format string is filled from the matched year.
+_CYCLE_TURNOUT_GENERAL = ("turnout_propensity_general", "ts-{cycle}")
+_CYCLE_TURNOUT_PRIMARY = ("turnout_propensity_primary", "ts-{cycle}")
+
+# Cycle patterns are matched at runtime; this dict declares the prefix
+# stem -> (score_type, methodology_template) mapping. The caller parses
+# the trailing year.
+CYCLE_PREFIXES: dict[str, tuple[str, str]] = {
+    "vb.tsmart_turnout_score_general_": _CYCLE_TURNOUT_GENERAL,
+    "vb.tsmart_turnout_score_primary_": _CYCLE_TURNOUT_PRIMARY,
+}
+
+
+def lookup(column_name: str, default_methodology: str) -> tuple[str, str] | None:
+    """Resolve a TS column name to (score_type, methodology_version).
+
+    Returns None if the column is not a known score column.
+
+    Args:
+        column_name: Full TS column name (with `vb.` prefix).
+        default_methodology: Methodology label for static (non-cycle)
+            scores. Typical value: "ts-2024".
+    """
+    if column_name in _STATIC:
+        score_type, template = _STATIC[column_name]
+        return score_type, template.format(default=default_methodology)
+    for prefix, (score_type, template) in CYCLE_PREFIXES.items():
+        if column_name.startswith(prefix):
+            cycle = column_name[len(prefix):]
+            if cycle.isdigit() and len(cycle) == 4:
+                return score_type, template.format(cycle=cycle)
+    return None
+
+
+def known_score_columns(default_methodology: str = "ts-2024") -> set[str]:
+    """All TS column names that map to a canonical score_type.
+
+    Excludes cycle-aligned columns (those are matched by prefix at
+    runtime since the year is variable). For introspection / docs.
+    """
+    return set(_STATIC.keys())

--- a/swh/voters/ts/scores.py
+++ b/swh/voters/ts/scores.py
@@ -1,0 +1,157 @@
+"""
+TS score extraction: bronze.voter_file_ts -> silver.person_scores.
+
+Reads bronze rows, parses each `raw` JSON payload, and emits one
+silver.person_scores row per recognized TS score column.
+
+Idempotent: re-running upserts on the natural key
+(person_key, score_type, source_vendor, methodology_version).
+Unmapped score-shaped columns stay in vendor_extras (no warning per-row
+to keep logs sane; the registered TS score columns are documented in
+docs/entities/fact-person-score.md).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from swh.voters.ts.score_mappings import CYCLE_PREFIXES, lookup
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pyspark.sql import SparkSession
+
+logger = logging.getLogger(__name__)
+
+VENDOR = "ts"
+DEFAULT_METHODOLOGY = "ts-2024"
+
+
+def _safe_float(value) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _score_rows_from_raw(
+    raw: dict,
+    person_key: str,
+    scored_at: datetime,
+    loaded_at: datetime,
+    default_methodology: str,
+) -> list[dict]:
+    """Emit silver.person_scores row-dicts for known score columns in raw.
+
+    Static + cycle-aligned TS score columns are both handled via the
+    `lookup` helper from score_mappings.
+    """
+    rows: list[dict] = []
+    for col, value in raw.items():
+        # Quick reject: only consider columns that COULD be a score.
+        if not (col.endswith("_score") or any(col.startswith(p) for p in CYCLE_PREFIXES)):
+            continue
+        resolved = lookup(col, default_methodology)
+        if resolved is None:
+            continue
+        score_type, methodology_version = resolved
+        v = _safe_float(value)
+        if v is None:
+            continue
+        rows.append({
+            "person_key": person_key,
+            "score_type": score_type,
+            "value": v,
+            "source_vendor": VENDOR,
+            "methodology_version": methodology_version,
+            "scored_at": scored_at,
+            "loaded_at": loaded_at,
+        })
+    return rows
+
+
+def extract_scores(
+    spark: "SparkSession",
+    bronze_table_key: str = "bronze.voter_file_ts",
+    silver_table_key: str = "silver.person_scores",
+    default_methodology: str = DEFAULT_METHODOLOGY,
+) -> int:
+    """Read bronze.voter_file_ts and upsert silver.person_scores.
+
+    Args:
+        spark: Active SparkSession with Delta extensions registered.
+        bronze_table_key: Registry key for the bronze table.
+        silver_table_key: Registry key for the silver score table.
+        default_methodology: Methodology label for static (non-cycle)
+            TS scores. Cycle-aligned scores embed the cycle year.
+
+    Returns:
+        Number of silver score rows written.
+    """
+    from delta.tables import DeltaTable
+
+    from socialwarehouse.delta.tables import SILVER_PERSON_SCORES, TABLES
+
+    bronze_path = TABLES[bronze_table_key]["path"]
+    silver_path = TABLES[silver_table_key]["path"]
+    loaded_at = datetime.now(tz=timezone.utc)
+
+    bronze_df = spark.read.format("delta").load(bronze_path)
+    rows = bronze_df.select(
+        "vendor_voter_id", "raw", "ingested_at"
+    ).collect()
+
+    score_records: list[dict] = []
+    seen_keys: set[tuple[str, str, str, str]] = set()
+    for r in rows:
+        vid = r["vendor_voter_id"]
+        if not vid:
+            continue
+        person_key = f"{VENDOR}:{vid}"
+        scored_at = r["ingested_at"]
+        try:
+            payload = json.loads(r["raw"])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        for row in _score_rows_from_raw(payload, person_key, scored_at, loaded_at, default_methodology):
+            key = (row["person_key"], row["score_type"],
+                   row["source_vendor"], row["methodology_version"])
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            score_records.append(row)
+
+    if not score_records:
+        logger.info("extract_scores: no scores in bronze; nothing to write.")
+        return 0
+
+    score_df = spark.createDataFrame(score_records, schema=SILVER_PERSON_SCORES)
+
+    if DeltaTable.isDeltaTable(spark, silver_path):
+        tgt = DeltaTable.forPath(spark, silver_path)
+        (
+            tgt.alias("t")
+            .merge(
+                score_df.alias("s"),
+                "t.person_key = s.person_key AND "
+                "t.score_type = s.score_type AND "
+                "t.source_vendor = s.source_vendor AND "
+                "t.methodology_version = s.methodology_version",
+            )
+            .whenMatchedUpdateAll()
+            .whenNotMatchedInsertAll()
+            .execute()
+        )
+    else:
+        partition_by = TABLES[silver_table_key].get("partition_by", [])
+        writer = score_df.write.format("delta")
+        if partition_by:
+            writer = writer.partitionBy(*partition_by)
+        writer.mode("overwrite").save(silver_path)
+
+    logger.info("extract_scores: wrote %d silver score rows.", len(score_records))
+    return len(score_records)

--- a/tests/unit/swh/voters/ts/test_ts_scores.py
+++ b/tests/unit/swh/voters/ts/test_ts_scores.py
@@ -1,0 +1,184 @@
+"""
+Tests for SW#259: TargetSmart score extraction.
+
+Pure-Python tests cover the score-mapping table + the per-row score
+extraction helper. Spark-gated tests cover the end-to-end extract_scores
+against the existing fixture (which includes vb.tsmart_partisan_score
+and vb.tsmart_climate_score).
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+class TestScoreMappings:
+    """Mapping resolution — no Spark required."""
+
+    def test_static_partisan(self):
+        from swh.voters.ts.score_mappings import lookup
+        assert lookup("vb.tsmart_partisan_score", "ts-2024") == ("partisan_score", "ts-2024")
+
+    def test_static_climate_becomes_issue_climate(self):
+        from swh.voters.ts.score_mappings import lookup
+        assert lookup("vb.tsmart_climate_score", "ts-2024") == ("issue_climate", "ts-2024")
+
+    def test_static_methodology_respects_default(self):
+        from swh.voters.ts.score_mappings import lookup
+        out = lookup("vb.tsmart_partisan_score", "ts-2026")
+        assert out == ("partisan_score", "ts-2026")
+
+    def test_cycle_aligned_turnout_general(self):
+        from swh.voters.ts.score_mappings import lookup
+        assert lookup("vb.tsmart_turnout_score_general_2024", "ts-2024") == (
+            "turnout_propensity_general", "ts-2024"
+        )
+
+    def test_cycle_aligned_turnout_primary_different_cycle(self):
+        from swh.voters.ts.score_mappings import lookup
+        assert lookup("vb.tsmart_turnout_score_primary_2022", "ts-2024") == (
+            "turnout_propensity_primary", "ts-2022"
+        )
+
+    def test_unknown_returns_none(self):
+        from swh.voters.ts.score_mappings import lookup
+        assert lookup("vb.tsmart_made_up_score", "ts-2024") is None
+
+    def test_non_score_column_returns_none(self):
+        from swh.voters.ts.score_mappings import lookup
+        assert lookup("vb.tsmart_first_name", "ts-2024") is None
+
+    def test_cycle_with_non_year_suffix_returns_none(self):
+        # `vb.tsmart_turnout_score_general_foo` — not a 4-digit year.
+        from swh.voters.ts.score_mappings import lookup
+        assert lookup("vb.tsmart_turnout_score_general_foo", "ts-2024") is None
+
+
+class TestScoreRowEmission:
+    """_score_rows_from_raw extracts rows from a parsed TS payload."""
+
+    def _now(self):
+        return datetime(2026, 5, 22, tzinfo=timezone.utc)
+
+    def test_emits_static_score(self):
+        from swh.voters.ts.scores import _score_rows_from_raw
+        raw = {"vb.tsmart_partisan_score": "72"}
+        rows = _score_rows_from_raw(raw, "ts:TS001", self._now(), self._now(), "ts-2024")
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["person_key"] == "ts:TS001"
+        assert r["score_type"] == "partisan_score"
+        assert r["value"] == 72.0
+        assert r["source_vendor"] == "ts"
+        assert r["methodology_version"] == "ts-2024"
+
+    def test_skips_unmapped(self):
+        from swh.voters.ts.scores import _score_rows_from_raw
+        raw = {"vb.tsmart_made_up_score": "5"}
+        rows = _score_rows_from_raw(raw, "ts:X", self._now(), self._now(), "ts-2024")
+        assert rows == []
+
+    def test_skips_non_score_fields(self):
+        from swh.voters.ts.scores import _score_rows_from_raw
+        raw = {"vb.tsmart_first_name": "Ada"}
+        rows = _score_rows_from_raw(raw, "ts:X", self._now(), self._now(), "ts-2024")
+        assert rows == []
+
+    def test_skips_unparseable_value(self):
+        from swh.voters.ts.scores import _score_rows_from_raw
+        raw = {"vb.tsmart_partisan_score": "not-a-number"}
+        rows = _score_rows_from_raw(raw, "ts:X", self._now(), self._now(), "ts-2024")
+        assert rows == []
+
+    def test_skips_empty_value(self):
+        from swh.voters.ts.scores import _score_rows_from_raw
+        raw = {"vb.tsmart_partisan_score": ""}
+        rows = _score_rows_from_raw(raw, "ts:X", self._now(), self._now(), "ts-2024")
+        assert rows == []
+
+    def test_emits_multiple_scores_per_row(self):
+        from swh.voters.ts.scores import _score_rows_from_raw
+        raw = {
+            "vb.tsmart_partisan_score": "72",
+            "vb.tsmart_climate_score": "55",
+            "vb.tsmart_turnout_score_general_2024": "0.85",
+            "vb.tsmart_first_name": "Ada",  # ignored
+        }
+        rows = _score_rows_from_raw(raw, "ts:TS001", self._now(), self._now(), "ts-2024")
+        types = {r["score_type"] for r in rows}
+        assert types == {"partisan_score", "issue_climate", "turnout_propensity_general"}
+
+    def test_emits_cycle_methodology_per_cycle(self):
+        from swh.voters.ts.scores import _score_rows_from_raw
+        raw = {
+            "vb.tsmart_turnout_score_general_2020": "0.5",
+            "vb.tsmart_turnout_score_general_2024": "0.8",
+        }
+        rows = _score_rows_from_raw(raw, "ts:X", self._now(), self._now(), "ts-2024")
+        # Same score_type, different methodology_version per cycle.
+        methodologies = {r["methodology_version"] for r in rows}
+        assert methodologies == {"ts-2020", "ts-2024"}
+
+
+# PySpark-gated end-to-end tests.
+pyspark = pytest.importorskip("pyspark", reason="pyspark not installed; end-to-end tests skipped")
+
+
+FIXTURE = Path(__file__).resolve().parents[4] / "fixtures" / "ts_sample.csv"
+
+
+@pytest.fixture(scope="module")
+def spark(tmp_path_factory):
+    import os
+    warehouse_root = tmp_path_factory.mktemp("warehouse-scores")
+    os.environ["SW_WAREHOUSE_ROOT"] = f"file://{warehouse_root}"
+
+    from pyspark.sql import SparkSession
+    session = (
+        SparkSession.builder
+        .master("local[2]")
+        .appName("sw259-ts-scores-test")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.driver.bindAddress", "127.0.0.1")
+        .config("spark.driver.host", "127.0.0.1")
+        .getOrCreate()
+    )
+    yield session
+    session.stop()
+
+
+class TestExtractScoresEndToEnd:
+    def test_extract_scores_from_fixture(self, spark):
+        from swh.voters.ts.bronze import ingest_bronze
+        from swh.voters.ts.scores import extract_scores
+
+        n_bronze = ingest_bronze(spark, csv_path=FIXTURE, state="TX")
+        assert n_bronze == 10
+
+        n_scores = extract_scores(spark, default_methodology="ts-2024")
+        # Fixture has vb.tsmart_partisan_score + vb.tsmart_climate_score
+        # populated for all 10 rows. Each row yields 2 score rows.
+        assert n_scores == 20
+
+    def test_extract_is_idempotent(self, spark):
+        from swh.voters.ts.scores import extract_scores
+        n_again = extract_scores(spark, default_methodology="ts-2024")
+        # Still 20 rows; upsert leaves the table at the same row-count
+        assert n_again == 20
+
+    def test_scores_table_has_expected_rows(self, spark):
+        from socialwarehouse.delta.tables import TABLES
+        df = spark.read.format("delta").load(TABLES["silver.person_scores"]["path"])
+        n_total = df.count()
+        assert n_total == 20
+        # Ada is fixture TS001 with partisan_score=72
+        ada_partisan = df.filter(
+            (df.person_key == "ts:TS001") & (df.score_type == "partisan_score")
+        ).collect()
+        assert len(ada_partisan) == 1
+        assert ada_partisan[0].value == 72.0
+        assert ada_partisan[0].source_vendor == "ts"
+        assert ada_partisan[0].methodology_version == "ts-2024"


### PR DESCRIPTION
Closes #259. Sub-issue B.2 of #250 (follow-on to #257).

Extracts TS score columns from `bronze.voter_file_ts` into `silver.person_scores` per the schema from #251.

## What lands

- `swh/voters/ts/score_mappings.py` — TS column → `(score_type, methodology_version)` mapping. Static scores (partisan, ideology, engagement, persuadability, 6 issue-stance) use `--methodology` default. Cycle-aligned (`turnout_score_general_<year>`, `turnout_score_primary_<year>`) parse the year into `methodology_version = ts-<year>`.
- `swh/voters/ts/scores.py` — `extract_scores(spark)` reads bronze, emits silver rows, upserts via `DeltaTable.merge` on the four-tuple natural key.
- CLI flag: `swh ingest-voter-file --include-scores [--methodology ts-2024]`. Default off; preserves spine behavior.
- 18 tests (8 mapping + 7 row-emission + 3 PySpark-gated end-to-end).
- `docs/entities/fact-person-score.md` updated with the TS-specific mapping table.

## Six approved acceptance criteria

- ✅ `swh/voters/ts/scores.py:extract_scores`
- ✅ `swh/voters/ts/score_mappings.py` TS-name → canonical (score_type, methodology_version_template)
- ✅ Unmapped score-shaped columns left in `vendor_extras` (no per-row warning)
- ✅ Idempotent: DeltaTable.merge on the four-tuple unique key
- ✅ CLI `--include-scores` flag, default off
- ✅ Tests + docs

## Out of scope (separate sub-issues)

- B.3 (#260): vote-history extraction + Person aggregates
- B.4 (#261): PostGIS materialization
- C-E: L2 / Catalist / PDI importers

Refs: #259, #257, #250, #251.
