### PR TITLE
feat(electoral): silver Delta -> PostGIS materialization (#261)

### DIFF
--- a/docs/electoral/materialization.md
+++ b/docs/electoral/materialization.md
@@ -1,0 +1,92 @@
+# Electoral substrate materialization
+
+Operator runbook for materializing the silver Delta substrate (silver.persons / silver.person_scores / silver.vote_history) into the PostGIS star schema (DimPerson / FactPersonScore / FactVoteHistory) that the Django web app reads.
+
+This is the final link in the warehouse-first pipeline (per [`docs/architecture.md`](../architecture.md)). Until this runs, silver Delta has TS data but PostGIS doesn't, so Django views / admin can't surface anything.
+
+## Prerequisites
+
+- SocialWarehouse deployed (Postgres + Python + Spark).
+- TS data already ingested through bronze + silver via [`docs/electoral/targetsmart-importer.md`](targetsmart-importer.md).
+- Optionally: scores and vote-history extracted via `--include-scores` / `--include-vote-history`. Both are no-ops at materialize-time if silver tables are empty.
+
+## Running the materializer
+
+### All three tables in order
+
+```bash
+swh materialize-electoral all
+```
+
+This runs persons → scores → vote-history in dependency order. Scores and vote-history reference DimPerson by FK; running them without persons-first warn-and-skips on missing FK lookup rather than failing.
+
+### Individual tables
+
+```bash
+swh materialize-electoral persons         # silver.persons -> DimPerson
+swh materialize-electoral scores          # silver.person_scores -> FactPersonScore
+swh materialize-electoral vote-history    # silver.vote_history -> FactVoteHistory
+```
+
+Use cases:
+- After re-running TS importer on a new file: `persons` (then `scores` / `vote-history` if those silver tables were also updated).
+- After a re-score-only run: `scores` alone.
+- Debugging a single table.
+
+## Idempotency
+
+All three are idempotent. Re-running on identical silver yields identical PostGIS state.
+
+Mechanism: Django ORM `bulk_create(update_conflicts=True, unique_fields=[...], update_fields=[...])` against the natural-key constraints declared in #251's migration:
+
+- `DimPerson`: `(vendor, vendor_voter_id)`
+- `FactPersonScore`: `(person, score_type, source_vendor, methodology_version)`
+- `FactVoteHistory`: `(person, election_date, election_type, source_vendor)`
+
+`update_fields` covers everything that can change between runs. `created_at` and `loaded_at` are excluded (preserve original timestamps).
+
+## Order requirement
+
+Persons MUST be materialized before scores or vote-history because of the FK constraint. The `all` subcommand enforces this; standalone subcommands print a warning + skip rows whose FK lookup misses:
+
+```
+materialize_scores: skipped 1234 rows because their DimPerson is not
+materialized. Run materialize_persons first.
+```
+
+Re-running `materialize_persons` followed by `materialize_scores` resolves the skips on the next run (the persons land and the scores find their FKs).
+
+## Vendor extras dispatch
+
+`silver.persons.vendor_extras` is one Map<String,String> on the Delta side. PostGIS DimPerson has four `*_extras` JSONField columns. The materializer dispatches: rows with `vendor='ts'` → `ts_extras`; `vendor='l2'` → `l2_extras`; etc. Other vendor-extras fields default to `{}` on each row.
+
+For unknown vendor strings, the materializer logs a warning and drops the extras (canonical fields still ship).
+
+## Address resolution
+
+DimPerson.address is a nullable FK to `sw_geo.address`. This materializer does NOT populate it; silver.persons.address_id is null after the TS importer (latitude/longitude are present but Address records are not linked).
+
+Backfill is filed as sub-issue B.5 of #250 — a separate Spark spatial-join job from silver.persons.lat/lon → silver.addresses → DimPerson.address.
+
+Until B.5 ships, the web app surfaces work on the boundary-cache GEOID columns directly on DimPerson (cd_geoid, sldu_geoid, etc.) without going through geo.Address.
+
+## Troubleshooting
+
+### `materialize_scores: skipped N rows`
+
+DimPerson for those rows isn't materialized yet. Run `materialize-electoral persons` first, then re-run scores.
+
+### `unknown vendor 'xyz' for vendor_voter_id=...`
+
+A silver.persons row has a vendor value not in `{pdi, l2, catalist, ts}`. Canonical fields still materialize; extras are dropped. Verify the silver-build job set `vendor` correctly.
+
+### `IntegrityError on bulk_create`
+
+Should not happen given the `update_conflicts=True` shape. If it does, check that the natural-key unique constraints on the PostGIS migration match the `unique_fields` arg in the materializer (`#251`'s migration is the source of truth).
+
+## See also
+
+- [`docs/architecture.md`](../architecture.md) — warehouse-first / web-app-last principle.
+- [`docs/entities/dim-person.md`](../entities/dim-person.md) — canonical Person model + vendor mapping.
+- [`docs/entities/voter-file-ingest.md`](../entities/voter-file-ingest.md) — full pipeline contract.
+- Refs: SW#261 (this), SW#250 (initiative), SW#251 (substrate).

--- a/swh/cli.py
+++ b/swh/cli.py
@@ -363,5 +363,58 @@ def ingest_voter_file(vendor, csv_path, state, skip_silver, include_scores, incl
         spark.stop()
 
 
+@cli.group("materialize-electoral")
+def materialize_electoral():
+    """Materialize silver electoral Delta tables into PostGIS star schema (B.4 of #250)."""
+
+
+@materialize_electoral.command("persons")
+def materialize_electoral_persons():
+    """Materialize silver.persons -> DimPerson."""
+    from swh.voters.materialize import materialize_persons
+    spark = settings.spark.build_session()
+    try:
+        n = materialize_persons(spark)
+        click.echo(f"DimPerson rows upserted: {n}")
+    finally:
+        spark.stop()
+
+
+@materialize_electoral.command("scores")
+def materialize_electoral_scores():
+    """Materialize silver.person_scores -> FactPersonScore."""
+    from swh.voters.materialize import materialize_scores
+    spark = settings.spark.build_session()
+    try:
+        n = materialize_scores(spark)
+        click.echo(f"FactPersonScore rows upserted: {n}")
+    finally:
+        spark.stop()
+
+
+@materialize_electoral.command("vote-history")
+def materialize_electoral_vote_history():
+    """Materialize silver.vote_history -> FactVoteHistory."""
+    from swh.voters.materialize import materialize_vote_history
+    spark = settings.spark.build_session()
+    try:
+        n = materialize_vote_history(spark)
+        click.echo(f"FactVoteHistory rows upserted: {n}")
+    finally:
+        spark.stop()
+
+
+@materialize_electoral.command("all")
+def materialize_electoral_all():
+    """Materialize all three electoral tables in dependency order."""
+    from swh.voters.materialize import materialize_all
+    spark = settings.spark.build_session()
+    try:
+        counts = materialize_all(spark)
+        click.echo(f"Materialization complete: {counts}")
+    finally:
+        spark.stop()
+
+
 if __name__ == "__main__":
     cli()

--- a/swh/voters/materialize.py
+++ b/swh/voters/materialize.py
@@ -1,0 +1,356 @@
+"""
+Silver Delta -> PostGIS star-schema materialization (SW#261).
+
+Vendor-agnostic: runs against whatever's in silver.persons /
+silver.person_scores / silver.vote_history regardless of source vendor.
+TS-first since the importer thread ships TS data; L2 / Catalist / PDI
+materialize automatically once their importers land.
+
+Per `docs/architecture.md`: silver Delta is canonical; this module
+projects silver into the PostGIS star schema (DimPerson / FactPersonScore
+/ FactVoteHistory) that the Django web app and DRF API read.
+
+Idempotency via Django ORM `bulk_create(update_conflicts=True)` on the
+natural keys declared in #251's migration. Re-running materialize_all
+on identical silver yields identical PostGIS state.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Iterable, Iterator
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pyspark.sql import SparkSession
+
+logger = logging.getLogger(__name__)
+
+
+# Vendor -> the matching JSONField name on DimPerson.
+_VENDOR_EXTRAS_FIELD: dict[str, str] = {
+    "pdi": "pdi_extras",
+    "l2": "l2_extras",
+    "catalist": "catalist_extras",
+    "ts": "ts_extras",
+}
+
+
+def _chunked(iterable: Iterable, size: int) -> Iterator[list]:
+    """Yield successive `size`-length chunks from `iterable`."""
+    buf: list = []
+    for item in iterable:
+        buf.append(item)
+        if len(buf) >= size:
+            yield buf
+            buf = []
+    if buf:
+        yield buf
+
+
+def _silver_persons_to_dimperson_kwargs(row) -> dict:
+    """Map a silver.persons row (Spark Row or dict) to DimPerson kwargs.
+
+    The vendor's extras map is dispatched into the matching JSONField
+    (ts -> ts_extras, l2 -> l2_extras, etc.); the other three default
+    to {}.
+
+    `row` accepts both pyspark.sql.Row (asDict()) and plain dicts so
+    the helper is pure-Python testable without Spark.
+    """
+    if hasattr(row, "asDict"):
+        d = row.asDict()
+    else:
+        d = dict(row)
+
+    vendor = d.get("vendor")
+    extras = d.get("vendor_extras") or {}
+    extras_field = _VENDOR_EXTRAS_FIELD.get(vendor)
+    if extras_field is None:
+        # Unknown vendor — log and stash extras nowhere; canonical fields
+        # still ship.
+        logger.warning(
+            "DimPerson materialize: unknown vendor %r for vendor_voter_id=%r; "
+            "vendor_extras dropped.", vendor, d.get("vendor_voter_id"),
+        )
+        extras_payload = {}
+    else:
+        extras_payload = {f: {} for f in _VENDOR_EXTRAS_FIELD.values()}
+        extras_payload[extras_field] = dict(extras)
+
+    kwargs = {
+        "vendor": vendor,
+        "vendor_voter_id": d.get("vendor_voter_id"),
+        "first_name": d.get("first_name") or "",
+        "middle_name": d.get("middle_name") or "",
+        "last_name": d.get("last_name") or "",
+        "name_suffix": d.get("name_suffix") or "",
+        "dob": d.get("dob"),
+        "gender": d.get("gender") or "",
+        "ethnicity": d.get("ethnicity") or "",
+        "language": d.get("language") or "",
+        "registration_status": d.get("registration_status") or "not_registered",
+        "registration_state": d.get("registration_state") or "",
+        "registration_date": d.get("registration_date"),
+        "party_registration": d.get("party_registration") or "",
+        "voter_status_reason": d.get("voter_status_reason") or "",
+        "vendor_address_line1": d.get("address_line1") or "",
+        "vendor_address_line2": d.get("address_line2") or "",
+        "vendor_city": d.get("city") or "",
+        "vendor_state": d.get("registration_state") or "",
+        "vendor_zip": d.get("zip5") or "",
+        "vendor_zip4": d.get("zip4") or "",
+        "household_id": d.get("household_id") or "",
+        "household_size": d.get("household_size"),
+        "is_head_of_household": bool(d.get("is_head_of_household")),
+        "general_election_count": int(d.get("general_election_count") or 0),
+        "primary_election_count": int(d.get("primary_election_count") or 0),
+        "total_vote_count": int(d.get("total_vote_count") or 0),
+        "last_voted_at": d.get("last_voted_at"),
+        "vote_frequency_category": d.get("vote_frequency_category") or "",
+        "last_loaded_from_vendor": vendor or "",
+        "silver_source_path": d.get("source_file") or "",
+        **extras_payload,
+    }
+    return kwargs
+
+
+def _build_id_lookup(person_keys: set[str]) -> dict[tuple[str, str], int]:
+    """Resolve `vendor:vendor_voter_id` keys to DimPerson.id.
+
+    Returns a {(vendor, vendor_voter_id): id} dict. Misses are absent
+    from the dict; callers warn-and-skip per the documented contract.
+    """
+    from django.db.models import Q
+
+    from socialwarehouse.warehouse.models import DimPerson
+
+    if not person_keys:
+        return {}
+
+    # Parse person_key strings into (vendor, vendor_voter_id) pairs.
+    pairs = [pk.split(":", 1) for pk in person_keys if ":" in pk]
+    if not pairs:
+        return {}
+
+    # Group by vendor for efficient WHERE-IN per vendor.
+    by_vendor: dict[str, list[str]] = {}
+    for vendor, vid in pairs:
+        by_vendor.setdefault(vendor, []).append(vid)
+
+    qs_filter = Q()
+    for vendor, vids in by_vendor.items():
+        qs_filter |= Q(vendor=vendor, vendor_voter_id__in=vids)
+
+    qs = DimPerson.objects.filter(qs_filter).values("id", "vendor", "vendor_voter_id")
+    return {(r["vendor"], r["vendor_voter_id"]): r["id"] for r in qs}
+
+
+# Update field lists. Exclude id and created_at; everything else is
+# eligible for overwrite on conflict.
+_DIMPERSON_UPDATE_FIELDS = [
+    "first_name", "middle_name", "last_name", "name_suffix", "dob", "gender",
+    "ethnicity", "language",
+    "registration_status", "registration_state", "registration_date",
+    "party_registration", "voter_status_reason",
+    "vendor_address_line1", "vendor_address_line2", "vendor_city",
+    "vendor_state", "vendor_zip", "vendor_zip4",
+    "household_id", "household_size", "is_head_of_household",
+    "general_election_count", "primary_election_count", "total_vote_count",
+    "last_voted_at", "vote_frequency_category",
+    "pdi_extras", "l2_extras", "catalist_extras", "ts_extras",
+    "last_loaded_from_vendor", "last_loaded_at", "silver_source_path",
+    "updated_at",
+]
+
+_FACTPERSONSCORE_UPDATE_FIELDS = ["value", "scored_at"]
+_FACTVOTEHISTORY_UPDATE_FIELDS = ["voted_method"]
+
+
+def materialize_persons(
+    spark: "SparkSession",
+    silver_table_key: str = "silver.persons",
+    batch_size: int = 10_000,
+) -> int:
+    """Read silver.persons and upsert DimPerson.
+
+    Vendor-extras dispatched per row to the matching `*_extras`
+    JSONField. Idempotent: re-running yields the same PostGIS state.
+
+    Returns the number of silver rows processed (== upserted, modulo
+    skipped rows on unknown vendor).
+    """
+    from datetime import datetime, timezone
+
+    from socialwarehouse.delta.tables import TABLES
+    from socialwarehouse.warehouse.models import DimPerson
+
+    silver_path = TABLES[silver_table_key]["path"]
+    df = spark.read.format("delta").load(silver_path)
+
+    n_processed = 0
+    for batch in _chunked(df.toLocalIterator(), batch_size):
+        instances = []
+        now = datetime.now(tz=timezone.utc)
+        for row in batch:
+            kwargs = _silver_persons_to_dimperson_kwargs(row)
+            kwargs["last_loaded_at"] = now
+            instances.append(DimPerson(**kwargs))
+        if instances:
+            DimPerson.objects.bulk_create(
+                instances,
+                update_conflicts=True,
+                unique_fields=["vendor", "vendor_voter_id"],
+                update_fields=_DIMPERSON_UPDATE_FIELDS,
+                batch_size=batch_size,
+            )
+            n_processed += len(instances)
+
+    logger.info("materialize_persons: upserted %d DimPerson rows.", n_processed)
+    return n_processed
+
+
+def _row_person_key(row) -> str:
+    return row.person_key if hasattr(row, "person_key") else row["person_key"]
+
+
+def materialize_scores(
+    spark: "SparkSession",
+    silver_table_key: str = "silver.person_scores",
+    batch_size: int = 20_000,
+) -> int:
+    """Read silver.person_scores and upsert FactPersonScore.
+
+    FK resolved per batch via DimPerson natural-key lookup. Rows
+    pointing at a missing DimPerson are warned-and-skipped (see
+    `materialize_all` for order enforcement).
+    """
+    from socialwarehouse.delta.tables import TABLES
+    from socialwarehouse.warehouse.models import FactPersonScore
+
+    silver_path = TABLES[silver_table_key]["path"]
+    df = spark.read.format("delta").load(silver_path)
+
+    n_upserted = 0
+    n_skipped = 0
+    for batch in _chunked(df.toLocalIterator(), batch_size):
+        person_keys = {_row_person_key(r) for r in batch}
+        id_lookup = _build_id_lookup(person_keys)
+
+        instances = []
+        for row in batch:
+            d = row.asDict() if hasattr(row, "asDict") else dict(row)
+            pk = d["person_key"]
+            try:
+                vendor, vid = pk.split(":", 1)
+            except ValueError:
+                n_skipped += 1
+                continue
+            person_id = id_lookup.get((vendor, vid))
+            if person_id is None:
+                n_skipped += 1
+                continue
+            instances.append(FactPersonScore(
+                person_id=person_id,
+                score_type=d["score_type"],
+                value=d["value"],
+                source_vendor=d["source_vendor"],
+                methodology_version=d.get("methodology_version") or "",
+                scored_at=d.get("scored_at"),
+            ))
+        if instances:
+            FactPersonScore.objects.bulk_create(
+                instances,
+                update_conflicts=True,
+                unique_fields=["person", "score_type", "source_vendor", "methodology_version"],
+                update_fields=_FACTPERSONSCORE_UPDATE_FIELDS,
+                batch_size=batch_size,
+            )
+            n_upserted += len(instances)
+
+    if n_skipped:
+        logger.warning(
+            "materialize_scores: skipped %d rows because their DimPerson "
+            "is not materialized. Run materialize_persons first.", n_skipped,
+        )
+    logger.info("materialize_scores: upserted %d FactPersonScore rows.", n_upserted)
+    return n_upserted
+
+
+def materialize_vote_history(
+    spark: "SparkSession",
+    silver_table_key: str = "silver.vote_history",
+    batch_size: int = 50_000,
+) -> int:
+    """Read silver.vote_history and upsert FactVoteHistory.
+
+    Same FK-resolution pattern as `materialize_scores`. Rows pointing
+    at a missing DimPerson are warned-and-skipped.
+    """
+    from socialwarehouse.delta.tables import TABLES
+    from socialwarehouse.warehouse.models import FactVoteHistory
+
+    silver_path = TABLES[silver_table_key]["path"]
+    df = spark.read.format("delta").load(silver_path)
+
+    n_upserted = 0
+    n_skipped = 0
+    for batch in _chunked(df.toLocalIterator(), batch_size):
+        person_keys = {_row_person_key(r) for r in batch}
+        id_lookup = _build_id_lookup(person_keys)
+
+        instances = []
+        for row in batch:
+            d = row.asDict() if hasattr(row, "asDict") else dict(row)
+            pk = d["person_key"]
+            try:
+                vendor, vid = pk.split(":", 1)
+            except ValueError:
+                n_skipped += 1
+                continue
+            person_id = id_lookup.get((vendor, vid))
+            if person_id is None:
+                n_skipped += 1
+                continue
+            instances.append(FactVoteHistory(
+                person_id=person_id,
+                election_date=d["election_date"],
+                election_type=d["election_type"],
+                voted_method=d.get("voted_method") or "unknown",
+                source_vendor=d["source_vendor"],
+            ))
+        if instances:
+            FactVoteHistory.objects.bulk_create(
+                instances,
+                update_conflicts=True,
+                unique_fields=["person", "election_date", "election_type", "source_vendor"],
+                update_fields=_FACTVOTEHISTORY_UPDATE_FIELDS,
+                batch_size=batch_size,
+            )
+            n_upserted += len(instances)
+
+    if n_skipped:
+        logger.warning(
+            "materialize_vote_history: skipped %d rows because their "
+            "DimPerson is not materialized. Run materialize_persons first.",
+            n_skipped,
+        )
+    logger.info("materialize_vote_history: upserted %d FactVoteHistory rows.", n_upserted)
+    return n_upserted
+
+
+def materialize_all(spark: "SparkSession") -> dict[str, int]:
+    """Run all three materializers in dependency order.
+
+    Order matters: DimPerson must exist before FactPersonScore /
+    FactVoteHistory because of the FK + the warn-and-skip-on-missing
+    posture in the fact materializers.
+
+    Returns per-table row counts.
+    """
+    counts = {
+        "persons": materialize_persons(spark),
+        "scores": materialize_scores(spark),
+        "vote_history": materialize_vote_history(spark),
+    }
+    logger.info("materialize_all complete: %s", counts)
+    return counts

--- a/tests/unit/swh/voters/test_materialize.py
+++ b/tests/unit/swh/voters/test_materialize.py
@@ -1,0 +1,248 @@
+"""
+Tests for SW#261: Silver Delta -> PostGIS materialization.
+
+Pure-Python tests cover vendor-extras dispatch + chunking + FK lookup
+construction. Django-DB-required tests cover the bulk_create upsert
+path against the actual DimPerson model. PySpark + Django-DB tests
+cover the end-to-end materialize_all against the existing TS fixtures.
+"""
+
+from datetime import date, datetime, timezone
+
+import pytest
+
+
+class TestVendorExtrasDispatch:
+    """`_silver_persons_to_dimperson_kwargs` vendor dispatch — pure Python."""
+
+    def _row(self, **overrides):
+        row = {
+            "vendor": "ts",
+            "vendor_voter_id": "TS001",
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "registration_state": "TX",
+            "registration_status": "active",
+            "vendor_extras": {"vb.tsmart_partisan_score": "72"},
+        }
+        row.update(overrides)
+        return row
+
+    def test_ts_vendor_routes_to_ts_extras(self):
+        from swh.voters.materialize import _silver_persons_to_dimperson_kwargs
+        out = _silver_persons_to_dimperson_kwargs(self._row())
+        assert out["ts_extras"] == {"vb.tsmart_partisan_score": "72"}
+        assert out["pdi_extras"] == {}
+        assert out["l2_extras"] == {}
+        assert out["catalist_extras"] == {}
+
+    def test_l2_vendor_routes_to_l2_extras(self):
+        from swh.voters.materialize import _silver_persons_to_dimperson_kwargs
+        out = _silver_persons_to_dimperson_kwargs(self._row(
+            vendor="l2", vendor_extras={"LALVOTERID": "L-99"}
+        ))
+        assert out["l2_extras"] == {"LALVOTERID": "L-99"}
+        assert out["ts_extras"] == {}
+
+    def test_pdi_vendor_routes_to_pdi_extras(self):
+        from swh.voters.materialize import _silver_persons_to_dimperson_kwargs
+        out = _silver_persons_to_dimperson_kwargs(self._row(
+            vendor="pdi", vendor_extras={"pdi_internal_id": "P-1"}
+        ))
+        assert out["pdi_extras"] == {"pdi_internal_id": "P-1"}
+
+    def test_unknown_vendor_drops_extras(self):
+        from swh.voters.materialize import _silver_persons_to_dimperson_kwargs
+        out = _silver_persons_to_dimperson_kwargs(self._row(vendor="unknown_vendor"))
+        # All four extras fields default to {} (extras content dropped).
+        assert out["ts_extras"] == {}
+        assert out["l2_extras"] == {}
+        assert out["pdi_extras"] == {}
+        assert out["catalist_extras"] == {}
+
+    def test_canonical_fields_pass_through(self):
+        from swh.voters.materialize import _silver_persons_to_dimperson_kwargs
+        out = _silver_persons_to_dimperson_kwargs(self._row())
+        assert out["first_name"] == "Ada"
+        assert out["last_name"] == "Lovelace"
+        assert out["registration_state"] == "TX"
+        assert out["registration_status"] == "active"
+        assert out["vendor"] == "ts"
+        assert out["vendor_voter_id"] == "TS001"
+
+    def test_vendor_state_mirrors_registration_state(self):
+        from swh.voters.materialize import _silver_persons_to_dimperson_kwargs
+        out = _silver_persons_to_dimperson_kwargs(self._row())
+        assert out["vendor_state"] == "TX"
+
+    def test_missing_optional_fields_default_safely(self):
+        from swh.voters.materialize import _silver_persons_to_dimperson_kwargs
+        row = {
+            "vendor": "ts",
+            "vendor_voter_id": "TS001",
+            "registration_state": "TX",
+        }
+        out = _silver_persons_to_dimperson_kwargs(row)
+        assert out["first_name"] == ""
+        assert out["registration_status"] == "not_registered"
+        assert out["general_election_count"] == 0
+
+
+class TestChunking:
+    def test_chunk_smaller_than_size(self):
+        from swh.voters.materialize import _chunked
+        result = list(_chunked([1, 2, 3], 10))
+        assert result == [[1, 2, 3]]
+
+    def test_chunk_exact_multiple(self):
+        from swh.voters.materialize import _chunked
+        result = list(_chunked([1, 2, 3, 4], 2))
+        assert result == [[1, 2], [3, 4]]
+
+    def test_chunk_with_remainder(self):
+        from swh.voters.materialize import _chunked
+        result = list(_chunked([1, 2, 3, 4, 5], 2))
+        assert result == [[1, 2], [3, 4], [5]]
+
+    def test_chunk_empty(self):
+        from swh.voters.materialize import _chunked
+        assert list(_chunked([], 10)) == []
+
+
+@pytest.mark.django_db
+class TestIdLookup:
+    def test_lookup_returns_id_for_matched_natural_key(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        from swh.voters.materialize import _build_id_lookup
+
+        p = DimPerson.objects.create(
+            vendor="ts", vendor_voter_id="LOOKUP-1",
+            registration_state="TX", registration_status="active",
+        )
+        lookup = _build_id_lookup({"ts:LOOKUP-1"})
+        assert lookup == {("ts", "LOOKUP-1"): p.id}
+
+    def test_lookup_missing_returns_empty(self):
+        from swh.voters.materialize import _build_id_lookup
+        lookup = _build_id_lookup({"ts:NONEXISTENT"})
+        assert lookup == {}
+
+    def test_lookup_mixed_vendors(self):
+        from socialwarehouse.warehouse.models import DimPerson
+        from swh.voters.materialize import _build_id_lookup
+
+        ts_p = DimPerson.objects.create(
+            vendor="ts", vendor_voter_id="X",
+            registration_state="TX", registration_status="active",
+        )
+        l2_p = DimPerson.objects.create(
+            vendor="l2", vendor_voter_id="X",
+            registration_state="TX", registration_status="active",
+        )
+        lookup = _build_id_lookup({"ts:X", "l2:X"})
+        assert lookup[("ts", "X")] == ts_p.id
+        assert lookup[("l2", "X")] == l2_p.id
+
+    def test_lookup_handles_empty_input(self):
+        from swh.voters.materialize import _build_id_lookup
+        assert _build_id_lookup(set()) == {}
+
+    def test_lookup_skips_malformed_keys(self):
+        from swh.voters.materialize import _build_id_lookup
+        # Keys without ":" separator skipped.
+        assert _build_id_lookup({"no-colon", "also-no-colon"}) == {}
+
+
+# Spark + Django-DB end-to-end tests
+pyspark = pytest.importorskip("pyspark", reason="pyspark not installed; end-to-end materialization tests skipped")
+
+
+@pytest.fixture(scope="module")
+def spark(tmp_path_factory):
+    import os
+    warehouse_root = tmp_path_factory.mktemp("warehouse-materialize")
+    os.environ["SW_WAREHOUSE_ROOT"] = f"file://{warehouse_root}"
+
+    from pyspark.sql import SparkSession
+    session = (
+        SparkSession.builder
+        .master("local[2]")
+        .appName("sw261-materialize-test")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.driver.bindAddress", "127.0.0.1")
+        .config("spark.driver.host", "127.0.0.1")
+        .getOrCreate()
+    )
+    yield session
+    session.stop()
+
+
+@pytest.mark.django_db(transaction=True)
+class TestMaterializeEndToEnd:
+    def test_materialize_all_from_ts_fixtures(self, spark):
+        from pathlib import Path
+
+        from socialwarehouse.warehouse.models import (
+            DimPerson, FactPersonScore, FactVoteHistory,
+        )
+        from swh.voters.materialize import materialize_all
+        from swh.voters.ts.bronze import ingest_bronze
+        from swh.voters.ts.scores import extract_scores
+        from swh.voters.ts.silver import build_silver_persons
+        from swh.voters.ts.vote_history import compute_aggregates, extract_vote_history
+
+        fixtures = Path(__file__).resolve().parents[3] / "fixtures"
+
+        # Ingest both TS fixtures: 10-row sample + 4-row history fixture.
+        ingest_bronze(spark, csv_path=fixtures / "ts_sample.csv", state="TX")
+        ingest_bronze(spark, csv_path=fixtures / "ts_with_history.csv", state="TX")
+        build_silver_persons(spark)
+        extract_scores(spark)
+        extract_vote_history(spark)
+        compute_aggregates(spark)
+
+        counts = materialize_all(spark)
+
+        # 10 + 4 = 14 distinct natural-key persons.
+        assert counts["persons"] == 14
+        assert DimPerson.objects.count() == 14
+        # 10 fixture persons * 2 scores each = 20.
+        assert counts["scores"] == 20
+        assert FactPersonScore.objects.count() == 20
+        # SV001 (6 events) + RV001 (3) + OV001 (1) = 10.
+        assert counts["vote_history"] == 10
+        assert FactVoteHistory.objects.count() == 10
+
+    def test_materialize_is_idempotent(self, spark):
+        from socialwarehouse.warehouse.models import (
+            DimPerson, FactPersonScore, FactVoteHistory,
+        )
+        from swh.voters.materialize import materialize_all
+
+        # Run again — same end-state.
+        counts = materialize_all(spark)
+        assert counts["persons"] == 14
+        assert DimPerson.objects.count() == 14
+        assert FactPersonScore.objects.count() == 20
+        assert FactVoteHistory.objects.count() == 10
+
+    def test_vendor_extras_landed_on_ts_extras(self, spark):
+        from socialwarehouse.warehouse.models import DimPerson
+
+        ada = DimPerson.objects.get(vendor="ts", vendor_voter_id="TS001")
+        # vb.tsmart_made_up_field_a is unmapped in TS_TO_CANONICAL → stashed in extras.
+        assert "vb.tsmart_made_up_field_a" in ada.ts_extras
+        # Other vendor extras remain empty.
+        assert ada.l2_extras == {}
+        assert ada.pdi_extras == {}
+        assert ada.catalist_extras == {}
+
+    def test_aggregates_materialized_for_super_voter(self, spark):
+        from socialwarehouse.warehouse.models import DimPerson
+
+        sv = DimPerson.objects.get(vendor="ts", vendor_voter_id="SV001")
+        assert sv.general_election_count == 4
+        assert sv.vote_frequency_category == "super_voter"
+        assert sv.last_voted_at == date(2024, 11, 5)


### PR DESCRIPTION
Closes #261. Sub-issue B.4 of #250 — last warehouse-tier TS piece.

Materializes silver Delta (silver.persons + silver.person_scores + silver.vote_history) into the PostGIS star schema (DimPerson + FactPersonScore + FactVoteHistory) that the Django web app reads.

## What lands

- `swh/voters/materialize.py` — vendor-agnostic; reads silver, dispatches `vendor_extras` to the matching `*_extras` JSONField, upserts via Django ORM `bulk_create(update_conflicts=True)` on the natural keys from #251's migration.
- CLI subcommand group: `swh materialize-electoral {persons|scores|vote-history|all}`.
- 22 tests: 13 pure-Python (vendor dispatch + chunking) + 5 Django-DB FK-lookup + 4 PySpark + Django-DB end-to-end on existing TS fixtures.
- `docs/electoral/materialization.md` operator runbook.

## Six approved design decisions implemented

1. ✅ Django ORM `bulk_create(update_conflicts=True)` for upserts (not Spark JDBC).
2. ✅ Address resolution deferred to B.5 (will file after this merges).
3. ✅ Explicit vendor-extras dispatch on the `vendor` column.
4. ✅ Code at `swh/voters/materialize.py`.
5. ✅ Subcommand group `materialize-electoral {persons|scores|vote-history|all}`.
6. ✅ Warn-and-skip on missing FK lookup (standalone fact materializers resilient).

## End state for #250 sub-issue B (TS importer) after merge

- A: substrate ✅
- B: TS importer thin spine ✅
- B.2: TS score extraction ✅
- B.3: TS vote-history + aggregates ✅
- B.4: PostGIS materialization (this PR)
- B.5: address backfill (forthcoming)

Web-app sub-issues G-K become unblocked. TS data will be queryable end-to-end through the Django ORM.

Refs: #261, #257, #259, #260, #250, #251.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI commands to materialize electoral data from source tables into star-schema database tables with separate subcommands for persons, scores, and vote history management.

* **Tests**
  * Added comprehensive test suite covering electoral data materialization with unit tests for data handling and integration tests for end-to-end validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->