### PR TITLE
chore: bump to 2.2.1-dev post-v2.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "socialwarehouse"
-version = "2.1.1-dev"
+version = "2.2.1-dev"
 description = "Data warehouse and delta lake for geographic, demographic, and civic data — the DSTK replacement"
 readme = "README.md"
 license = {text = "Proprietary"}

--- a/socialwarehouse/__init__.py
+++ b/socialwarehouse/__init__.py
@@ -11,4 +11,4 @@ Architecture:
                        DSTK REST API, Delta Lake + Spark orchestration
 """
 
-__version__ = "2.1.1-dev"
+__version__ = "2.2.1-dev"


### PR DESCRIPTION
Post-v2.2.0 dev-version bump on develop. Mirrors the post-v2.1.0 pattern from earlier today.