### PR TITLE
release: v2.2.0 — TS importer end-to-end + fork-and-rename audit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "socialwarehouse"
-version = "2.1.1-dev"
+version = "2.2.0"
 description = "Data warehouse and delta lake for geographic, demographic, and civic data — the DSTK replacement"
 readme = "README.md"
 license = {text = "Proprietary"}

--- a/socialwarehouse/__init__.py
+++ b/socialwarehouse/__init__.py
@@ -11,4 +11,4 @@ Architecture:
                        DSTK REST API, Delta Lake + Spark orchestration
 """
 
-__version__ = "2.1.1-dev"
+__version__ = "2.2.0"


### PR DESCRIPTION
Second release under queue-empty-then-release. Closes the TS warehouse-tier thread under #250 sub-issue B + sub-issue F.

## What landed since v2.1.0

- #258 — TS importer thin spine
- #262 — TS score extraction
- #263 — TS vote-history extraction + Person aggregates
- #264 — Spark→PostGIS materialization
- #266 — address backfill
- #268 — fork-and-rename quickstart audit

## End-state for the TS thread

TS voter file → bronze.voter_file_ts → silver.persons + silver.person_scores + silver.vote_history → DimPerson + FactPersonScore + FactVoteHistory. Django ORM / web app queries the full surface.

## Deferred

- C / D / E (L2 / Catalist / PDI importers) — no test data available.
- G / H / I / J / K (web-app surfaces) — operator has other priorities.

## Compatibility

Purely additive since v2.1.0. No breaking changes.