### PR TITLE
feat(electoral): address backfill — silver.persons + DimPerson.address (#265)

### DIFF
--- a/docs/electoral/materialization.md
+++ b/docs/electoral/materialization.md
@@ -64,11 +64,34 @@ For unknown vendor strings, the materializer logs a warning and drops the extras
 
 ## Address resolution
 
-DimPerson.address is a nullable FK to `sw_geo.address`. This materializer does NOT populate it; silver.persons.address_id is null after the TS importer (latitude/longitude are present but Address records are not linked).
+DimPerson.address is a nullable FK to `sw_geo.address`. The persons materializer does NOT populate it; silver.persons.address_id is null after the TS importer (lat/lon are present but Address records are not linked).
 
-Backfill is filed as sub-issue B.5 of #250 — a separate Spark spatial-join job from silver.persons.lat/lon → silver.addresses → DimPerson.address.
+The `backfill-addresses` subcommand handles the linkage:
 
-Until B.5 ships, the web app surfaces work on the boundary-cache GEOID columns directly on DimPerson (cd_geoid, sldu_geoid, etc.) without going through geo.Address.
+```bash
+swh materialize-electoral backfill-addresses [--tolerance 0.00001]
+```
+
+Reads silver.persons WHERE address_id IS NULL AND lat/lon are populated, looks up matching `sw_geo.Address` by lat/lon range (default tolerance ~1m at the equator), then updates BOTH silver.persons.address_id (via DeltaTable.merge) AND DimPerson.address (via Django ORM bulk_update).
+
+### Matching policy
+
+- Lat/lon range match using `latitude__gte / latitude__lte / longitude__gte / longitude__lte` (DecimalField comparison; doesn't require Address.geom to be populated).
+- If multiple Address rows match within tolerance (multi-unit buildings, Census-block centroid sharing): lowest-id wins deterministically, warning logged. "Right" answer for multi-unit is a follow-on if real-world data shows it.
+- If no Address matches within tolerance: row is skipped silently; DimPerson.address stays null. Web app handles nullable FK already.
+- Idempotent: silver-side filter on `address_id IS NULL` means already-linked rows aren't re-processed; running twice with no new Address rows in between is a no-op.
+
+### Tolerance tuning
+
+Default `--tolerance 0.00001` degrees ≈ ~1.11m at the equator. Tighten if vendor lat/lon precision is high and false-matches happen at multi-unit buildings. Loosen if vendor lat/lon precision is low and legitimate matches miss.
+
+### When to run
+
+After every Address ingest (so newly canonical addresses link to existing persons), and after every voter-file ingest (so newly canonical persons link to existing addresses). The subcommand is idempotent so over-running is safe.
+
+### Prerequisite
+
+`sw_geo.Address` must have rows with lat/lon. If the geo subsystem hasn't been seeded, the backfill is a no-op. Until then, the web app surfaces work on the boundary-cache GEOID columns directly on DimPerson (cd_geoid, sldu_geoid, etc.) without going through geo.Address.
 
 ## Troubleshooting
 

--- a/swh/cli.py
+++ b/swh/cli.py
@@ -416,5 +416,18 @@ def materialize_electoral_all():
         spark.stop()
 
 
+@materialize_electoral.command("backfill-addresses")
+@click.option("--tolerance", type=float, default=0.00001, show_default=True, help="Degrees tolerance for lat/lon match (~1m at the equator)")
+def materialize_electoral_backfill_addresses(tolerance):
+    """Backfill silver.persons.address_id + DimPerson.address from lat/lon."""
+    from swh.voters.address_backfill import backfill_addresses
+    spark = settings.spark.build_session()
+    try:
+        counts = backfill_addresses(spark, tolerance=tolerance)
+        click.echo(f"Address backfill complete: {counts}")
+    finally:
+        spark.stop()
+
+
 if __name__ == "__main__":
     cli()

--- a/swh/voters/address_backfill.py
+++ b/swh/voters/address_backfill.py
@@ -1,0 +1,205 @@
+"""
+Address backfill: link silver.persons + DimPerson to canonical addresses.
+
+Sub-issue B.5 of #250. Companion to B.4 (#261 / PR #264), which
+materialized DimPerson with `address` left null.
+
+Looks up `sw_geo.Address` rows whose lat/lon match the vendor-supplied
+lat/lon on silver.persons (within a configurable tolerance), then
+updates both:
+
+- silver.persons.address_id (Delta) via DeltaTable.merge so the
+  silver canonical view records the linkage.
+- DimPerson.address_id (PostGIS) so the Django web app picks up
+  geo.Address records directly.
+
+Matching strategy: lat/lon range match with a small tolerance
+(default 0.00001 degrees ~= ~1m at the equator). Avoids depending on
+sw_geo.Address.geom being populated; works on rows where only the
+DecimalField lat/lon are set. If geom is populated, this still works
+because the underlying lat/lon must match for geom to be consistent.
+
+If multiple Address rows match within tolerance (e.g. multi-unit
+buildings sharing a Census-block centroid), the lowest-id match wins
+deterministically and a warning is logged. The "right" answer for
+multi-unit addresses is a follow-on if real-world data shows it.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from pyspark.sql import SparkSession
+
+logger = logging.getLogger(__name__)
+
+
+# Default tolerance ~= 1m at the equator. Caller can pass a different
+# value if real-world TS lat/lon precision warrants it. Anything tighter
+# than ~1e-6 degrees risks rejecting legitimate matches due to upstream
+# float rounding; anything looser starts conflating neighboring parcels.
+DEFAULT_TOLERANCE_DEGREES = 0.00001
+
+
+def _find_address_id(
+    lat: float,
+    lon: float,
+    tolerance: float = DEFAULT_TOLERANCE_DEGREES,
+) -> int | None:
+    """Return the lowest-id sw_geo.Address whose lat/lon is within tolerance.
+
+    Returns None if no match. Multi-match yields a warning + the
+    lowest-id winner.
+    """
+    from socialwarehouse.geo.models import Address
+
+    lat_min = Decimal(str(lat - tolerance))
+    lat_max = Decimal(str(lat + tolerance))
+    lon_min = Decimal(str(lon - tolerance))
+    lon_max = Decimal(str(lon + tolerance))
+
+    candidates = list(
+        Address.objects
+        .filter(
+            latitude__gte=lat_min, latitude__lte=lat_max,
+            longitude__gte=lon_min, longitude__lte=lon_max,
+        )
+        .values_list("id", flat=True)
+        .order_by("id")[:5]
+    )
+    if not candidates:
+        return None
+    if len(candidates) > 1:
+        logger.warning(
+            "Address backfill: %d candidates within tolerance %f at "
+            "(%f, %f); picking lowest-id %d. Tighten tolerance or "
+            "model multi-unit addresses if this is wrong.",
+            len(candidates), tolerance, lat, lon, candidates[0],
+        )
+    return candidates[0]
+
+
+def _resolve_addresses(
+    rows: list[dict],
+    tolerance: float,
+) -> dict[str, int]:
+    """For each input row, look up the matching Address.
+
+    Returns {person_key: address_id} for the rows that matched.
+    """
+    out: dict[str, int] = {}
+    for r in rows:
+        lat = r.get("latitude")
+        lon = r.get("longitude")
+        if lat is None or lon is None:
+            continue
+        addr_id = _find_address_id(float(lat), float(lon), tolerance)
+        if addr_id is not None:
+            out[r["person_key"]] = addr_id
+    return out
+
+
+def backfill_addresses(
+    spark: "SparkSession",
+    silver_table_key: str = "silver.persons",
+    tolerance: float = DEFAULT_TOLERANCE_DEGREES,
+    batch_size: int = 10_000,
+) -> dict[str, int]:
+    """Backfill silver.persons.address_id and DimPerson.address.
+
+    Args:
+        spark: Active SparkSession with Delta extensions.
+        silver_table_key: Registry key for silver.persons.
+        tolerance: Degrees tolerance for lat/lon match (default ~= 1m).
+        batch_size: Rows per batch for the silver-iteration + DB lookup.
+
+    Returns:
+        dict with `silver_updated` (rows where address_id was set on
+        silver.persons) and `postgis_updated` (DimPerson rows where
+        address_id was set).
+    """
+    from delta.tables import DeltaTable
+    from pyspark.sql.types import (
+        LongType,
+        StringType,
+        StructField,
+        StructType,
+    )
+
+    from socialwarehouse.delta.tables import TABLES
+    from socialwarehouse.warehouse.models import DimPerson
+
+    silver_path = TABLES[silver_table_key]["path"]
+    df = (
+        spark.read.format("delta").load(silver_path)
+        .filter("address_id IS NULL AND latitude IS NOT NULL AND longitude IS NOT NULL")
+        .select("vendor", "vendor_voter_id", "person_key", "latitude", "longitude")
+    )
+
+    total_silver = 0
+    total_postgis = 0
+    update_schema = StructType([
+        StructField("person_key", StringType(), False),
+        StructField("new_address_id", LongType(), False),
+    ])
+    silver_table = DeltaTable.forPath(spark, silver_path)
+
+    for batch in _chunk(df.toLocalIterator(), batch_size):
+        rows = [r.asDict() if hasattr(r, "asDict") else dict(r) for r in batch]
+        resolved = _resolve_addresses(rows, tolerance)
+        if not resolved:
+            continue
+
+        # ── Update silver.persons.address_id via merge ──
+        updates = [
+            {"person_key": pk, "new_address_id": int(aid)}
+            for pk, aid in resolved.items()
+        ]
+        updates_df = spark.createDataFrame(updates, schema=update_schema)
+        (
+            silver_table.alias("t")
+            .merge(updates_df.alias("u"), "t.person_key = u.person_key")
+            .whenMatchedUpdate(set={"address_id": "u.new_address_id"})
+            .execute()
+        )
+        total_silver += len(updates)
+
+        # ── Update DimPerson.address via Django ORM ──
+        # Build (vendor, vendor_voter_id) -> address_id map and bulk-update.
+        # bulk_update requires loaded instances; for a backfill of this
+        # shape that's fine (one query per batch).
+        natural_keys = [
+            (r["vendor"], r["vendor_voter_id"])
+            for r in rows
+            if r["person_key"] in resolved
+        ]
+        if not natural_keys:
+            continue
+        from django.db.models import Q
+        q = Q()
+        for v, vid in natural_keys:
+            q |= Q(vendor=v, vendor_voter_id=vid)
+        persons = list(DimPerson.objects.filter(q))
+        for p in persons:
+            p.address_id = resolved.get(f"{p.vendor}:{p.vendor_voter_id}")
+        DimPerson.objects.bulk_update(persons, ["address_id"], batch_size=batch_size)
+        total_postgis += len(persons)
+
+    counts = {"silver_updated": total_silver, "postgis_updated": total_postgis}
+    logger.info("backfill_addresses complete: %s", counts)
+    return counts
+
+
+def _chunk(it, size: int):
+    """Mirror of materialize._chunked; local copy to avoid circular import."""
+    buf: list = []
+    for item in it:
+        buf.append(item)
+        if len(buf) >= size:
+            yield buf
+            buf = []
+    if buf:
+        yield buf

--- a/tests/unit/swh/voters/test_address_backfill.py
+++ b/tests/unit/swh/voters/test_address_backfill.py
@@ -1,0 +1,161 @@
+"""
+Tests for SW#265 (B.5 of #250): address backfill.
+
+Django-DB tests cover the per-row Address lookup helper. PySpark +
+django-db tests cover the end-to-end `backfill_addresses` against a
+fixture where lat/lon match a known Address row.
+"""
+
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+
+class TestChunkHelper:
+    def test_yields_chunks(self):
+        from swh.voters.address_backfill import _chunk
+        assert list(_chunk([1, 2, 3, 4, 5], 2)) == [[1, 2], [3, 4], [5]]
+
+    def test_empty_input(self):
+        from swh.voters.address_backfill import _chunk
+        assert list(_chunk([], 5)) == []
+
+
+@pytest.mark.django_db
+class TestFindAddressId:
+    def _make_address(self, lat, lon, state="TX"):
+        from socialwarehouse.geo.models import Address
+        return Address.objects.create(
+            state_abbreviation=state,
+            latitude=Decimal(str(lat)),
+            longitude=Decimal(str(lon)),
+        )
+
+    def test_exact_match(self):
+        from swh.voters.address_backfill import _find_address_id
+        a = self._make_address(30.2672, -97.7431)
+        assert _find_address_id(30.2672, -97.7431) == a.id
+
+    def test_within_tolerance(self):
+        from swh.voters.address_backfill import _find_address_id
+        # Address at known lat/lon
+        a = self._make_address(30.2672, -97.7431)
+        # Query at a slightly different position within default tolerance (0.00001)
+        match = _find_address_id(30.26720001, -97.74310001)
+        assert match == a.id
+
+    def test_outside_tolerance(self):
+        from swh.voters.address_backfill import _find_address_id
+        self._make_address(30.2672, -97.7431)
+        # Far enough away that default tolerance won't catch it
+        assert _find_address_id(30.30, -97.80) is None
+
+    def test_no_addresses_returns_none(self):
+        from swh.voters.address_backfill import _find_address_id
+        assert _find_address_id(30.0, -97.0) is None
+
+    def test_multiple_matches_picks_lowest_id(self):
+        from swh.voters.address_backfill import _find_address_id
+        a1 = self._make_address(30.2672, -97.7431)
+        a2 = self._make_address(30.2672, -97.7431)
+        match = _find_address_id(30.2672, -97.7431)
+        assert match == a1.id
+        assert match < a2.id
+
+
+@pytest.mark.django_db
+class TestResolveAddresses:
+    def test_resolves_only_rows_with_lat_lon(self):
+        from socialwarehouse.geo.models import Address
+        from swh.voters.address_backfill import _resolve_addresses
+
+        a = Address.objects.create(
+            state_abbreviation="TX",
+            latitude=Decimal("30.2672"),
+            longitude=Decimal("-97.7431"),
+        )
+        rows = [
+            {"person_key": "ts:HAS-COORDS", "latitude": 30.2672, "longitude": -97.7431},
+            {"person_key": "ts:NO-COORDS", "latitude": None, "longitude": None},
+            {"person_key": "ts:NO-MATCH", "latitude": 50.0, "longitude": 10.0},
+        ]
+        resolved = _resolve_addresses(rows, tolerance=0.00001)
+        assert resolved == {"ts:HAS-COORDS": a.id}
+
+
+# PySpark + Django-DB end-to-end
+pyspark = pytest.importorskip("pyspark", reason="pyspark not installed; backfill end-to-end test skipped")
+
+
+@pytest.fixture(scope="module")
+def spark(tmp_path_factory):
+    import os
+    warehouse_root = tmp_path_factory.mktemp("warehouse-backfill")
+    os.environ["SW_WAREHOUSE_ROOT"] = f"file://{warehouse_root}"
+
+    from pyspark.sql import SparkSession
+    session = (
+        SparkSession.builder
+        .master("local[2]")
+        .appName("sw265-address-backfill-test")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
+        .config("spark.sql.shuffle.partitions", "2")
+        .config("spark.driver.bindAddress", "127.0.0.1")
+        .config("spark.driver.host", "127.0.0.1")
+        .getOrCreate()
+    )
+    yield session
+    session.stop()
+
+
+@pytest.mark.django_db(transaction=True)
+class TestBackfillEndToEnd:
+    def test_backfill_links_dimperson_to_address(self, spark):
+        from decimal import Decimal
+
+        from socialwarehouse.geo.models import Address
+        from socialwarehouse.warehouse.models import DimPerson
+        from swh.voters.address_backfill import backfill_addresses
+        from swh.voters.materialize import materialize_persons
+        from swh.voters.ts.bronze import ingest_bronze
+        from swh.voters.ts.silver import build_silver_persons
+
+        fixtures = Path(__file__).resolve().parents[3] / "fixtures"
+
+        # Create a canonical Address at Ada's known TS lat/lon (TS001
+        # row in ts_sample.csv: 30.2672, -97.7431).
+        addr = Address.objects.create(
+            state_abbreviation="TX",
+            latitude=Decimal("30.2672"),
+            longitude=Decimal("-97.7431"),
+        )
+
+        # Ingest the spine + materialize DimPerson with address=null
+        ingest_bronze(spark, csv_path=fixtures / "ts_sample.csv", state="TX")
+        build_silver_persons(spark)
+        materialize_persons(spark)
+
+        ada = DimPerson.objects.get(vendor="ts", vendor_voter_id="TS001")
+        assert ada.address_id is None  # not yet backfilled
+
+        counts = backfill_addresses(spark)
+        assert counts["postgis_updated"] >= 1
+        assert counts["silver_updated"] >= 1
+
+        ada.refresh_from_db()
+        assert ada.address_id == addr.id
+
+    def test_backfill_idempotent_already_linked(self, spark):
+        from socialwarehouse.warehouse.models import DimPerson
+        from swh.voters.address_backfill import backfill_addresses
+
+        # Ada is already linked. Re-running silver-WHERE-address_id-NULL
+        # filter excludes her row, so the second pass is a no-op for her.
+        counts = backfill_addresses(spark)
+        ada = DimPerson.objects.get(vendor="ts", vendor_voter_id="TS001")
+        assert ada.address_id is not None  # still linked
+        # counts reflects only the persons still null after first pass —
+        # the 9 fixture rows without a matching Address row stay null.
+        assert counts["postgis_updated"] == 0


### PR DESCRIPTION
Closes #265. Sub-issue B.5 of #250 — closes the deferred Q2 from #261.

After this merges, **every TS sub-issue under #250 is complete** (A substrate, B spine, B.2 scores, B.3 vote-history, B.4 PostGIS materialization, B.5 address backfill). Web-app sub-issues G-K are fully unblocked.

## What lands

- `swh/voters/address_backfill.py` — reads silver.persons WHERE address_id IS NULL AND lat/lon present; looks up matching `sw_geo.Address` by lat/lon range; updates silver via DeltaTable.merge + DimPerson via Django ORM bulk_update.
- CLI: `swh materialize-electoral backfill-addresses [--tolerance N]`. Default tolerance 1e-5 degrees (~1m at the equator).
- 10 tests: pure-Python chunk + 6 Django-DB lookup/resolve + 2 PySpark + Django-DB end-to-end.
- `docs/electoral/materialization.md` extended with the backfill section.

## Matching policy

- Lat/lon range match via DecimalField `__gte` / `__lte`. Doesn't depend on `Address.geom` being populated.
- Multi-match: lowest-id wins deterministically + warning logged. Multi-unit buildings can produce conflations; revisit if real data shows it's systematic.
- Idempotent: silver-side filter `address_id IS NULL` excludes already-linked rows on re-run.

## Coverage end-state for #250 sub-issue B

| | Status |
|---|---|
| A — substrate | ✅ (PR #254) |
| B — TS spine | ✅ (PR #258) |
| B.2 — TS scores | ✅ (PR #262) |
| B.3 — TS vote-history + aggregates | ✅ (PR #263) |
| B.4 — PostGIS materialization | ✅ (PR #264) |
| B.5 — address backfill | this PR |

Refs: #265, #261, #250.
