### PR TITLE
feat(electoral): TS vote-history extraction + Person aggregates (#260)

### DIFF
--- a/docs/entities/fact-vote-history.md
+++ b/docs/entities/fact-vote-history.md
@@ -48,6 +48,45 @@ When two vendors report the same vote with different `voted_method`:
 - DimPerson aggregates count the vote once per `(election_date, election_type)` to avoid double-counting. The Spark job handles this; see the silver-build doc when it ships.
 - Consumer queries that want "give me this person's method" must pick a vendor; querying across both without picking is ambiguous.
 
+## TargetSmart importer mapping (SW#260)
+
+Defined in `swh/voters/ts/vote_history_mappings.py`. TS encodes vote participation as per-cycle columns; the importer parses each column name into `(election_type, year, is_method_column)`.
+
+### Column patterns
+
+| TS prefix | Election type | Default election date |
+|---|---|---|
+| `vb.vf_g_<year>` | general | `<year>-11-05` |
+| `vb.vf_p_<year>` | primary | `<year>-03-15` |
+| `vb.vf_g_method_<year>` | general (method) | (paired with `vb.vf_g_<year>`) |
+| `vb.vf_p_method_<year>` | primary (method) | (paired with `vb.vf_p_<year>`) |
+
+A row is emitted to `silver.vote_history` when the participation column is truthy (`Y`, `y`, `1`, `T`, `t`, `TRUE`, `True`). Method columns supply `voted_method`; if absent, `voted_method` defaults to `unknown`.
+
+### Method codes
+
+| TS code | Canonical `voted_method` |
+|---|---|
+| `I` | `in_person` |
+| `A` | `absentee` |
+| `M` | `mail` |
+| `E` | `early` |
+| `P` | `provisional` |
+| (empty / unknown) | `unknown` |
+
+### Vote-frequency buckets
+
+Computed in `compute_aggregates()` and materialized onto `silver.persons.vote_frequency_category`:
+
+| Bucket | Definition |
+|---|---|
+| `super_voter` | ≥4 generals voted |
+| `regular` | 2-3 generals voted |
+| `occasional` | exactly 1 general voted |
+| `non` | 0 generals voted (regardless of primary participation) |
+
+Operators with state-specific primary dates should extend `ELECTION_TYPE_PREFIXES` in `vote_history_mappings.py`; the defaults are documented approximations.
+
 ## Why we don't store more election metadata
 
 `FactElectionResult` (existing) holds vote tallies, candidates, offices, parties at the geography level. `FactVoteHistory` is the per-person counterpart: "did this person vote?", not "what did they vote for?" (voter privacy means the latter is not in the file at all).

--- a/swh/cli.py
+++ b/swh/cli.py
@@ -317,8 +317,9 @@ def fec_centrality(graph_input_path, party):
 @click.option("--state", required=True, help="2-char USPS state code (e.g. TX); becomes the bronze partition key")
 @click.option("--skip-silver", is_flag=True, default=False, help="Run bronze ingest only; skip the silver.persons build (for staged loads)")
 @click.option("--include-scores", is_flag=True, default=False, help="Also extract silver.person_scores from the bronze rows (B.2 of #250)")
+@click.option("--include-vote-history", is_flag=True, default=False, help="Also extract silver.vote_history + compute Person aggregates (B.3 of #250)")
 @click.option("--methodology", default="ts-2024", show_default=True, help="Methodology label for static TS scores (cycle-aligned scores embed their cycle year)")
-def ingest_voter_file(vendor, csv_path, state, skip_silver, include_scores, methodology):
+def ingest_voter_file(vendor, csv_path, state, skip_silver, include_scores, include_vote_history, methodology):
     """Ingest a vendor voter file through the medallion pipeline.
 
     Currently supports TargetSmart format. Vendor CSV -> bronze.voter_file_<vendor>
@@ -334,7 +335,13 @@ def ingest_voter_file(vendor, csv_path, state, skip_silver, include_scores, meth
     if vendor != "ts":
         raise click.UsageError(f"Vendor {vendor!r} is not yet supported; only 'ts' ships in #257.")
 
-    from swh.voters.ts import build_silver_persons, extract_scores, ingest_bronze
+    from swh.voters.ts import (
+        build_silver_persons,
+        compute_aggregates,
+        extract_scores,
+        extract_vote_history,
+        ingest_bronze,
+    )
 
     click.echo(f"Bronze ingest: vendor={vendor} file={csv_path} state={state}")
     spark = settings.spark.build_session()
@@ -347,6 +354,11 @@ def ingest_voter_file(vendor, csv_path, state, skip_silver, include_scores, meth
             if include_scores:
                 n_scores = extract_scores(spark, default_methodology=methodology)
                 click.echo(f"Silver scores upserted: {n_scores}")
+            if include_vote_history:
+                n_history = extract_vote_history(spark)
+                click.echo(f"Silver vote-history rows upserted: {n_history}")
+                n_agg = compute_aggregates(spark)
+                click.echo(f"Person aggregates updated: {n_agg}")
     finally:
         spark.stop()
 

--- a/swh/voters/ts/__init__.py
+++ b/swh/voters/ts/__init__.py
@@ -19,5 +19,12 @@ See `docs/electoral/targetsmart-importer.md` for the operator runbook.
 from swh.voters.ts.bronze import ingest_bronze
 from swh.voters.ts.scores import extract_scores
 from swh.voters.ts.silver import build_silver_persons
+from swh.voters.ts.vote_history import compute_aggregates, extract_vote_history
 
-__all__ = ["ingest_bronze", "build_silver_persons", "extract_scores"]
+__all__ = [
+    "ingest_bronze",
+    "build_silver_persons",
+    "extract_scores",
+    "extract_vote_history",
+    "compute_aggregates",
+]

--- a/swh/voters/ts/vote_history.py
+++ b/swh/voters/ts/vote_history.py
@@ -1,0 +1,244 @@
+"""
+TS vote-history extraction: bronze.voter_file_ts -> silver.vote_history.
+
+Parses per-cycle TS columns (vb.vf_g_<year>, vb.vf_p_<year>) into
+individual silver.vote_history rows. Method columns
+(vb.vf_g_method_<year>, vb.vf_p_method_<year>) are paired with their
+participation columns and supply voted_method.
+
+Compute_aggregates recomputes the denormalized aggregate columns on
+silver.persons (general_election_count, primary_election_count,
+total_vote_count, last_voted_at, vote_frequency_category) from
+silver.vote_history.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from swh.voters.ts.vote_history_mappings import (
+    canonical_method,
+    election_date_for,
+    is_voted,
+    parse_column,
+    vote_frequency_category,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pyspark.sql import SparkSession
+
+logger = logging.getLogger(__name__)
+
+VENDOR = "ts"
+
+
+def _vote_history_rows_from_raw(
+    raw: dict,
+    person_key: str,
+    loaded_at: datetime,
+) -> list[dict]:
+    """Emit silver.vote_history row-dicts from a parsed TS payload.
+
+    Method columns are paired with participation columns by year. A
+    participation column with no matching method column gets
+    voted_method='unknown'.
+    """
+    # First pass: collect participation events per (etype, year).
+    participated: dict[tuple[str, int], bool] = {}
+    methods: dict[tuple[str, int], str] = {}
+    for col, value in raw.items():
+        parsed = parse_column(col)
+        if parsed is None:
+            continue
+        etype, year, is_method = parsed
+        key = (etype, year)
+        if is_method:
+            methods[key] = canonical_method(value)
+        else:
+            if is_voted(value):
+                participated[key] = True
+
+    rows: list[dict] = []
+    for (etype, year), _ in participated.items():
+        rows.append({
+            "person_key": person_key,
+            "election_date": election_date_for(etype, year),
+            "election_year": year,
+            "election_type": etype,
+            "voted_method": methods.get((etype, year), "unknown"),
+            "source_vendor": VENDOR,
+            "loaded_at": loaded_at,
+        })
+    return rows
+
+
+def extract_vote_history(
+    spark: "SparkSession",
+    bronze_table_key: str = "bronze.voter_file_ts",
+    silver_table_key: str = "silver.vote_history",
+) -> int:
+    """Read bronze.voter_file_ts and upsert silver.vote_history.
+
+    Args:
+        spark: Active SparkSession with Delta extensions.
+        bronze_table_key: Registry key for the bronze table.
+        silver_table_key: Registry key for the silver vote-history table.
+
+    Returns:
+        Number of silver vote-history rows written.
+    """
+    from delta.tables import DeltaTable
+
+    from socialwarehouse.delta.tables import SILVER_VOTE_HISTORY, TABLES
+
+    bronze_path = TABLES[bronze_table_key]["path"]
+    silver_path = TABLES[silver_table_key]["path"]
+    loaded_at = datetime.now(tz=timezone.utc)
+
+    bronze_df = spark.read.format("delta").load(bronze_path)
+    rows = bronze_df.select("vendor_voter_id", "raw").collect()
+
+    history_records: list[dict] = []
+    seen_keys: set[tuple[str, "date", str, str]] = set()
+    for r in rows:
+        vid = r["vendor_voter_id"]
+        if not vid:
+            continue
+        person_key = f"{VENDOR}:{vid}"
+        try:
+            payload = json.loads(r["raw"])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        for row in _vote_history_rows_from_raw(payload, person_key, loaded_at):
+            key = (row["person_key"], row["election_date"],
+                   row["election_type"], row["source_vendor"])
+            if key in seen_keys:
+                continue
+            seen_keys.add(key)
+            history_records.append(row)
+
+    if not history_records:
+        logger.info("extract_vote_history: no events found; nothing to write.")
+        return 0
+
+    history_df = spark.createDataFrame(history_records, schema=SILVER_VOTE_HISTORY)
+
+    if DeltaTable.isDeltaTable(spark, silver_path):
+        tgt = DeltaTable.forPath(spark, silver_path)
+        (
+            tgt.alias("t")
+            .merge(
+                history_df.alias("s"),
+                "t.person_key = s.person_key AND "
+                "t.election_date = s.election_date AND "
+                "t.election_type = s.election_type AND "
+                "t.source_vendor = s.source_vendor",
+            )
+            .whenMatchedUpdateAll()
+            .whenNotMatchedInsertAll()
+            .execute()
+        )
+    else:
+        partition_by = TABLES[silver_table_key].get("partition_by", [])
+        writer = history_df.write.format("delta")
+        if partition_by:
+            writer = writer.partitionBy(*partition_by)
+        writer.mode("overwrite").save(silver_path)
+
+    logger.info("extract_vote_history: wrote %d silver rows.", len(history_records))
+    return len(history_records)
+
+
+def compute_aggregates(
+    spark: "SparkSession",
+    silver_history_key: str = "silver.vote_history",
+    silver_persons_key: str = "silver.persons",
+) -> int:
+    """Recompute aggregate counters on silver.persons from silver.vote_history.
+
+    Updates: general_election_count, primary_election_count,
+    total_vote_count, last_voted_at, vote_frequency_category.
+
+    Args:
+        spark: Active SparkSession.
+        silver_history_key: Registry key for silver.vote_history.
+        silver_persons_key: Registry key for silver.persons.
+
+    Returns:
+        Number of silver.persons rows updated.
+    """
+    from delta.tables import DeltaTable
+    from pyspark.sql import functions as F
+    from pyspark.sql.types import (
+        DateType,
+        IntegerType,
+        StringType,
+        StructField,
+        StructType,
+    )
+
+    from socialwarehouse.delta.tables import TABLES
+
+    history_path = TABLES[silver_history_key]["path"]
+    persons_path = TABLES[silver_persons_key]["path"]
+
+    history = spark.read.format("delta").load(history_path)
+
+    agg = (
+        history
+        .groupBy("person_key")
+        .agg(
+            F.sum(F.when(F.col("election_type") == "general", 1).otherwise(0)).alias("general_election_count"),
+            F.sum(F.when(F.col("election_type") == "primary", 1).otherwise(0)).alias("primary_election_count"),
+            F.count("*").alias("total_vote_count"),
+            F.max("election_date").alias("last_voted_at"),
+        )
+    )
+    rows = agg.collect()
+
+    # Compute vote_frequency_category in driver and re-parallelize. Small N.
+    agg_rows = []
+    for r in rows:
+        g = int(r["general_election_count"] or 0)
+        t = int(r["total_vote_count"] or 0)
+        agg_rows.append({
+            "person_key": r["person_key"],
+            "general_election_count": g,
+            "primary_election_count": int(r["primary_election_count"] or 0),
+            "total_vote_count": t,
+            "last_voted_at": r["last_voted_at"],
+            "vote_frequency_category": vote_frequency_category(g, t),
+        })
+
+    if not agg_rows:
+        return 0
+
+    agg_schema = StructType([
+        StructField("person_key", StringType(), False),
+        StructField("general_election_count", IntegerType(), True),
+        StructField("primary_election_count", IntegerType(), True),
+        StructField("total_vote_count", IntegerType(), True),
+        StructField("last_voted_at", DateType(), True),
+        StructField("vote_frequency_category", StringType(), True),
+    ])
+    agg_df = spark.createDataFrame(agg_rows, schema=agg_schema)
+
+    persons = DeltaTable.forPath(spark, persons_path)
+    (
+        persons.alias("p")
+        .merge(agg_df.alias("a"), "p.person_key = a.person_key")
+        .whenMatchedUpdate(set={
+            "general_election_count": "a.general_election_count",
+            "primary_election_count": "a.primary_election_count",
+            "total_vote_count": "a.total_vote_count",
+            "last_voted_at": "a.last_voted_at",
+            "vote_frequency_category": "a.vote_frequency_category",
+        })
+        .execute()
+    )
+
+    logger.info("compute_aggregates: updated %d silver.persons rows.", len(agg_rows))
+    return len(agg_rows)

--- a/swh/voters/ts/vote_history_mappings.py
+++ b/swh/voters/ts/vote_history_mappings.py
@@ -1,0 +1,106 @@
+"""
+TS vote-history column-pattern parsing.
+
+TS encodes vote participation as per-cycle columns:
+- vb.vf_g_<year>          general participation (truthy = voted)
+- vb.vf_p_<year>          primary participation (truthy = voted)
+- vb.vf_g_method_<year>   method code for general (I/A/M/E/P/...)
+- vb.vf_p_method_<year>   method code for primary
+
+Election dates: TS ships year-only granularity. We use canonical defaults
+per election_type. Operators with state-specific primary dates should
+extend this map; the default is a documented approximation.
+"""
+
+from datetime import date
+
+
+# Election-type prefix -> (election_type label, default month-day).
+# Year is parsed from the column name; combined with month-day to get a Date.
+ELECTION_TYPE_PREFIXES: dict[str, tuple[str, tuple[int, int]]] = {
+    "vb.vf_g_method_": ("general", (11, 5)),    # method columns are paired with g_<year>
+    "vb.vf_p_method_": ("primary", (3, 15)),
+    "vb.vf_g_": ("general", (11, 5)),
+    "vb.vf_p_": ("primary", (3, 15)),
+}
+
+
+# TS method-code -> canonical voted_method.
+# Source: TS data dictionary, vote-method codes for vf_*_method_* columns.
+METHOD_CODES: dict[str, str] = {
+    "I": "in_person",
+    "A": "absentee",
+    "M": "mail",
+    "E": "early",
+    "P": "provisional",
+    "": "unknown",
+}
+
+
+TRUTHY_VOTED = {"1", "Y", "y", "T", "t", "TRUE", "true", "True"}
+
+
+def parse_column(column_name: str) -> tuple[str, int, bool] | None:
+    """Resolve a TS column name to (election_type, year, is_method_column).
+
+    Returns None if the column is not a vote-history column. Method
+    columns return is_method_column=True; participation columns return
+    False.
+    """
+    # Check method prefixes first since they're more specific
+    # (vb.vf_g_method_ matches before vb.vf_g_).
+    for prefix, (etype, _md) in ELECTION_TYPE_PREFIXES.items():
+        if column_name.startswith(prefix):
+            year_part = column_name[len(prefix):]
+            if year_part.isdigit() and len(year_part) == 4:
+                is_method = "_method_" in prefix
+                return etype, int(year_part), is_method
+    return None
+
+
+def election_date_for(election_type: str, year: int) -> date:
+    """Canonical date for (election_type, year).
+
+    General defaults to Nov 5; primary defaults to Mar 15. Operators
+    needing state-accurate primary dates can override at silver-build
+    time (follow-on).
+    """
+    for prefix, (etype, (mm, dd)) in ELECTION_TYPE_PREFIXES.items():
+        if etype == election_type:
+            return date(year, mm, dd)
+    return date(year, 1, 1)  # fallback; shouldn't happen for known types
+
+
+def canonical_method(code: str) -> str:
+    """TS method code -> canonical voted_method string."""
+    if code is None:
+        return "unknown"
+    return METHOD_CODES.get(code.strip(), "unknown")
+
+
+def is_voted(value) -> bool:
+    """Did the voter participate in this election per the TS value?"""
+    if value is None:
+        return False
+    return str(value).strip() in TRUTHY_VOTED
+
+
+# Vote-frequency category derived from total counts. Bucket boundaries
+# documented here for stability; if these change, downstream consumers
+# need to know.
+def vote_frequency_category(general_count: int, total_count: int) -> str:
+    """Derive a coarse engagement bucket from vote counts.
+
+    Buckets:
+    - super_voter: 4+ generals voted
+    - regular: 2-3 generals voted
+    - occasional: 1 general voted
+    - non: 0 generals voted (regardless of primary participation)
+    """
+    if general_count >= 4:
+        return "super_voter"
+    if general_count >= 2:
+        return "regular"
+    if general_count >= 1:
+        return "occasional"
+    return "non"

--- a/tests/fixtures/ts_with_history.csv
+++ b/tests/fixtures/ts_with_history.csv
@@ -1,0 +1,5 @@
+vb.voterbase_id,vb.tsmart_first_name,vb.tsmart_last_name,vb.vf_voter_status,vb.vf_source_state,vb.vf_g_2024,vb.vf_g_method_2024,vb.vf_g_2022,vb.vf_g_method_2022,vb.vf_g_2020,vb.vf_g_method_2020,vb.vf_g_2018,vb.vf_g_method_2018,vb.vf_p_2024,vb.vf_p_method_2024,vb.vf_p_2022,vb.vf_p_method_2022
+SV001,Ada,Voter,active,TX,Y,I,Y,M,Y,M,Y,I,Y,I,Y,M
+RV001,Reg,Voter,active,TX,Y,I,Y,M,N,,N,,Y,I,N,
+OV001,Occ,Voter,active,TX,Y,I,N,,N,,N,,N,,N,
+NV001,Non,Voter,active,TX,N,,N,,N,,N,,N,,N,

--- a/tests/unit/swh/voters/ts/test_ts_vote_history.py
+++ b/tests/unit/swh/voters/ts/test_ts_vote_history.py
@@ -1,0 +1,259 @@
+"""
+Tests for SW#260: TargetSmart vote-history extraction + Person aggregates.
+
+Pure-Python tests cover column-pattern parsing, method-code mapping,
+truthiness, and frequency bucketing. Spark-gated tests cover the
+end-to-end extract + aggregate against the dedicated history fixture.
+"""
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+class TestColumnParsing:
+    def test_general_year(self):
+        from swh.voters.ts.vote_history_mappings import parse_column
+        assert parse_column("vb.vf_g_2024") == ("general", 2024, False)
+
+    def test_primary_year(self):
+        from swh.voters.ts.vote_history_mappings import parse_column
+        assert parse_column("vb.vf_p_2022") == ("primary", 2022, False)
+
+    def test_general_method(self):
+        from swh.voters.ts.vote_history_mappings import parse_column
+        assert parse_column("vb.vf_g_method_2024") == ("general", 2024, True)
+
+    def test_primary_method(self):
+        from swh.voters.ts.vote_history_mappings import parse_column
+        assert parse_column("vb.vf_p_method_2020") == ("primary", 2020, True)
+
+    def test_non_vote_history_returns_none(self):
+        from swh.voters.ts.vote_history_mappings import parse_column
+        assert parse_column("vb.tsmart_first_name") is None
+        assert parse_column("vb.vf_party") is None
+
+    def test_non_year_suffix_returns_none(self):
+        from swh.voters.ts.vote_history_mappings import parse_column
+        assert parse_column("vb.vf_g_foo") is None
+
+
+class TestMethodCodes:
+    def test_in_person(self):
+        from swh.voters.ts.vote_history_mappings import canonical_method
+        assert canonical_method("I") == "in_person"
+
+    def test_absentee(self):
+        from swh.voters.ts.vote_history_mappings import canonical_method
+        assert canonical_method("A") == "absentee"
+
+    def test_mail(self):
+        from swh.voters.ts.vote_history_mappings import canonical_method
+        assert canonical_method("M") == "mail"
+
+    def test_early(self):
+        from swh.voters.ts.vote_history_mappings import canonical_method
+        assert canonical_method("E") == "early"
+
+    def test_provisional(self):
+        from swh.voters.ts.vote_history_mappings import canonical_method
+        assert canonical_method("P") == "provisional"
+
+    def test_empty_is_unknown(self):
+        from swh.voters.ts.vote_history_mappings import canonical_method
+        assert canonical_method("") == "unknown"
+
+    def test_unknown_code_falls_back_to_unknown(self):
+        from swh.voters.ts.vote_history_mappings import canonical_method
+        assert canonical_method("Z") == "unknown"
+
+    def test_none_is_unknown(self):
+        from swh.voters.ts.vote_history_mappings import canonical_method
+        assert canonical_method(None) == "unknown"
+
+
+class TestTruthiness:
+    def test_y_is_voted(self):
+        from swh.voters.ts.vote_history_mappings import is_voted
+        assert is_voted("Y") is True
+        assert is_voted("y") is True
+
+    def test_one_is_voted(self):
+        from swh.voters.ts.vote_history_mappings import is_voted
+        assert is_voted("1") is True
+
+    def test_n_is_not_voted(self):
+        from swh.voters.ts.vote_history_mappings import is_voted
+        assert is_voted("N") is False
+        assert is_voted("0") is False
+        assert is_voted("") is False
+        assert is_voted(None) is False
+
+
+class TestElectionDate:
+    def test_general_date(self):
+        from swh.voters.ts.vote_history_mappings import election_date_for
+        assert election_date_for("general", 2024) == date(2024, 11, 5)
+
+    def test_primary_date(self):
+        from swh.voters.ts.vote_history_mappings import election_date_for
+        assert election_date_for("primary", 2022) == date(2022, 3, 15)
+
+
+class TestFrequencyCategory:
+    def test_super_voter(self):
+        from swh.voters.ts.vote_history_mappings import vote_frequency_category
+        assert vote_frequency_category(general_count=4, total_count=5) == "super_voter"
+        assert vote_frequency_category(general_count=5, total_count=5) == "super_voter"
+
+    def test_regular(self):
+        from swh.voters.ts.vote_history_mappings import vote_frequency_category
+        assert vote_frequency_category(2, 4) == "regular"
+        assert vote_frequency_category(3, 5) == "regular"
+
+    def test_occasional(self):
+        from swh.voters.ts.vote_history_mappings import vote_frequency_category
+        assert vote_frequency_category(1, 1) == "occasional"
+
+    def test_non(self):
+        from swh.voters.ts.vote_history_mappings import vote_frequency_category
+        assert vote_frequency_category(0, 0) == "non"
+        # Even if voter has primary participation but no generals, they're "non"
+        assert vote_frequency_category(0, 3) == "non"
+
+
+class TestRowEmission:
+    def _now(self):
+        return datetime(2026, 5, 22, tzinfo=timezone.utc)
+
+    def test_voted_general_with_method(self):
+        from swh.voters.ts.vote_history import _vote_history_rows_from_raw
+        raw = {
+            "vb.vf_g_2024": "Y",
+            "vb.vf_g_method_2024": "I",
+        }
+        rows = _vote_history_rows_from_raw(raw, "ts:X", self._now())
+        assert len(rows) == 1
+        assert rows[0]["election_type"] == "general"
+        assert rows[0]["election_year"] == 2024
+        assert rows[0]["election_date"] == date(2024, 11, 5)
+        assert rows[0]["voted_method"] == "in_person"
+
+    def test_voted_no_method_falls_back_to_unknown(self):
+        from swh.voters.ts.vote_history import _vote_history_rows_from_raw
+        raw = {"vb.vf_g_2024": "Y"}
+        rows = _vote_history_rows_from_raw(raw, "ts:X", self._now())
+        assert len(rows) == 1
+        assert rows[0]["voted_method"] == "unknown"
+
+    def test_not_voted_emits_nothing(self):
+        from swh.voters.ts.vote_history import _vote_history_rows_from_raw
+        raw = {"vb.vf_g_2024": "N", "vb.vf_g_method_2024": ""}
+        rows = _vote_history_rows_from_raw(raw, "ts:X", self._now())
+        assert rows == []
+
+    def test_method_without_participation_emits_nothing(self):
+        from swh.voters.ts.vote_history import _vote_history_rows_from_raw
+        # Method column present but no Y for the corresponding year.
+        raw = {"vb.vf_g_method_2024": "I"}
+        rows = _vote_history_rows_from_raw(raw, "ts:X", self._now())
+        assert rows == []
+
+    def test_multiple_cycles(self):
+        from swh.voters.ts.vote_history import _vote_history_rows_from_raw
+        raw = {
+            "vb.vf_g_2024": "Y", "vb.vf_g_method_2024": "I",
+            "vb.vf_g_2022": "Y", "vb.vf_g_method_2022": "M",
+            "vb.vf_p_2024": "Y",  # no method = unknown
+        }
+        rows = _vote_history_rows_from_raw(raw, "ts:X", self._now())
+        assert len(rows) == 3
+        types_years = {(r["election_type"], r["election_year"]) for r in rows}
+        assert types_years == {("general", 2024), ("general", 2022), ("primary", 2024)}
+
+
+# PySpark-gated end-to-end tests.
+pyspark = pytest.importorskip("pyspark", reason="pyspark not installed; end-to-end tests skipped")
+
+
+FIXTURE = Path(__file__).resolve().parents[4] / "fixtures" / "ts_with_history.csv"
+
+
+@pytest.fixture(scope="module")
+def spark(tmp_path_factory):
+    import os
+    warehouse_root = tmp_path_factory.mktemp("warehouse-history")
+    os.environ["SW_WAREHOUSE_ROOT"] = f"file://{warehouse_root}"
+
+    from pyspark.sql import SparkSession
+    session = (
+        SparkSession.builder
+        .master("local[2]")
+        .appName("sw260-ts-vote-history-test")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.driver.bindAddress", "127.0.0.1")
+        .config("spark.driver.host", "127.0.0.1")
+        .getOrCreate()
+    )
+    yield session
+    session.stop()
+
+
+class TestExtractVoteHistory:
+    def test_extracts_from_fixture(self, spark):
+        from swh.voters.ts.bronze import ingest_bronze
+        from swh.voters.ts.silver import build_silver_persons
+        from swh.voters.ts.vote_history import extract_vote_history
+
+        n_bronze = ingest_bronze(spark, csv_path=FIXTURE, state="TX")
+        assert n_bronze == 4
+        # Need persons rows to exist for compute_aggregates to merge against.
+        build_silver_persons(spark)
+
+        n_history = extract_vote_history(spark)
+        # Expected event count from fixture:
+        # SV001: g2024, g2022, g2020, g2018, p2024, p2022 = 6
+        # RV001: g2024, g2022, p2024 = 3
+        # OV001: g2024 = 1
+        # NV001: (none) = 0
+        # Total = 10
+        assert n_history == 10
+
+    def test_extract_idempotent(self, spark):
+        from swh.voters.ts.vote_history import extract_vote_history
+        n_again = extract_vote_history(spark)
+        assert n_again == 10
+
+
+class TestComputeAggregates:
+    def test_aggregates_super_voter(self, spark):
+        from socialwarehouse.delta.tables import TABLES
+        from swh.voters.ts.vote_history import compute_aggregates
+
+        n_updated = compute_aggregates(spark)
+        assert n_updated == 3  # only the 3 voters with any history
+
+        df = spark.read.format("delta").load(TABLES["silver.persons"]["path"])
+        sv = df.filter(df.vendor_voter_id == "SV001").collect()[0]
+        assert sv.general_election_count == 4
+        assert sv.primary_election_count == 2
+        assert sv.total_vote_count == 6
+        assert sv.vote_frequency_category == "super_voter"
+        assert sv.last_voted_at == date(2024, 11, 5)
+
+    def test_aggregates_regular(self, spark):
+        from socialwarehouse.delta.tables import TABLES
+        df = spark.read.format("delta").load(TABLES["silver.persons"]["path"])
+        rv = df.filter(df.vendor_voter_id == "RV001").collect()[0]
+        assert rv.general_election_count == 2
+        assert rv.vote_frequency_category == "regular"
+
+    def test_aggregates_occasional(self, spark):
+        from socialwarehouse.delta.tables import TABLES
+        df = spark.read.format("delta").load(TABLES["silver.persons"]["path"])
+        ov = df.filter(df.vendor_voter_id == "OV001").collect()[0]
+        assert ov.general_election_count == 1
+        assert ov.vote_frequency_category == "occasional"


### PR DESCRIPTION
Closes #260. Sub-issue B.3 of #250 (follow-on to #257 / #259).

Extracts TS per-cycle vote columns into `silver.vote_history` and recomputes denormalized aggregates on `silver.persons`.

## What lands

- `swh/voters/ts/vote_history_mappings.py` — column-pattern parser + method-code map + frequency-category bucketing.
- `swh/voters/ts/vote_history.py` — `extract_vote_history(spark)` + `compute_aggregates(spark)`.
- CLI flag: `--include-vote-history`. Default off.
- 32 tests (27 pure-Python + 5 PySpark-gated end-to-end).
- `tests/fixtures/ts_with_history.csv` — 4 voters calibrated to each frequency bucket.
- `docs/entities/fact-vote-history.md` updated with the TS-specific mapping table.

## Approved acceptance criteria

- ✅ `extract_vote_history` reads bronze, parses per-cycle columns, emits silver rows.
- ✅ `compute_aggregates` recomputes the five aggregate columns on `silver.persons`.
- ✅ Election-date defaults: general `<year>-11-05`, primary `<year>-03-15`. Documented.
- ✅ `vote_frequency_category` buckets: super_voter (4+), regular (2-3), occasional (1), non (0). Documented.
- ✅ Idempotent via DeltaTable.merge on the natural-key tuple.
- ✅ CLI `--include-vote-history` flag, default off.
- ✅ Tests + docs.

## Closes the TS warehouse-tier work

After this merges, the only TS sub-issue remaining is **B.4 (#261)** — Spark→PostGIS materialization. The Delta silver substrate for TS will then be feature-complete (persons + scores + vote-history).

Refs: #260, #257, #259, #250, #251.
