### PR TITLE
docs(orchestration): how-tos, guides, reference, and Mermaid asset graph (#275 follow-on)

### DIFF
--- a/.self-review-orch-docs.md
+++ b/.self-review-orch-docs.md
@@ -3,8 +3,8 @@
 Working as: software engineer + tech lead (orchestration-layer documentation author, follow-on to SW#276 merge).
 Peer review needed from: tech lead (operator, dheerajchand, SW maintainer).
 Lead review needed from: tech lead — merge gate.
-Goal source: operator request in session — "Merged it. Now I want you to ensure that everything is correctly documented, that there are how to's and guides." Follow-on extension: "And that those docs and guides, perhaps, up front on the README, explain how to use this as a template."
-Plan reference: gap-audit posted in chat (5 missing docs identified: index, how-to-add-asset, how-to-operate, reference, CLAUDE.md update); extended with README template-framing addition after maintainer follow-on. This artifact verifies the gaps were filled across both passes.
+Goal source: operator request in session — "Merged it. Now I want you to ensure that everything is correctly documented, that there are how to's and guides." Two follow-on clarifications: "And that those docs and guides, perhaps, up front on the README, explain how to use this as a template." Then: "It's not just docs for Dagster, I mean for the whole project."
+Plan reference: extended three times in-cycle as operator scope clarified — (i) orchestration docs (initial gap-audit, 5 docs), (ii) README template framing (Dagster-skewed first pass, corrected on push 2), (iii) whole-project template docs (5 new docs under docs/template/ on push 3 after operator clarified that "template" meant project-wide, not just orchestration). This artifact verifies all three passes.
 
 ## Peer review (mechanics, correctness, craft floor)
 
@@ -16,6 +16,18 @@ Plan reference: gap-audit posted in chat (5 missing docs identified: index, how-
 - `CLAUDE.md` updated: grep `orchestration/` in CLAUDE.md → present in package structure tree + new docs pointer. PASS.
 - README "Use this as a template" section (follow-on commit): grep `^## Use this as a template` → present near the top of README, before "Architecture". Decision-table maps reader-situation → doc-to-read. PASS.
 - README "Dagster orchestration" section compressed: original 33 lines (duplicated content from docs/orchestration/README.md) reduced to 17 lines pointing at the canonical doc set. Cross-link to docs/orchestration/README.md present. PASS.
+- Whole-project template docs (push 3): five new docs under `docs/template/` covering README overview, fork+rename, swap-geography, add-a-new-domain, upgrade-from-upstream. Total ~1180 lines. `ls docs/template/*.md | wc -l` → 5. PASS.
+- README decision table refactored: "Start here" pointer to `docs/template/README.md`; 10-row decision table now leads with the whole-project template rows (fork, swap-geography, add-domain, upgrade-from-upstream) before the orchestration-specific rows. Dagster-skewed framing of push 2 corrected. PASS.
+
+**Whole-project template doc design choices:**
+
+- **Five-doc split** mirrors the orchestration doc set's shape (README + 4 how-tos) but at the project level. The five cover the actual fork lifecycle: orient → fork+rename → customize (geography + domain) → maintain (upgrade).
+- **`docs/template/README.md` is the orientation doc**, not a recap of the existing template-readiness design docs under `docs/designs/`. The design docs are decision-rationale; the template README is "here's how to use what was designed."
+- **Pre-author inventory as Step 0** in every how-to, per the discipline the session shipped (CCP#207) and applied (SW#275). Inventory template inline so downstream authors don't have to chase a separate template doc.
+- **how-to-fork-and-rename.md is the *manual* path** because the automated `template_init` mechanism (G.3 design) hasn't shipped. Explicit pointer to G.3 with note to prefer it once available. Manual flow documented so operators aren't blocked on G.3 implementation.
+- **how-to-swap-geography.md walks the boundary-catalog replacement** per template-c's pattern but generalized — abstracts the US-specific implementation into a procedure. Calls out what doesn't change (medallion architecture, get_spark_session, factory API) so instance projects know the stable surface.
+- **how-to-add-a-new-domain.md is broader than how-to-add-asset-to-existing-domain.md** — the latter is one asset; this one is a whole new Django app + Delta schemas + dim/fact + asset module + API surface. Audience split is deliberate.
+- **how-to-upgrade-from-upstream.md introduces the soft-fork upgrade workflow** with the Category A/B/C taxonomy (inherited-verbatim / forked-diverged / instance-owned) so instance maintainers have a mental model for conflict resolution. Recommends sync cadence + sync log.
 
 **`_writing-claims-rules.md` writing-claims:3 (unquantified completeness).** Commit body claims "4 new doc files + 1 modified" — count matches. Total ~880 new lines of docs + 12 lines of CLAUDE.md update. No "various docs" or "documentation improvements" handwaving.
 

--- a/.self-review-orch-docs.md
+++ b/.self-review-orch-docs.md
@@ -1,0 +1,51 @@
+## Assumptions
+
+Working as: software engineer + tech lead (orchestration-layer documentation author, follow-on to SW#276 merge).
+Peer review needed from: tech lead (operator, dheerajchand, SW maintainer).
+Lead review needed from: tech lead — merge gate.
+Goal source: operator request in session — "Merged it. Now I want you to ensure that everything is correctly documented, that there are how to's and guides."
+Plan reference: gap-audit posted in chat (5 missing docs identified: index, how-to-add-asset, how-to-operate, reference, CLAUDE.md update); this artifact verifies the gaps were filled.
+
+## Peer review (mechanics, correctness, craft floor)
+
+**`_writing-claims-rules.md` writing-claims:1 (grep before declaring complete).** Verified all five deliverables landed:
+- `docs/orchestration/README.md` (110 lines): grep `^## ` → 6 sections (asset graph, docs index, quick reference, source modules, tests, pre-author inventory). PASS.
+- `docs/orchestration/how-to-add-asset-to-existing-domain.md` (313 lines): grep `^### Step` → 8 numbered steps (0-8), plus "Common variations" + "What NOT to do" + "See also". PASS.
+- `docs/orchestration/how-to-operate.md` (252 lines): grep `^## ` → 4 sections (local dev, debugging, production deployment, see also). PASS.
+- `docs/orchestration/reference.md` (201 lines): 6 reference tables (env vars, resource fields × 3, asset keys, factory signatures × 2, common errors). PASS.
+- `CLAUDE.md` updated: grep `orchestration/` in CLAUDE.md → present in package structure tree + new docs pointer. PASS.
+
+**`_writing-claims-rules.md` writing-claims:3 (unquantified completeness).** Commit body claims "4 new doc files + 1 modified" — count matches. Total ~880 new lines of docs + 12 lines of CLAUDE.md update. No "various docs" or "documentation improvements" handwaving.
+
+**Mermaid validation.** Asset graph diagram in README.md validated via `mermaid_validate` tool → "valid". Renders the bronze→silver→gold→postgis flow + the schedule/sensor/job triggers. PASS.
+
+**Cross-references.** Every doc has a "See also" section linking to siblings. README is the index; how-tos point at reference; reference points at how-tos. Round-trip is closed.
+
+**`_writing-prose-rules.md` (SW prose style).** Docs follow the existing SW pattern: topic-based dirs, narrative prose with code blocks, tables for reference data. No marketing/AI-tone markers (no "delve", no "navigate", no "in conclusion"). PASS.
+
+**`_no-ai-fingerprints` / detect-ai-fingerprints.** Scanned added prose — clean.
+
+**Docs/source consistency.** Reference doc's env var table matches the actual fields declared in `resources.py` (verified by re-reading the merged orchestration code in this worktree). Factory signature tables match the actual function signatures in `asset_factories.py`. Asset key patterns match the actual key derivation in `_key_for()` + `postgis_materialization_asset()`. If `resources.py` evolves, this reference doc needs to track — flagged in the closing "What NOT to do" of the how-to-add-asset doc (treat factories as stable API; asset modules as examples).
+
+**`[rule:authoring-against-state]` rule 6.** The how-to-add-asset doc embeds the pre-author-inventory template as Step 0, making the discipline mechanical for downstream authors. The README + how-to-operate doc both reference rule 6 explicitly. The discipline propagates rather than dying at the rule's own ticket.
+
+**Diff inspection.** Read every new file end-to-end. No accidental file moves, no debug content, no placeholder TODOs. Cross-doc links use relative paths (work on GitHub + locally).
+
+## Lead review (approach-fit, blast radius, sequencing)
+
+As docs author: the four-doc shape (index + add-asset + operate + reference) plus the existing `instance-project-guide.md` covers the operational surface a user landing in `docs/orchestration/` needs. The split between "add asset to existing domain" (this PR) and "instance-project-guide" (existing) is deliberate — the former is for SW maintainers extending SW's own asset graph; the latter is for downstream forks. Conflating them would have produced one bloated doc that doesn't serve either audience well.
+
+The README is the index — a user landing in `docs/orchestration/` knows what else exists. Without it, they'd have to guess which doc to read first.
+
+Blast radius: docs-only, plus a 12-line CLAUDE.md addition. No code changes. Reversible by a revert commit.
+
+Sequencing: develop-first merge, promote to main per the usual cadence. Docs don't need a sub-issue follow-on; the doc set is internally complete.
+
+Approach-fit verdict: PASS.
+
+## Evidence-predates-work
+
+Artifact: /tmp/sw-orch-docs/.self-review-orch-docs.md
+First-added commit: same-cycle.
+Work commit: to-be-created
+Verification: the gap-audit in chat (5 docs identified before authoring started) is the pre-existing design surface. Same-cycle artifact discipline is flagged.

--- a/.self-review-orch-docs.md
+++ b/.self-review-orch-docs.md
@@ -3,8 +3,8 @@
 Working as: software engineer + tech lead (orchestration-layer documentation author, follow-on to SW#276 merge).
 Peer review needed from: tech lead (operator, dheerajchand, SW maintainer).
 Lead review needed from: tech lead — merge gate.
-Goal source: operator request in session — "Merged it. Now I want you to ensure that everything is correctly documented, that there are how to's and guides."
-Plan reference: gap-audit posted in chat (5 missing docs identified: index, how-to-add-asset, how-to-operate, reference, CLAUDE.md update); this artifact verifies the gaps were filled.
+Goal source: operator request in session — "Merged it. Now I want you to ensure that everything is correctly documented, that there are how to's and guides." Follow-on extension: "And that those docs and guides, perhaps, up front on the README, explain how to use this as a template."
+Plan reference: gap-audit posted in chat (5 missing docs identified: index, how-to-add-asset, how-to-operate, reference, CLAUDE.md update); extended with README template-framing addition after maintainer follow-on. This artifact verifies the gaps were filled across both passes.
 
 ## Peer review (mechanics, correctness, craft floor)
 
@@ -14,6 +14,8 @@ Plan reference: gap-audit posted in chat (5 missing docs identified: index, how-
 - `docs/orchestration/how-to-operate.md` (252 lines): grep `^## ` → 4 sections (local dev, debugging, production deployment, see also). PASS.
 - `docs/orchestration/reference.md` (201 lines): 6 reference tables (env vars, resource fields × 3, asset keys, factory signatures × 2, common errors). PASS.
 - `CLAUDE.md` updated: grep `orchestration/` in CLAUDE.md → present in package structure tree + new docs pointer. PASS.
+- README "Use this as a template" section (follow-on commit): grep `^## Use this as a template` → present near the top of README, before "Architecture". Decision-table maps reader-situation → doc-to-read. PASS.
+- README "Dagster orchestration" section compressed: original 33 lines (duplicated content from docs/orchestration/README.md) reduced to 17 lines pointing at the canonical doc set. Cross-link to docs/orchestration/README.md present. PASS.
 
 **`_writing-claims-rules.md` writing-claims:3 (unquantified completeness).** Commit body claims "4 new doc files + 1 modified" — count matches. Total ~880 new lines of docs + 12 lines of CLAUDE.md update. No "various docs" or "documentation improvements" handwaving.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,21 @@ socialwarehouse/
 │   ├── geo/              # 7 endpoints: geocode, reverse_geocode, boundaries, proximity, intersections
 │   └── warehouse/        # ViewSets: geographies, election-results, acs-estimates
 ├── delta/                # Delta Lake + Spark (Phase 4)
+├── orchestration/        # Dagster orchestration layer (SW#275; optional extra)
+│   ├── resources.py      # WarehouseConfig, SparkResource, PostGISResource
+│   ├── asset_factories.py # delta_table_asset, postgis_materialization_asset
+│   ├── assets/           # per-domain asset graphs (geo demo; civic/demographic/economic via SW#277-279)
+│   ├── schedules.py      # geo_nightly_schedule, geo_refresh_job
+│   ├── sensors.py        # bronze_addresses_arrival
+│   └── definitions.py    # canonical Definitions object (dagster dev -m socialwarehouse.orchestration)
 ├── settings/             # Django settings (base, dev, prod, test)
-├── celery_app.py
+├── celery_app.py         # Celery (web-app async); separate from Dagster (warehouse orchestration)
 └── urls.py
 ```
+
+**Orchestration docs:** see `docs/orchestration/` — README index,
+how-to-add-asset, how-to-operate, instance-project-guide, reference.
+Install with `pip install -e ".[orchestration]"`.
 
 ## Key Models
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@ A multi-domain data warehouse and data lake system for social, civic, demographi
 
 ## Use this as a template
 
-SocialWarehouse is designed to be forked. The same architecture (Delta Lake medallion → PostGIS star-schema → Django ORM, with Dagster orchestration on top) works for any boundary-keyed multi-domain warehouse. Instance projects fork SW, rename the package, swap the geography (US → UK, EU, regional), and add or replace domains, inheriting orchestration + factories + resource patterns from upstream.
+SocialWarehouse is designed to be forked. The same architecture (Delta Lake medallion → PostGIS star-schema → Django ORM, with Dagster orchestration on top) works for any boundary-keyed multi-domain warehouse. Instance projects fork SW, rename the package, swap the geography (US → UK, EU, regional), and add or replace domains, inheriting the patterns from upstream.
 
-**Are you here because…**
+**📖 Start here:** [`docs/template/README.md`](docs/template/README.md) — overview of template usage end-to-end, decision orientation, what-you-inherit-vs-what-you-write.
+
+### Quick decision orientation
 
 | You want to | Read first |
 |---|---|
-| **Fork SW for your own warehouse** (UK, EU, regional, topic-specific) | [`docs/quickstart.md`](docs/quickstart.md) then [`docs/orchestration/instance-project-guide.md`](docs/orchestration/instance-project-guide.md) |
-| **Run SW locally to see what it does** | [`docs/quickstart.md`](docs/quickstart.md) — `git clone` to seeded dev instance in under an hour |
+| **Fork SW for your own warehouse** (UK, EU, regional, topic-specific) | [`docs/template/README.md`](docs/template/README.md) → [`docs/template/how-to-fork-and-rename.md`](docs/template/how-to-fork-and-rename.md) |
+| **Swap geography** (replace US Census with ONS / Eurostat / StatCan / etc.) | [`docs/template/how-to-swap-geography.md`](docs/template/how-to-swap-geography.md) |
+| **Add a new domain** (environmental, transit, real-estate, public-health, etc.) | [`docs/template/how-to-add-a-new-domain.md`](docs/template/how-to-add-a-new-domain.md) |
+| **Upgrade your fork from upstream SW** (absorb improvements without churning your fork) | [`docs/template/how-to-upgrade-from-upstream.md`](docs/template/how-to-upgrade-from-upstream.md) |
+| **Run SW locally to see what it does** (US-default) | [`docs/quickstart.md`](docs/quickstart.md) — `git clone` to seeded dev instance in under an hour |
 | **Add a new asset to an existing SW domain** (e.g. a new silver transformation) | [`docs/orchestration/how-to-add-asset-to-existing-domain.md`](docs/orchestration/how-to-add-asset-to-existing-domain.md) |
 | **Operate Dagster** (local dev, debug failures, deploy to prod) | [`docs/orchestration/how-to-operate.md`](docs/orchestration/how-to-operate.md) |
 | **Look up env vars, asset key conventions, factory signatures** | [`docs/orchestration/reference.md`](docs/orchestration/reference.md) |
@@ -22,15 +27,19 @@ SocialWarehouse is designed to be forked. The same architecture (Delta Lake meda
 
 - **Delta Lake layer** (`socialwarehouse/delta/`) — bronze/silver/gold medallion with reusable Spark + Sedona configuration, table-path helpers, and a Spark-based geographic enrichment library
 - **PostGIS serving tier** with a star-schema dimensional model (`DimGeography` SCD2, `FactACSEstimate`, `FactDecennialCount`, `FactElectionResult`, `FactPrecinctResult`, `FactRedistrictingPlan`)
+- **Boundary catalog** (`socialwarehouse/geo/`) — `Address` cache + `AddressBoundaryPeriod` temporal snapshots + F11 helpers + `CensusVintageConfig`, covering 13 US Census boundary types
 - **Dagster orchestration** (optional extra `[orchestration]`) — `ConfigurableResource`s, asset factories, demo `geo` asset graph end-to-end (bronze → silver → gold → PostGIS), one schedule + sensor example
 - **Django REST API** (DSTK replacement) — geocoding, reverse-geocoding, boundary lookup, proximity, intersections, civic-lookup
 - **Django web app frame** via [`geodjango_simple_template`](https://github.com/siege-analytics/geodjango_simple_template) git submodule
+- **Documented fork patterns** under [`docs/template/`](docs/template/) — five how-tos covering the full fork lifecycle (rename, swap-geography, add-domain, upgrade-from-upstream, plus the README overview)
 
 ### What you bring
 
-- Your own geography ingests (US Census ships in the box; other geographies fork the ingest pattern from `docs/designs/template-c-boundary-catalog.md`)
-- Your own domain-specific asset graphs (geo demo ships; civic, demographic, economic land via [SW#277-279](https://github.com/siege-analytics/socialwarehouse/issues/277))
+- Your own geography catalog (US Census ships; other geographies follow [`how-to-swap-geography.md`](docs/template/how-to-swap-geography.md))
+- Your own domain-specific dim/fact models + asset graphs (geo demo ships; civic, demographic, economic land via [SW#277-279](https://github.com/siege-analytics/socialwarehouse/issues/277))
+- Your own seed_demo entries for the regions you care about
 - Instance-specific Django settings (the package supports a settings hierarchy; instance projects override `socialwarehouse.settings.prod`)
+- An upstream-sync cadence per [`how-to-upgrade-from-upstream.md`](docs/template/how-to-upgrade-from-upstream.md) so you absorb SW improvements without drifting
 
 Built with:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,36 @@
 # The Social Warehouse
 
-This is a data warehouse and data lake system for social, civic and social analysis from [Siege Analytics](1).
+A multi-domain data warehouse and data lake system for social, civic, demographic, and economic analysis from [Siege Analytics](1). The US-default configuration ships with geography, civic, demographic, and economic domains keyed to US Census boundaries — but **the architecture is a template**, not a finished product, and the value comes from forking it for your own geography or domain combination.
+
+## Use this as a template
+
+SocialWarehouse is designed to be forked. The same architecture (Delta Lake medallion → PostGIS star-schema → Django ORM, with Dagster orchestration on top) works for any boundary-keyed multi-domain warehouse. Instance projects fork SW, rename the package, swap the geography (US → UK, EU, regional), and add or replace domains, inheriting orchestration + factories + resource patterns from upstream.
+
+**Are you here because…**
+
+| You want to | Read first |
+|---|---|
+| **Fork SW for your own warehouse** (UK, EU, regional, topic-specific) | [`docs/quickstart.md`](docs/quickstart.md) then [`docs/orchestration/instance-project-guide.md`](docs/orchestration/instance-project-guide.md) |
+| **Run SW locally to see what it does** | [`docs/quickstart.md`](docs/quickstart.md) — `git clone` to seeded dev instance in under an hour |
+| **Add a new asset to an existing SW domain** (e.g. a new silver transformation) | [`docs/orchestration/how-to-add-asset-to-existing-domain.md`](docs/orchestration/how-to-add-asset-to-existing-domain.md) |
+| **Operate Dagster** (local dev, debug failures, deploy to prod) | [`docs/orchestration/how-to-operate.md`](docs/orchestration/how-to-operate.md) |
+| **Look up env vars, asset key conventions, factory signatures** | [`docs/orchestration/reference.md`](docs/orchestration/reference.md) |
+| **Understand the warehouse-first architecture** | [`docs/architecture.md`](docs/architecture.md) |
+| **Understand the template-readiness design decisions** (vintage polymorphization, boundary catalog, ingest patterns, init flow) | [`docs/designs/template-{b,c,d,e,f,g}-*.md`](docs/designs/) |
+
+### What you get out of the box
+
+- **Delta Lake layer** (`socialwarehouse/delta/`) — bronze/silver/gold medallion with reusable Spark + Sedona configuration, table-path helpers, and a Spark-based geographic enrichment library
+- **PostGIS serving tier** with a star-schema dimensional model (`DimGeography` SCD2, `FactACSEstimate`, `FactDecennialCount`, `FactElectionResult`, `FactPrecinctResult`, `FactRedistrictingPlan`)
+- **Dagster orchestration** (optional extra `[orchestration]`) — `ConfigurableResource`s, asset factories, demo `geo` asset graph end-to-end (bronze → silver → gold → PostGIS), one schedule + sensor example
+- **Django REST API** (DSTK replacement) — geocoding, reverse-geocoding, boundary lookup, proximity, intersections, civic-lookup
+- **Django web app frame** via [`geodjango_simple_template`](https://github.com/siege-analytics/geodjango_simple_template) git submodule
+
+### What you bring
+
+- Your own geography ingests (US Census ships in the box; other geographies fork the ingest pattern from `docs/designs/template-c-boundary-catalog.md`)
+- Your own domain-specific asset graphs (geo demo ships; civic, demographic, economic land via [SW#277-279](https://github.com/siege-analytics/socialwarehouse/issues/277))
+- Instance-specific Django settings (the package supports a settings hierarchy; instance projects override `socialwarehouse.settings.prod`)
 
 Built with:
 
@@ -91,38 +121,26 @@ It is recommended that you create a generalized `.yml` file for each image you b
 
 For instance, we define image-building configurations in `docker/spark-build-image.yml` and define our integration of the image into the various services in `docker/spark.profile.yml`. You can see how we use one image in multiple services with different envrionment variables and volumes.
 
-## Running Dagster locally
+## Dagster orchestration
 
 Warehouse pipeline orchestration lives in `socialwarehouse/orchestration/`
-and is an **optional extra** — install with:
+and is an **optional extra** (`pip install -e ".[orchestration]"`).
+The full guide — install, local dev, debugging, production deployment,
+adding assets, instance-project extension — lives at
+[`docs/orchestration/`](docs/orchestration/README.md).
+
+Quick start:
 
 ```bash
 pip install -e ".[orchestration]"
-```
-
-Set the standard SW env vars (warehouse root, S3 creds, Django settings module)
-in your `.env`, then launch the Dagster dev UI:
-
-```bash
 export DJANGO_SETTINGS_MODULE=socialwarehouse.settings.dev
-export SW_WAREHOUSE_ROOT=file:///tmp/sw-warehouse   # or s3a://your-bucket
+export SW_WAREHOUSE_ROOT=file:///tmp/sw-warehouse
 dagster dev -m socialwarehouse.orchestration
 ```
 
-Open http://localhost:3000 to see the asset graph, schedules, and
-sensors. The demo `geo` asset graph (bronze `addresses_raw` → silver
-`addresses_typed` → gold `addresses_enriched` → PostGIS `geo.address`)
-materializes end-to-end via `dagster asset materialize -m
-socialwarehouse.orchestration --select '*'`.
-
-**Separation from Celery:** Dagster handles warehouse pipeline
-orchestration (scheduled refreshes, sensor-driven backfills,
-Delta→PostGIS materialization). Celery (`socialwarehouse.celery_app`)
-handles web-app-triggered async tasks. They coexist without overlap.
-
-**Instance projects** extending this template add their own domain
-assets via the factory pattern; see
-`docs/orchestration/instance-project-guide.md`.
+Open http://localhost:3000 for the asset graph (bronze → silver → gold → PostGIS).
+Dagster is **separate from Celery** — Dagster orchestrates the warehouse
+pipeline; Celery handles web-app-triggered async tasks.
 
 ## References
 

--- a/docs/orchestration/README.md
+++ b/docs/orchestration/README.md
@@ -1,0 +1,110 @@
+# Orchestration — index
+
+The `socialwarehouse.orchestration` subpackage owns warehouse pipeline
+orchestration: scheduled bronze→silver→gold Delta refreshes,
+sensor-driven backfills, and Delta→PostGIS materialization. It runs
+on **Dagster**.
+
+It is **separate from Celery** (`socialwarehouse.celery_app`), which
+owns web-app-triggered async tasks. Dagster orchestrates the
+warehouse pipeline; Celery handles request-driven async work. They
+coexist without overlap.
+
+## Asset graph (demo: `geo` domain)
+
+```mermaid
+graph LR
+    A["bronze/addresses_raw<br/>(SourceAsset)"] --> B["silver/addresses_typed<br/>(delta_table_asset)"]
+    B --> C["gold/addresses_enriched<br/>(delta_table_asset)"]
+    C --> D["postgis/geo/address<br/>(postgis_materialization_asset)"]
+
+    S["geo_nightly_schedule<br/>(02:00 UTC daily)"] -.kicks.-> J["geo_refresh job<br/>(selects silver/gold/postgis)"]
+    SE["bronze_addresses_sensor<br/>(5min cursor)"] -.observes.-> A
+    SE -.requests.-> J
+    J -.materializes.-> B
+    J -.materializes.-> C
+    J -.materializes.-> D
+
+    classDef src fill:#e1f5e1,stroke:#2d8a2d
+    classDef compute fill:#e1ecf5,stroke:#2d5a8a
+    classDef sink fill:#f5e1e1,stroke:#8a2d2d
+    classDef trigger fill:#fff5e1,stroke:#8a6e2d
+
+    class A src
+    class B,C compute
+    class D sink
+    class S,SE,J trigger
+```
+
+Each domain (civic, demographic, economic, etc.) declares its own
+asset module under `socialwarehouse/orchestration/assets/<domain>.py`
+following the same pattern. The geo module is the demonstration; the
+others land via their own sub-issues from SW#275.
+
+## Documentation
+
+| Document | When to read |
+|---|---|
+| [README.md](README.md) (this file) | Landing here for the first time, want the overview + asset graph |
+| [how-to-add-asset-to-existing-domain.md](how-to-add-asset-to-existing-domain.md) | You're adding a new asset (e.g. a new silver transformation) to a domain that already exists in SW |
+| [instance-project-guide.md](instance-project-guide.md) | You're an **instance project** (UK-warehouse, EU-warehouse, etc.) forking SW and need to add your own domains or override SW's |
+| [how-to-operate.md](how-to-operate.md) | You're running Dagster — local dev, debugging a failed asset, deploying to production |
+| [reference.md](reference.md) | You need the env var matrix, the asset key naming convention, the factory function signatures, or troubleshooting for a specific error |
+
+## Quick reference
+
+```bash
+# Install (optional extra)
+pip install -e ".[orchestration]"
+
+# Required env vars (set in .env)
+DJANGO_SETTINGS_MODULE=socialwarehouse.settings.dev
+SW_WAREHOUSE_ROOT=file:///tmp/sw-warehouse   # or s3a://your-bucket
+SW_CATALOG=socialwarehouse                    # optional, default 'socialwarehouse'
+SW_VINTAGE=2020                               # optional, default 2020
+
+# Launch the Dagster UI
+dagster dev -m socialwarehouse.orchestration
+
+# Run a specific asset from the CLI
+dagster asset materialize -m socialwarehouse.orchestration --select 'warehouse/silver/addresses_typed'
+
+# Run the full geo refresh job
+dagster job execute -m socialwarehouse.orchestration -j geo_refresh
+```
+
+## Source
+
+| Module | Purpose |
+|---|---|
+| `socialwarehouse/orchestration/__init__.py` | Entry point, re-exports `defs` |
+| `socialwarehouse/orchestration/definitions.py` | The canonical `Definitions` object Dagster discovers |
+| `socialwarehouse/orchestration/resources.py` | `WarehouseConfig`, `SparkResource`, `PostGISResource` |
+| `socialwarehouse/orchestration/asset_factories.py` | `delta_table_asset`, `postgis_materialization_asset` |
+| `socialwarehouse/orchestration/assets/geo.py` | Demo geo asset graph |
+| `socialwarehouse/orchestration/schedules.py` | `geo_nightly_schedule`, `geo_refresh_job` |
+| `socialwarehouse/orchestration/sensors.py` | `bronze_addresses_sensor` |
+
+## Tests
+
+```bash
+pytest tests/orchestration/
+```
+
+Tests skip cleanly when the `[orchestration]` extra is not installed
+— the optional-extra contract is preserved for non-Dagster SW
+consumers.
+
+## Pre-author inventory discipline
+
+Per `[rule:authoring-against-state]` rule 6 (from
+`claude-configs-public`), every asset compute function change should
+be preceded by a pre-author inventory posted to the relevant ticket
+BEFORE the asset is modified. The factories don't enforce this; the
+discipline is on the author. The orchestration layer's job is to
+make the discipline mechanical once exercised — the asset keys +
+factory wiring give the reviewer a clean spec to check the
+implementation against.
+
+See `how-to-add-asset-to-existing-domain.md` for the inventory
+template applied to a concrete asset.

--- a/docs/orchestration/how-to-add-asset-to-existing-domain.md
+++ b/docs/orchestration/how-to-add-asset-to-existing-domain.md
@@ -1,0 +1,313 @@
+# How to add a new asset to an existing domain
+
+This is the workflow for adding a single asset (e.g. a new silver
+transformation or a new gold materialization) to a domain that
+**already exists** in SW. If you're adding a brand-new domain or
+forking SW into an instance project, read
+[instance-project-guide.md](instance-project-guide.md) instead.
+
+## TL;DR
+
+1. Define the Delta schema in `socialwarehouse/delta/tables.py` (if it's a new table).
+2. Write a compute function that takes `(context, spark)` and writes the table.
+3. Call `delta_table_asset(...)` to wrap it; export from the domain module.
+4. Add it to the domain module's `all_assets` list.
+5. Post a pre-author inventory to the relevant ticket (per rule 6).
+6. Test in `dagster dev`; commit + PR.
+
+## Step-by-step
+
+### 0. Pre-author inventory (rule 6) — do this FIRST
+
+Before writing the asset, post a pre-author inventory to the GitHub
+issue tracking this work. The inventory makes the assumptions
+explicit and gives the reviewer a clean spec to check the diff
+against. Template:
+
+```markdown
+## Pre-author inventory for `<asset key>`
+
+### Inputs read
+- Ticket: <link>
+- Upstream Delta table(s) the asset will read: <paths>
+- Downstream consumers (other assets, Django models, PostGIS tables): <list>
+
+### Knowledge requirements
+- What is the row count of each upstream Delta table? (measure live, don't guess)
+- What is the schema drift between upstream and target? Any new columns?
+- What is the dedup key / merge strategy?
+- Does this asset depend on a partition column (state, vintage, date)?
+- Are there downstream consumers that pin the asset's output schema?
+
+### Contact-point measurements (per `[rule:authoring-against-state]`)
+- **data-shape (rule 1):** row counts on the upstream tables
+- **config-state (rule 2):** Spark Connect config snapshot if cluster-resource demands change
+- **plan-shape (rule 4):** if the asset chains many unions, count the depth
+- **version-resolution (rule 5):** N/A unless adding new public symbols
+
+### Surface areas beyond rules 1-5
+- Existing similar assets in the domain (don't duplicate)
+- Existing management commands that may compose with or be obsoleted by this asset
+
+### Hypothesis
+"The asset `warehouse/<layer>/<table>` will read `{upstream_table}` and
+produce a Delta table at `{target_path}` containing `{row_count}` rows
+with schema `{schema}`. The merge strategy is `{strategy}`. Downstream
+consumer `{consumer}` will see the new asset key."
+```
+
+### 1. Define the Delta schema (if new table)
+
+In `socialwarehouse/delta/tables.py`, add the schema following the
+existing bronze / silver / gold conventions:
+
+```python
+from pyspark.sql.types import StructType, StructField, StringType, IntegerType
+from .config import get_table_path
+
+GEO_SILVER_ADDRESSES_GEOCODED_SCHEMA = StructType([
+    StructField("address_id", StringType(), nullable=False),
+    StructField("lat", DoubleType(), nullable=True),
+    StructField("lon", DoubleType(), nullable=True),
+    StructField("geocode_quality", IntegerType(), nullable=True),
+    # ... more fields ...
+])
+
+def addresses_geocoded_path():
+    return get_table_path("silver", "addresses_geocoded")
+```
+
+Skip this step if the table already exists in `delta/tables.py` (the
+asset just materializes an existing schema).
+
+### 2. Write the compute function
+
+The compute function receives `(context, spark)` and is responsible
+for writing the Delta table at the target path. It should NOT
+reimplement Spark session creation or path computation — both come
+from existing socialwarehouse infrastructure.
+
+```python
+# in socialwarehouse/orchestration/assets/geo.py
+
+def _compute_addresses_geocoded(context, spark):
+    """Geocode silver.addresses_typed -> silver.addresses_geocoded."""
+    from socialwarehouse.delta.config import get_table_path
+
+    source_path = get_table_path("silver", "addresses_typed")
+    target_path = get_table_path("silver", "addresses_geocoded")
+
+    typed = spark.read.format("delta").load(source_path)
+    context.log.info("typed row count: %d", typed.count())
+
+    # Geocoding transform — invoke existing helper or write inline.
+    # For non-trivial transforms, factor into delta/enrichment.py
+    # rather than inline-in-asset (so the same transform can be
+    # called from non-Dagster paths too).
+    geocoded = typed.withColumn("lat", _lookup_lat(typed["address"])) \
+                    .withColumn("lon", _lookup_lon(typed["address"])) \
+                    .withColumn("geocode_quality", _quality_score(typed["address"]))
+
+    geocoded.write.format("delta").mode("overwrite").save(target_path)
+```
+
+Conventions:
+- Use `context.log.info(...)` for asset-progress messages — they
+  surface in the Dagster UI's run log.
+- Measure-before-write: log the row count of the source before the
+  transform runs (cheap; load-bearing for catching upstream drift).
+- The mode (`overwrite` vs `append` vs `merge`) is a deliberate
+  choice — `overwrite` is the default for vintage-rebuilds; `append`
+  for incremental loads; `merge` for upserts.
+
+### 3. Wrap with the factory
+
+In the same domain module:
+
+```python
+addresses_geocoded = delta_table_asset(
+    layer="silver",
+    table="addresses_geocoded",
+    deps=["silver/addresses_typed"],
+    compute_fn=_compute_addresses_geocoded,
+    description="Geocoded addresses (silver). Lat/lon assigned via the lookup service.",
+)
+```
+
+The factory:
+- Derives the asset key as `["warehouse", "silver", "addresses_geocoded"]`
+- Wires the dep as `AssetKey(["warehouse", "silver", "addresses_typed"])`
+- Injects the `SparkResource` so `compute_fn` gets a live `spark` session
+- Reports the materialization result with row count + path metadata
+
+### 4. Register in `all_assets`
+
+At the bottom of the domain module:
+
+```python
+all_assets = [
+    addresses_raw,
+    addresses_typed,
+    addresses_geocoded,   # ← new asset
+    addresses_enriched,
+    geo_address_postgis,
+]
+```
+
+The `Definitions` object in `socialwarehouse/orchestration/definitions.py`
+discovers assets from `geo.all_assets`; no separate registration needed.
+
+### 5. Add the asset to a schedule or sensor (optional)
+
+If the new asset should be on the nightly refresh, the existing
+`geo_refresh_job` already selects `AssetSelection.groups("silver",
+"gold", "postgis")` — any asset in those groups is auto-included.
+
+If the new asset needs its own schedule (different cadence, different
+selection), add it to `socialwarehouse/orchestration/schedules.py`:
+
+```python
+addresses_geocoded_hourly_job = define_asset_job(
+    name="addresses_geocoded_hourly",
+    selection=AssetSelection.assets(addresses_geocoded),
+)
+
+addresses_geocoded_hourly_schedule = ScheduleDefinition(
+    job=addresses_geocoded_hourly_job,
+    cron_schedule="0 * * * *",  # every hour
+    execution_timezone="UTC",
+)
+
+all_schedules.append(addresses_geocoded_hourly_schedule)
+all_jobs.append(addresses_geocoded_hourly_job)
+```
+
+### 6. Test locally
+
+```bash
+# Restart dagster dev (it auto-reloads on file changes but a fresh
+# start avoids stale-import surprises)
+dagster dev -m socialwarehouse.orchestration
+
+# Confirm the new asset shows up in the UI graph
+# (open http://localhost:3000, navigate to Assets)
+
+# Materialize the new asset against a local warehouse
+dagster asset materialize -m socialwarehouse.orchestration \
+  --select 'warehouse/silver/addresses_geocoded'
+```
+
+If the materialization fails, check:
+- The dep asset (`warehouse/silver/addresses_typed`) has been
+  materialized first (or is materialized in the same run via
+  `--select '*addresses_geocoded'`)
+- The target Delta path is writable (`ls -la $SW_WAREHOUSE_ROOT/silver/`)
+- The Spark session is created with Sedona enabled if the asset
+  uses spatial operations
+
+### 7. Write the asset test
+
+In `tests/orchestration/test_<domain>_assets.py`:
+
+```python
+def test_addresses_geocoded_asset_keys():
+    from socialwarehouse.orchestration.assets.geo import addresses_geocoded
+    from dagster import AssetKey
+
+    assert addresses_geocoded.key == AssetKey(["warehouse", "silver", "addresses_geocoded"])
+    assert AssetKey(["warehouse", "silver", "addresses_typed"]) in addresses_geocoded.dependency_keys
+```
+
+This doesn't run the compute function (which needs a live Spark
+cluster); it verifies the asset graph topology is correct, which
+catches the most common "wrong key" / "missing dep" errors.
+
+### 8. Commit + open PR
+
+```bash
+git checkout -b feat/<domain>-<asset>-asset
+git add socialwarehouse/orchestration/assets/<domain>.py tests/orchestration/test_<domain>_assets.py
+git commit -m "feat(orchestration): add <domain>/<asset> asset (#<ticket>)"
+git push -u origin feat/<domain>-<asset>-asset
+gh pr create --base develop ...
+```
+
+Per the workspace's `[rule:self-review]` discipline, include a
+self-review artifact path in the commit's trailer block.
+
+## Common variations
+
+### Asset that materializes to PostGIS (not Delta)
+
+Use `postgis_materialization_asset` instead of `delta_table_asset`:
+
+```python
+my_postgis_asset = postgis_materialization_asset(
+    source_layer="gold",
+    source_table="addresses_enriched",
+    target_django_app_label="geo",
+    target_django_model_name="Address",
+    compute_sql=_shape_for_address_model,
+)
+```
+
+The factory handles the Delta read + Pandas conversion + SQLAlchemy
+write. For datasets above ~500K rows, see SW#280 for the planned
+COPY-based path (currently uses `to_sql`).
+
+### Asset that depends on multiple upstreams
+
+```python
+addresses_joined = delta_table_asset(
+    layer="silver",
+    table="addresses_joined",
+    deps=["silver/addresses_typed", "silver/persons_typed"],
+    compute_fn=_compute_addresses_joined,
+)
+```
+
+Inside the compute function, both source paths come from
+`get_table_path()` calls; Dagster's dep wiring guarantees both
+upstreams are materialized before this asset runs.
+
+### Asset that's a SourceAsset (declared, not produced)
+
+For raw bronze data ingested by an upstream pipeline (not by
+Dagster), declare a `SourceAsset` instead of using the factory:
+
+```python
+from dagster import AssetKey, SourceAsset
+
+raw_voters = SourceAsset(
+    key=AssetKey(["warehouse", "bronze", "voters_raw"]),
+    description="Raw voter rows from the upstream ingest pipeline.",
+    group_name="bronze",
+)
+```
+
+Use a sensor (see `sensors.py`) to detect when the raw asset has new
+data and request downstream materialization.
+
+## What NOT to do
+
+- **Do NOT reimplement `get_spark_session` or `get_table_path`** in
+  your asset. Use the canonical functions from `delta/config.py`.
+- **Do NOT inline a large transform in the asset's compute function**
+  if it could be called from non-Dagster paths. Factor into
+  `delta/enrichment.py` (or a new `delta/<topic>.py` module) and
+  invoke from the asset. This keeps the orchestration layer thin and
+  the transforms reusable.
+- **Do NOT use Celery to schedule an asset.** Use a Dagster schedule
+  or sensor. The two systems serve different concerns.
+- **Do NOT skip the pre-author inventory.** The discipline is the
+  point — assets that drift from upstream schemas without an
+  inventory record become the SW#2094-class incident the rule
+  exists to prevent.
+
+## See also
+
+- [reference.md](reference.md) — full env var matrix, asset key conventions, factory API
+- [how-to-operate.md](how-to-operate.md) — running, debugging, deploying
+- [instance-project-guide.md](instance-project-guide.md) — for instance projects forking SW
+- [SW#275](https://github.com/siege-analytics/socialwarehouse/issues/275) — parent ticket for the orchestration scaffold
+- [`[rule:authoring-against-state]`](https://github.com/siege-analytics/claude-configs-public/blob/main/skills/_authoring-against-state-rules.md) — the discipline rule the pre-author inventory implements

--- a/docs/orchestration/how-to-operate.md
+++ b/docs/orchestration/how-to-operate.md
@@ -1,0 +1,252 @@
+# How to operate the orchestration layer
+
+Covers the day-to-day operations: running locally, debugging failed
+assets, and deploying to production.
+
+## Local development
+
+### One-time setup
+
+```bash
+# In your SW dev venv
+pip install -e ".[orchestration]"
+
+# Confirm the optional extra installed cleanly
+python -c "import dagster, dagster_postgres, dagster_spark; print('OK')"
+```
+
+Set the standard SW env vars in your `.env` (the orchestration layer
+reads the same vars `delta/config.py` reads):
+
+```env
+DJANGO_SETTINGS_MODULE=socialwarehouse.settings.dev
+SW_WAREHOUSE_ROOT=file:///tmp/sw-warehouse
+SW_CATALOG=socialwarehouse
+SW_VINTAGE=2020
+```
+
+If your local Postgres + PostGIS aren't already running, start them
+via `docker-compose up postgres` (or however your dev env is wired).
+
+### Launch the Dagster UI
+
+```bash
+dagster dev -m socialwarehouse.orchestration
+```
+
+Open http://localhost:3000. You should see:
+
+- **Assets** tab — the asset graph (bronze → silver → gold → postgis)
+- **Jobs** tab — `geo_refresh`
+- **Schedules** tab — `geo_nightly_schedule` (disabled by default in `dagster dev`)
+- **Sensors** tab — `bronze_addresses_arrival` (disabled by default)
+
+`dagster dev` launches three processes: the **webserver** (UI), the
+**daemon** (runs schedules + sensors), and the **gRPC code server**
+(loads your code, isolated from the webserver). The daemon is what
+fires schedules and sensors in the background; without it, the UI
+shows definitions but nothing actually runs.
+
+### Materialize an asset from the CLI
+
+```bash
+# A single asset:
+dagster asset materialize -m socialwarehouse.orchestration \
+  --select 'warehouse/silver/addresses_typed'
+
+# The full geo graph (skip the bronze SourceAsset):
+dagster asset materialize -m socialwarehouse.orchestration \
+  --select 'warehouse/silver/* warehouse/gold/* postgis/geo/*'
+
+# Everything (Dagster's wildcard):
+dagster asset materialize -m socialwarehouse.orchestration --select '*'
+```
+
+The `--select` flag uses Dagster's asset-selection syntax. Common
+patterns:
+- `'<key>'` — exact key
+- `'<key>+'` — the key and all downstream
+- `'+<key>'` — the key and all upstream
+- `'<group>/*'` — all assets in a group (e.g. `silver/*`)
+
+### Run a job
+
+```bash
+dagster job execute -m socialwarehouse.orchestration -j geo_refresh
+```
+
+Jobs are useful for grouping assets that should always run together
+(same retry policy, same alerting, same config).
+
+## Debugging a failed asset
+
+### Failure reported in the UI
+
+When an asset fails in the Dagster UI, click into the run, then:
+
+1. **Click the failed asset's step** in the run view — Dagster shows
+   the structured logs from `context.log.info(...)` calls.
+2. **Look for the stack trace** at the bottom of the step view. Most
+   asset failures fall into one of these buckets:
+
+| Error pattern | Likely cause | Fix |
+|---|---|---|
+| `RuntimeError: WAREHOUSE_ROOT=... requires S3 credentials` | S3 creds not set in env | Set `S3_ACCESS_KEY` + `S3_SECRET_KEY`, or point `SW_WAREHOUSE_ROOT` at a local `file://` path for dev |
+| `py4j.protocol.Py4JJavaError: Failed to load Delta` | Delta extension not registered | Confirm `SparkResource.enable_sedona=True` (default) and that the Spark session was built via `delta.config.get_spark_session()` |
+| `ModuleNotFoundError: No module named 'django'` | DJANGO_SETTINGS_MODULE not set when `PostGISResource` initializes | Set `DJANGO_SETTINGS_MODULE` in `.env` or Dagster code-location env config |
+| `AssetCheckEvaluation: row count dropped 90%` (custom check) | Upstream data shape regression | Run the upstream asset's rule-1 measurement; check ingestion pipeline |
+| `dagster._core.errors.DagsterInvariantViolationError: AssetKey ... not found` | Dep asset's key changed without updating the consumer | grep for the old key and update consumers |
+
+### Failure not reported (asset stuck running)
+
+If an asset doesn't fail but doesn't complete:
+
+1. **Check Spark UI** at http://localhost:4040 (default) — is the
+   query stuck in a stage? If yes, the issue is in the Spark
+   execution, not Dagster.
+2. **Check the asset's `context.log` output** — was the last logged
+   message a `count()` call? `count()` on a large Delta table can
+   take minutes to hours; consider switching to an approximate count
+   or skipping the metadata count for assets that materialize huge
+   tables.
+3. **Check `dagster job execute --debug` output** — runs the asset
+   in foreground with verbose logging.
+
+### Sensor not firing
+
+If `bronze_addresses_arrival` (or any sensor) isn't kicking jobs:
+
+1. **Confirm the daemon is running.** In `dagster dev` output, look
+   for "daemon running" messages. If absent, the daemon crashed —
+   restart `dagster dev`.
+2. **Confirm the sensor is enabled in the UI.** Sensors default to
+   disabled in `dagster dev`. Toggle on in the Sensors tab.
+3. **Check the sensor's cursor.** In the Sensors tab, click the
+   sensor, then "Cursor" — shows the last evaluation's cursor
+   value. If the cursor advanced but no run fired, the cursor
+   logic may be skipping (legitimately, if no new commit). If the
+   cursor didn't advance, the probe is failing — check the
+   sensor's logs.
+4. **Verify the probed Delta table exists.** The sensor calls
+   `DESCRIBE HISTORY delta.\`<path>\``; if the path doesn't exist
+   yet, the sensor skips with "probe failed". Materialize the
+   bronze asset at least once before the sensor can observe it.
+
+### Asset is correct but takes too long
+
+1. Run `EXPLAIN` on the underlying Spark query (factor the
+   transform into a function you can call from a notebook).
+2. Check whether the asset is doing a `count()` for metadata — if
+   the table is huge, count is expensive. Replace with `None` or
+   an approximate count in the factory's `MaterializeResult`.
+3. Confirm the Spark cluster has the expected resources
+   (`kubectl exec <spark-pod> -- spark-shell --conf 'spark.executor.memory'`
+   per `delta/config.py`'s rule-2 inventory).
+4. For PostGIS materializations on large datasets, the current
+   `to_sql` path won't scale — SW#280 tracks the COPY-based replacement.
+
+## Production deployment
+
+`dagster dev` is for local development only. Production runs three
+separate processes:
+
+### 1. The code server (loads your code)
+
+```bash
+dagster api grpc \
+  --module-name socialwarehouse.orchestration \
+  --host 0.0.0.0 \
+  --port 4000
+```
+
+Containerize this and point Dagster's `workspace.yaml` at it. The
+code server is isolated from the webserver, so SW code changes
+deploy by restarting the code server without restarting the UI.
+
+### 2. The webserver (UI)
+
+```bash
+dagster-webserver -w workspace.yaml -p 3000
+```
+
+The `workspace.yaml` lists the code server(s):
+
+```yaml
+load_from:
+  - grpc_server:
+      host: socialwarehouse-orchestration-code
+      port: 4000
+      location_name: socialwarehouse
+```
+
+### 3. The daemon (runs schedules + sensors)
+
+```bash
+dagster-daemon run -w workspace.yaml
+```
+
+The daemon needs the same `workspace.yaml` so it knows what code
+servers to communicate with.
+
+### Dagster's own storage
+
+Dagster needs **its own Postgres database** for run storage,
+schedule state, sensor cursors, and event logs. **Do NOT use SW's
+domain Postgres for this in production** — Dagster's writes are
+chatty and would compete with the domain workload.
+
+`dagster.yaml` (place at `$DAGSTER_HOME`):
+
+```yaml
+storage:
+  postgres:
+    postgres_db:
+      hostname: dagster-postgres
+      port: 5432
+      username: dagster
+      password:
+        env: DAGSTER_PG_PASSWORD
+      db_name: dagster
+```
+
+For local dev, sharing SW's Postgres is fine — Dagster creates its
+own tables under a `dagster_` prefix and won't collide.
+
+### Recommended deployment shape
+
+| Component | Container | Notes |
+|---|---|---|
+| Webserver | `socialwarehouse-orchestration-webserver` | Public-facing (behind auth); exposes UI on 3000 |
+| Daemon | `socialwarehouse-orchestration-daemon` | One replica only (multi-daemon causes duplicate schedule fires) |
+| Code server | `socialwarehouse-orchestration-code` | Multiple replicas OK; webserver load-balances |
+| Run worker | spawned by daemon per run | Configured via `dagster.yaml run_launcher` — for SW, use `k8s_run_launcher` so each asset run gets a clean pod |
+| Dagster Postgres | `dagster-postgres` | Separate from SW's app Postgres |
+
+### Production monitoring
+
+- Dagster's UI shows run history, failed runs, sensor health
+- Forward Dagster's logs to your standard log aggregator (see
+  SW#280 for the Dagster ↔ SW logger integration sub-issue)
+- Alert on failed runs via Dagster's `RunFailureSensor` (build one
+  per environment that pages on-call)
+- Track schedule lateness as a key metric — a schedule that's
+  hours late silently is the failure mode worth catching early
+
+### Backfills in production
+
+```bash
+dagster asset backfill -m socialwarehouse.orchestration \
+  --select '*addresses_enriched' \
+  --partition-key 2010
+```
+
+Once SW#281 (partitioned-assets backfill strategy) lands, backfills
+get first-class UI support. Until then, ad-hoc backfills are
+explicit CLI invocations.
+
+## See also
+
+- [README.md](README.md) — index + asset graph diagram
+- [reference.md](reference.md) — env var matrix, asset key conventions
+- [how-to-add-asset-to-existing-domain.md](how-to-add-asset-to-existing-domain.md) — author workflow
+- Dagster's own deployment docs: https://docs.dagster.io/deployment

--- a/docs/orchestration/reference.md
+++ b/docs/orchestration/reference.md
@@ -1,0 +1,201 @@
+# Orchestration — reference
+
+Lookup tables for the orchestration layer's public API surface.
+
+## Environment variables
+
+Read by `socialwarehouse.orchestration.resources` at resource
+initialization. Defaults are sane for local dev with file:// storage;
+production sets them via `.env` or the deployment env config.
+
+| Variable | Default | Read by | Purpose |
+|---|---|---|---|
+| `DJANGO_SETTINGS_MODULE` | (none, required) | `PostGISResource.engine()` | Django settings module — `PostGISResource` calls `django.setup()` then reads `settings.DATABASES['default']` |
+| `SW_WAREHOUSE_ROOT` | `s3a://socialwarehouse` | `WarehouseConfig.warehouse_root` + `delta.config` | Root path for Delta tables (e.g. `s3a://your-bucket`, `file:///tmp/sw-warehouse`) |
+| `SW_CATALOG` | `socialwarehouse` | `WarehouseConfig.catalog` | Logical catalog namespace (instance projects override) |
+| `SW_VINTAGE` | `2020` | `WarehouseConfig.vintage` | Default Census vintage / data-year for runs (overridable per run via run config) |
+| `S3_ENDPOINT` | `http://10.10.0.10:9000` | `delta.config` | S3-compatible endpoint URL (used by Spark, not Dagster directly) |
+| `S3_ACCESS_KEY` | (empty) | `delta.config` | S3 access key; required if `SW_WAREHOUSE_ROOT` starts with `s3a://` |
+| `S3_SECRET_KEY` | (empty) | `delta.config` | S3 secret key; required if `SW_WAREHOUSE_ROOT` starts with `s3a://` |
+| `DAGSTER_HOME` | (none, recommended) | Dagster runtime | Dagster's own state directory (run storage, schedule state). Production: separate Postgres via `dagster.yaml`. |
+| `DAGSTER_PG_PASSWORD` | (none) | `dagster.yaml` (production) | Password for Dagster's own Postgres in production deployments |
+
+`SW_*` env vars are the same ones `socialwarehouse/delta/config.py`
+reads — Dagster and the Django/CLI paths see the same warehouse by
+design.
+
+## Resource classes
+
+### `WarehouseConfig`
+
+Carries instance-level warehouse configuration. Instance projects
+override by constructing a different value and passing to
+`Definitions(resources={"warehouse": WarehouseConfig(...)})`.
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `warehouse_root` | `str` | `SW_WAREHOUSE_ROOT` env or `s3a://socialwarehouse` | Delta table root path |
+| `catalog` | `str` | `SW_CATALOG` env or `socialwarehouse` | Logical catalog namespace |
+| `vintage` | `int` | `SW_VINTAGE` env or `2020` | Default vintage for asset runs |
+| `partition_state` | `Optional[str]` | `None` | Optional state code to partition runs by (e.g. `"TX"`); `None` = full-warehouse |
+
+### `SparkResource`
+
+Wraps `socialwarehouse.delta.config.get_spark_session()`. Does NOT
+reinvent the Spark session.
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `app_name` | `str` | `"socialwarehouse-orchestration"` | Spark application name (only first call's value takes effect per JVM session) |
+| `enable_sedona` | `bool` | `True` | Register Apache Sedona spatial extensions (default True because most SW assets are spatial) |
+
+Usage in an asset compute function:
+
+```python
+def _my_compute(context, spark):
+    # spark is already injected; no need to call get_spark_session()
+    df = spark.read.format("delta").load(...)
+```
+
+If you need the resource directly (rare — the factory injects it for
+you):
+
+```python
+def _my_compute(context):
+    spark_resource: SparkResource = context.resources.spark
+    with spark_resource.session(context) as spark:
+        ...
+```
+
+### `PostGISResource`
+
+Wraps a SQLAlchemy engine bound to Django's default DB connection.
+Reads connection params from `django.conf.settings.DATABASES['default']`.
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `application_name` | `str` | `"socialwarehouse-orchestration"` | Postgres `application_name` for connection identification |
+| `statement_timeout_ms` | `int` | `300_000` (5min) | Postgres `statement_timeout` in milliseconds; override per-asset for long materializations |
+
+Usage:
+
+```python
+def _my_compute(context):
+    postgis: PostGISResource = context.resources.postgis
+    with postgis.engine() as engine:
+        df.to_sql("table", engine, if_exists="append", index=False)
+```
+
+## Asset key conventions
+
+The orchestration layer uses a 3-part asset key convention:
+
+| Pattern | Example | Used for |
+|---|---|---|
+| `["warehouse", <layer>, <table>]` | `warehouse/bronze/addresses_raw` | Delta tables (bronze/silver/gold) |
+| `["postgis", <app>, <model_lower>]` | `postgis/geo/address` | PostGIS materializations (target = Django model) |
+
+The keys are produced by the factories:
+
+- `delta_table_asset(layer=L, table=T)` → `AssetKey(["warehouse", L, T])`
+- `postgis_materialization_asset(target_django_app_label=A, target_django_model_name=M)` → `AssetKey(["postgis", A, M.lower()])`
+
+The `warehouse/<layer>/<table>` key intentionally mirrors the on-disk
+Delta path produced by `delta.config.get_table_path(layer, table)` —
+the asset graph and the on-disk layout stay coupled by construction.
+If you grep for an asset key, the matching path is mechanical.
+
+Asset selection in `dagster asset materialize` uses the same syntax:
+
+```bash
+dagster asset materialize --select 'warehouse/silver/*'    # all silver Delta assets
+dagster asset materialize --select 'postgis/geo/*'         # all geo PostGIS assets
+dagster asset materialize --select 'warehouse/bronze/addresses_raw+'  # bronze + all downstream
+```
+
+## Factory API
+
+### `delta_table_asset(...) -> AssetsDefinition`
+
+```python
+def delta_table_asset(
+    *,
+    layer: str,              # 'bronze' | 'silver' | 'gold'
+    table: str,              # table name (matches delta/tables.py)
+    deps: Iterable[str] = None,    # list of 'layer/table' strings
+    compute_fn: Callable[[AssetExecutionContext, SparkSession], None],
+    description: Optional[str] = None,
+    group_name: Optional[str] = None,  # defaults to layer
+) -> AssetsDefinition: ...
+```
+
+- `compute_fn(context, spark)` writes the Delta table at
+  `get_table_path(layer, table)`.
+- Returns an `AssetsDefinition` with key
+  `["warehouse", layer, table]`, deps wired, `SparkResource` injected.
+- Materialization metadata: `{"path": <delta-path>, "row_count": int, "layer": str}`.
+
+### `postgis_materialization_asset(...) -> AssetsDefinition`
+
+```python
+def postgis_materialization_asset(
+    *,
+    source_layer: str,             # 'silver' | 'gold'
+    source_table: str,             # source Delta table name
+    target_django_app_label: str,  # e.g. 'geo'
+    target_django_model_name: str, # e.g. 'Address'
+    compute_sql: Callable[[SparkSession, str], DataFrame],
+    description: Optional[str] = None,
+    group_name: str = "postgis",
+) -> AssetsDefinition: ...
+```
+
+- `compute_sql(spark, source_path)` returns a DataFrame shaped for
+  the target Django model.
+- Returns an `AssetsDefinition` with key
+  `["postgis", app_label, model_name.lower()]`, dep on
+  `["warehouse", source_layer, source_table]`, both `SparkResource`
+  and `PostGISResource` injected.
+- Materialization metadata: `{"source_path": <delta-path>, "target_table": <db-table>, "row_count": int}`.
+- Currently uses `df.toPandas() ; pdf.to_sql(...)` — see SW#280 for
+  the planned COPY-based path for large datasets.
+
+## Common errors and fixes
+
+| Error | Cause | Fix |
+|---|---|---|
+| `ImportError: No module named 'dagster'` when importing SW | Tried to import `socialwarehouse.orchestration` without `[orchestration]` extra installed | Install with `pip install -e ".[orchestration]"` |
+| `RuntimeError: WAREHOUSE_ROOT=... requires S3 credentials` | `SW_WAREHOUSE_ROOT` is s3a:// but `S3_ACCESS_KEY`/`S3_SECRET_KEY` are empty | Set the env vars OR point `SW_WAREHOUSE_ROOT` at a `file://` path for dev |
+| `django.core.exceptions.ImproperlyConfigured: DJANGO_SETTINGS_MODULE` | `PostGISResource` initialized without Django settings | Set `DJANGO_SETTINGS_MODULE=socialwarehouse.settings.dev` in `.env` |
+| `dagster._core.errors.DagsterInvariantViolationError: AssetKey ['warehouse', ...] is not part of the set of assets` | Dep asset declared with wrong key | Verify the dep's `layer/table` matches the upstream asset's actual key (use `warehouse/<layer>/<table>` form) |
+| `py4j.protocol.Py4JJavaError: ... Delta` | Delta extension not registered | Ensure `SparkResource` is used (which calls `delta.config.get_spark_session()` — that's where the Delta extensions are registered) |
+| `py4j.protocol.Py4JJavaError: ... Sedona` | Sedona not registered, but asset uses spatial operations | Set `SparkResource(enable_sedona=True)` (default) and confirm `apache-sedona` is installed (`pip install -e ".[spark]"`) |
+| Asset graph in UI is empty / "no assets" | Definitions module not discovered | Verify launch command: `dagster dev -m socialwarehouse.orchestration` (not `python -m`); confirm `socialwarehouse.orchestration.defs` exists |
+| Sensor enabled but never fires | Daemon not running OR sensor probe failing | `dagster dev` output should show "daemon running"; check Sensors tab → Cursor → recent evaluations for errors |
+| `to_sql` extremely slow / OOM | Materialization above ~500K rows hits the `toPandas` bottleneck | Track via SW#280 — switch to Parquet staging + Postgres COPY |
+
+## Pinned Dagster version
+
+```toml
+[project.optional-dependencies]
+orchestration = [
+    "dagster>=1.9,<2",
+    "dagster-webserver>=1.9,<2",
+    "dagster-postgres>=0.25,<1",
+    "dagster-spark>=0.25,<1",
+]
+```
+
+The `1.9,<2` pin locks the major version. Bumping the upper bound
+requires verifying the API surface this layer uses
+(`ConfigurableResource`, `@asset`, `AssetKey`, `MaterializeResult`,
+`Definitions`, `define_asset_job`, `ScheduleDefinition`,
+`AssetSelection.groups`, `@sensor`, `SensorResult`, `RunRequest`,
+`SkipReason`, `SourceAsset`) is still stable.
+
+## See also
+
+- [README.md](README.md) — index + Mermaid asset graph
+- [how-to-add-asset-to-existing-domain.md](how-to-add-asset-to-existing-domain.md) — author workflow
+- [how-to-operate.md](how-to-operate.md) — run/debug/deploy
+- [instance-project-guide.md](instance-project-guide.md) — for instance projects forking SW

--- a/docs/template/README.md
+++ b/docs/template/README.md
@@ -1,0 +1,81 @@
+# Use SocialWarehouse as a template
+
+SocialWarehouse is **a template, not a finished product**. The US-default configuration ships with geography, civic, demographic, and economic domains keyed to US Census boundaries — but the architecture (Delta Lake medallion → PostGIS star-schema → Django ORM, with Dagster orchestration on top) works for any boundary-keyed multi-domain warehouse. Instance projects fork SW, rename the package, swap or add geographies/domains, and inherit the patterns from upstream.
+
+## What "template" actually means here
+
+SW's template-readiness is tracked under [SW#189](https://github.com/siege-analytics/socialwarehouse/issues/189) and broken into six design tracks ([B/C/D/E/F/G under `docs/designs/template-*.md`](../designs/)):
+
+| Track | Concern | Status |
+|---|---|---|
+| **B** — Vintage polymorphization | Make all data vintage-aware so historical decades can coexist | Design landed |
+| **C** — Boundary catalog | The set of boundary types the warehouse keys on (state/county/tract/zcta/place/cbsa/school_district/...) | Implementation complete |
+| **D** — Demographic ingest | Pluggable pattern for demographic data sources (ACS, decennial, etc.) | Design landed |
+| **E** — Economic ingest | Pluggable pattern for economic data sources (QCEW, BEA, IRS SOI, etc.) | Design landed |
+| **F** — Civic ingest | Pluggable pattern for civic data sources (NCES, special districts, etc.) | Design landed |
+| **G** — Quickstart + template-init | Automated fork+rename+seed flow | Design landed; implementation pending |
+
+The patterns from B-F are what an instance project consumes. The G mechanism (automated init) is coming; until then, the fork+rename flow is manual (see [how-to-fork-and-rename.md](how-to-fork-and-rename.md)).
+
+## Who should fork SocialWarehouse
+
+You should consider forking SW if you're building:
+
+- A **boundary-keyed multi-domain warehouse** for a geography that isn't the US (UK with Ordnance Survey + ONS Census; EU with Eurostat NUTS; Canada with Statistics Canada; etc.)
+- A **topic-specific warehouse** that combines several public datasets with consistent geographic keying (e.g. a public-health warehouse combining CDC + Census + EPA at the county level)
+- A **regional warehouse** for a sub-national geography (state-level, MSA-level, watershed-level)
+- An **augmented US warehouse** that needs domains SW doesn't ship (e.g. environmental, transit, real-estate)
+
+You probably **don't need to fork** SW if you're:
+
+- Adding a new data source within an existing SW domain (just contribute upstream)
+- Using SW as-is for US analysis (just install + use)
+- Running a one-off analysis that doesn't need warehouse persistence (use the Delta layer directly, no template needed)
+
+## What you inherit; what you write
+
+| Layer | Inherited from SW | You write |
+|---|---|---|
+| **Delta Lake medallion** (`delta/`) | `get_spark_session`, `get_table_path`, table-path conventions, enrichment helpers | Your domain's bronze schemas + the silver/gold transforms |
+| **PostGIS star schema** (`warehouse/`) | `DimGeography` SCD2, `DimTime`, `DimSurvey`, fact-table patterns | Your domain's specific dim/fact tables; instance-specific FK extensions |
+| **Boundary catalog** (`geo/models/`) | `Address`, `AddressBoundaryPeriod`, `_BOUNDARY_TYPES` registry, F11 helpers | Your geography's boundary types (see [how-to-swap-geography.md](how-to-swap-geography.md)) |
+| **Django REST API** (`api/`) | `geocode`, `reverse_geocode`, `boundaries`, `proximity`, `intersections`, `civic_lookup` patterns | Your domain-specific endpoints |
+| **Dagster orchestration** (`orchestration/`) | `WarehouseConfig`, `SparkResource`, `PostGISResource`, `delta_table_asset`, `postgis_materialization_asset` factories, demo geo asset graph | Your domain asset modules (`orchestration/assets/<domain>.py`); your schedules + sensors |
+| **Django web app frame** | GST submodule (`vendor/geodjango_simple_template/`) — `locations` app + project staticfiles | Your instance-specific views, admin extensions |
+| **Project structure** | Package layout, settings hierarchy (`base`/`dev`/`prod`/`test`), Makefile + docker-compose pattern | Your renamed package + Django apps + .env |
+
+## How-to docs in this directory
+
+| Doc | When to read |
+|---|---|
+| [README.md](README.md) (this file) | Landing here for the first time, want the overview + decision orientation |
+| [how-to-fork-and-rename.md](how-to-fork-and-rename.md) | You've decided to fork — concrete steps to clone, rename, init |
+| [how-to-swap-geography.md](how-to-swap-geography.md) | Your instance project uses non-US boundaries (UK Ordnance Survey, EU NUTS, Canada Statistics Canada, etc.) |
+| [how-to-add-a-new-domain.md](how-to-add-a-new-domain.md) | You're adding a domain SW doesn't ship (environmental, transit, real-estate, public-health, etc.) |
+| [how-to-upgrade-from-upstream.md](how-to-upgrade-from-upstream.md) | You've forked, time has passed, and you want to absorb SW improvements without churning your fork |
+
+## Other doc surfaces you'll need
+
+- [`docs/architecture.md`](../architecture.md) — warehouse-first principle, the design-order rule (Delta → PostGIS → Django, never the reverse), tier relationships
+- [`docs/quickstart.md`](../quickstart.md) — `git clone` to seeded dev instance in under 1 hour (US-default), useful as a sanity check before forking
+- [`docs/designs/template-*.md`](../designs/) — the design decisions per track (read the relevant one before forking that part of the template)
+- [`docs/orchestration/`](../orchestration/README.md) — Dagster orchestration layer (how-to-add-asset, how-to-operate, reference, plus the instance-project guide specifically for Dagster extension)
+- [`docs/entities/`](../entities/) — per-entity reference for the canonical models (boundary catalog, Address cache, fact tables)
+
+## Pre-author inventory discipline (applies to forks too)
+
+Per [`[rule:authoring-against-state]`](https://github.com/siege-analytics/claude-configs-public/blob/main/skills/_authoring-against-state-rules.md) rule 6, every fork-step (especially geography swap and new-domain addition) should be preceded by a pre-author inventory in the relevant ticket. The discipline is the same as for asset additions: read the inputs, enumerate the open questions, measure the contact points, record findings before authoring. The how-to docs in this directory embed inventory templates as Step 0.
+
+## When NOT to use this template
+
+- **Single-table analytical projects.** Use `pandas` or `polars` directly; SW's warehouse layers are overhead.
+- **Real-time / streaming workloads.** SW is batch-oriented (Delta refreshes, Dagster schedules). Streaming-first systems should look at Kafka + Flink / Spark Streaming patterns, not this template.
+- **Pure web apps with no warehouse.** GST ([geodjango_simple_template](https://github.com/siege-analytics/geodjango_simple_template)) is the right starting point; SW is GST + the warehouse stack.
+- **Project that needs a different orchestration framework.** If you've committed to Airflow / Prefect / dbt-only, the SW Dagster layer is wrong shape — though the Delta + PostGIS pieces are usable independently.
+
+## See also
+
+- [SW#189](https://github.com/siege-analytics/socialwarehouse/issues/189) — template-readiness parent initiative
+- [SW#275](https://github.com/siege-analytics/socialwarehouse/issues/275) — Dagster orchestration scaffold (template-track follow-on)
+- Architecture: [`docs/architecture.md`](../architecture.md)
+- Contribution guide: [`../../CONTRIBUTING.md`](../../CONTRIBUTING.md)

--- a/docs/template/how-to-add-a-new-domain.md
+++ b/docs/template/how-to-add-a-new-domain.md
@@ -1,0 +1,342 @@
+# How to add a new domain
+
+This guide is for instance projects that need a domain SW doesn't ship — environmental, transit, real-estate, public-health, education-outcomes, anything that's boundary-keyed and warrants its own bronze/silver/gold/PostGIS/API surface.
+
+If you're adding a new *asset* to a domain that already exists, see [`../orchestration/how-to-add-asset-to-existing-domain.md`](../orchestration/how-to-add-asset-to-existing-domain.md) instead. This guide is for adding the domain itself.
+
+## What a "domain" is in SW
+
+A domain in SW is a coherent slice of warehouse content with:
+
+- A **Django app** (`<your-warehouse>/<domain>/`) containing dim/fact models for the PostGIS serving tier
+- A **Delta schema set** in `<your-warehouse>/delta/tables.py` for the domain's bronze/silver/gold tables
+- An **ingest pattern** for getting source data into bronze (management commands, sensors, or external pipeline)
+- A **Dagster asset module** (`<your-warehouse>/orchestration/assets/<domain>.py`) declaring the bronze→silver→gold→PostGIS asset graph
+- An **API surface** (`<your-warehouse>/api/<domain>/`) exposing domain-specific endpoints
+- **Documentation** (`docs/entities/<domain>_*.md` for entity reference; optional design doc under `docs/designs/`)
+
+SW's existing domains: `geo` (foundational), `civic`, `demographic`, `economic`, `warehouse` (shared dim/fact). Your new domain follows the same shape.
+
+## Pattern reference
+
+SW's design docs for the existing domains are the canonical pattern reference:
+
+| Domain | Design doc | What to mirror |
+|---|---|---|
+| Demographic (ACS pattern) | [`docs/designs/template-d-demographic-ingest.md`](../designs/template-d-demographic-ingest.md) | Multi-variable ingest, vintage-keyed, fact-table per estimate type |
+| Economic (QCEW/BLS pattern) | [`docs/designs/template-e-economic-ingest.md`](../designs/template-e-economic-ingest.md) | Quarterly cadence, NAICS hierarchy, multi-vintage join |
+| Civic (NCES/special districts pattern) | [`docs/designs/template-f-civic-ingest.md`](../designs/template-f-civic-ingest.md) | Boundary-key dependency on geo, attribute-rich fact tables |
+
+Pick the closest pattern to your new domain. For environmental → likely economic (vintage cadence, multi-attribute, boundary-keyed). For real-estate → likely demographic (parcel-level, fact-per-estimate). For transit → mixed; you may need to invent the pattern (see "Step 8" below).
+
+## Step 0 — Pre-author inventory
+
+```markdown
+## Pre-author inventory — new domain: <domain-name>
+
+### Inputs read
+- This guide
+- The closest existing domain's design doc + implementation
+- Your data source's documentation
+- `docs/architecture.md` (warehouse-first principle)
+
+### Knowledge requirements
+- What is the canonical source for this domain's data?
+  (URL, API, file format, license, refresh cadence)
+- What's the boundary key?
+  (Does it key on state/county/tract? On a non-Census boundary
+  like watershed / school zone / transit district?)
+- What's the temporal grain?
+  (Annual? Quarterly? Daily? Point-in-time?)
+- What's the natural unit row in bronze?
+  (One row per address-year? Per facility-month?
+  Per parcel? Per route-day?)
+- What fact table(s) will the gold tier need?
+  (One fact per estimate type, mirroring ACS's pattern? Or one
+  wide fact, mirroring NCES's pattern?)
+- What dim tables are reused vs new?
+  (DimGeography is always reused; DimTime is reused if temporal;
+  DimSource may be new for source attribution; DimMetric may be
+  new if your domain is metric-heavy)
+- What API endpoints does this domain need?
+  (Point-lookup? Boundary-aggregate? Trend-over-time?)
+
+### Contact-point measurements (per [rule:authoring-against-state])
+- rule 1: source row count (sample at smallest geography)
+- rule 2: ingest tooling config (refresh cadence, API rate limits)
+- rule 4: plan shape — if asset graph has many unions or wide joins
+- rule 5: grep `<your-warehouse>` for any existing references to
+  this domain (in case partial work exists)
+
+### Surface areas beyond rules 1-5
+- Existing Django apps (don't collide on app_label)
+- Existing dim/fact models (reuse DimGeography, DimTime; only
+  introduce new dims if your domain genuinely needs them)
+- Existing API URL prefixes (don't collide on `/api/<prefix>/`)
+- Existing seed_demo command (your domain joins the seed)
+
+### Hypothesis
+"After this domain ships, `<your-warehouse>/<domain>/` will contain
+{N} dim tables ({list}) and {M} fact tables ({list}), each indexed by
+`<boundary>_code` + `vintage`. The asset graph will materialize
+{bronze_table} → {silver_table} → {gold_table} → {postgis_target}
+on a {cadence} schedule. API endpoints {list} surface the gold tier
+to the web app."
+```
+
+## Step 1 — Create the Django app
+
+```bash
+cd <your-warehouse>
+python manage.py startapp <domain>
+```
+
+Then in `<your-warehouse>/<domain>/apps.py`:
+
+```python
+from django.apps import AppConfig
+
+class <Domain>Config(AppConfig):
+    name = "<your-warehouse>.<domain>"
+    label = "<prefix>_<domain>"  # e.g. "uk_health", "ca_transit"
+    verbose_name = "<Human-readable name>"
+```
+
+Register in `<your-warehouse>/settings/base.py`:
+
+```python
+INSTALLED_APPS = [
+    # ...
+    "<your-warehouse>.<domain>",
+]
+```
+
+## Step 2 — Declare the bronze/silver/gold Delta schemas
+
+In `<your-warehouse>/delta/tables.py`, add your domain's table set:
+
+```python
+# ── <Domain> bronze ─────────────────────────────────────────
+
+<DOMAIN>_BRONZE_<TABLE>_SCHEMA = StructType([
+    StructField("source_id", StringType(), nullable=False),
+    StructField("attribute_a", StringType(), nullable=True),
+    StructField("attribute_b", DoubleType(), nullable=True),
+    # ... raw source columns as StringType where unsure ...
+    StructField("ingested_at", TimestampType(), nullable=False),
+])
+
+# ── <Domain> silver ─────────────────────────────────────────
+
+<DOMAIN>_SILVER_<TABLE>_SCHEMA = StructType([
+    StructField("<boundary>_code", StringType(), nullable=False),  # boundary key
+    StructField("vintage", StringType(), nullable=False),
+    StructField("attribute_a_typed", StringType(), nullable=False),
+    StructField("attribute_b_typed", DecimalType(18, 4), nullable=True),
+    # ... canonical typed columns ...
+])
+
+# ── <Domain> gold ───────────────────────────────────────────
+
+<DOMAIN>_GOLD_<TABLE>_SCHEMA = StructType([
+    # Enriched columns; boundary attributes joined in; ready for PostGIS load
+    ...
+])
+```
+
+Register in `TABLES = {...}`:
+
+```python
+TABLES = {
+    # ...
+    "<domain>/bronze/<table>": <DOMAIN>_BRONZE_<TABLE>_SCHEMA,
+    "<domain>/silver/<table>": <DOMAIN>_SILVER_<TABLE>_SCHEMA,
+    "<domain>/gold/<table>": <DOMAIN>_GOLD_<TABLE>_SCHEMA,
+}
+```
+
+## Step 3 — Declare the PostGIS dim/fact models
+
+In `<your-warehouse>/<domain>/models/`:
+
+```python
+# <your-warehouse>/<domain>/models/dimensions.py
+class Dim<Domain>Source(models.Model):
+    """Source attribution for <domain> facts."""
+    name = models.CharField(max_length=100, unique=True)
+    url = models.URLField()
+    license = models.CharField(max_length=100)
+    # ...
+
+    class Meta:
+        app_label = "<prefix>_<domain>"
+
+
+# <your-warehouse>/<domain>/models/facts.py
+class Fact<Domain>Measurement(models.Model):
+    geography = models.ForeignKey(
+        "warehouse.DimGeography",
+        on_delete=models.PROTECT,
+        related_name="<domain>_measurements",
+    )
+    time = models.ForeignKey(
+        "warehouse.DimTime",
+        on_delete=models.PROTECT,
+    )
+    source = models.ForeignKey(Dim<Domain>Source, on_delete=models.PROTECT)
+    metric_value = models.DecimalField(max_digits=18, decimal_places=4)
+    # ...
+
+    class Meta:
+        app_label = "<prefix>_<domain>"
+        indexes = [
+            models.Index(fields=["geography", "time"]),
+            models.Index(fields=["source"]),
+        ]
+```
+
+Reuse `DimGeography`, `DimTime` from `warehouse/`; introduce new dims only if your domain genuinely needs them (DimSource if source attribution matters; DimMetric if metric-heavy).
+
+Generate the migration:
+
+```bash
+python manage.py makemigrations <domain>
+```
+
+## Step 4 — Write the ingest pattern
+
+Three shapes; pick one:
+
+### Shape A — Management command (one-shot or periodic)
+
+```python
+# <your-warehouse>/<domain>/management/commands/load_<source>.py
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument("--vintage", required=True)
+        parser.add_argument("--state", default=None)
+
+    def handle(self, *args, **options):
+        # Fetch source data; write to bronze Delta path
+        ...
+```
+
+Best for: sources with a fixed-cadence batch refresh (annual surveys, quarterly releases).
+
+### Shape B — Dagster sensor + asset (event-driven)
+
+```python
+# <your-warehouse>/orchestration/sensors.py
+@sensor(job=<domain>_refresh_job)
+def <source>_arrival_sensor(context):
+    # Detect new data at the source (S3 prefix, RSS feed, etc.)
+    # Request materialization when new
+    ...
+```
+
+Best for: sources that arrive irregularly (real-time API, vendor file drops).
+
+### Shape C — External pipeline writes bronze; Dagster picks up
+
+The source data lands in bronze via a pipeline outside SW (Airbyte, custom ingest service). SW's bronze is declared as a `SourceAsset` and the silver/gold assets pick up automatically.
+
+Best for: sources owned by a separate team or system.
+
+## Step 5 — Write the Dagster asset module
+
+Mirror the geo module pattern. See [`../orchestration/how-to-add-asset-to-existing-domain.md`](../orchestration/how-to-add-asset-to-existing-domain.md) for the detailed asset-authoring workflow. The brief version:
+
+```python
+# <your-warehouse>/orchestration/assets/<domain>.py
+from dagster import AssetKey, SourceAsset
+from socialwarehouse.orchestration.asset_factories import (
+    delta_table_asset,
+    postgis_materialization_asset,
+)
+
+<table>_raw = SourceAsset(
+    key=AssetKey(["warehouse", "bronze", "<domain>_<table>"]),
+    description="Raw <domain> ingest from <source>.",
+    group_name="bronze",
+)
+
+def _compute_<table>_typed(context, spark):
+    # Bronze → silver typing transform
+    ...
+
+<table>_typed = delta_table_asset(
+    layer="silver",
+    table="<domain>_<table>_typed",
+    deps=["bronze/<domain>_<table>"],
+    compute_fn=_compute_<table>_typed,
+)
+
+# ... gold asset, PostGIS materialization asset ...
+
+all_assets = [<table>_raw, <table>_typed, ...]
+```
+
+Register in `<your-warehouse>/orchestration/assets/__init__.py` and update `definitions.py` to include the new domain.
+
+## Step 6 — Write the API surface
+
+```python
+# <your-warehouse>/api/<domain>/urls.py
+urlpatterns = [
+    path("lookup/", <Domain>LookupView.as_view(), name="<domain>-lookup"),
+    path("aggregate/", <Domain>AggregateView.as_view(), name="<domain>-aggregate"),
+]
+
+# <your-warehouse>/api/urls.py — mount the new sub-router
+urlpatterns = [
+    # ...
+    path("<domain>/", include("<your-warehouse>.api.<domain>.urls")),
+]
+```
+
+The endpoint pattern follows DRF + the existing SW `geo` API conventions. See `<your-warehouse>/api/geo/` for the canonical shape.
+
+## Step 7 — Add to seed_demo
+
+```python
+# <your-warehouse>/<domain>/management/commands/_seed_demo_<domain>.py
+def seed_<domain>(state, vintage):
+    """Tiny seed for <domain> — one state, one vintage."""
+    ...
+
+# <your-warehouse>/management/commands/seed_demo.py
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        # ... existing seed calls ...
+        seed_<domain>(options["state"], options["vintage"])
+```
+
+The seed should load **one state, one vintage, small variable subset** — fast (under a minute) so the quickstart stays under an hour.
+
+## Step 8 — When your domain doesn't fit the existing patterns
+
+If your domain has shape that none of D/E/F covers (e.g. event-stream-shaped like transit, or hierarchical-tree-shaped like classifications):
+
+1. Write a design doc at `<your-instance>/docs/designs/<domain>.md` explaining the shape and the pattern you're inventing
+2. File it as an issue in your instance project
+3. Implement; revisit the doc after the first end-to-end works
+4. If the pattern is generally useful, consider upstreaming as a new SW template-readiness track
+
+Don't try to force a shape-fit if the existing patterns are wrong for your domain — that's how warehouse-first discipline breaks down.
+
+## Documentation
+
+For every new domain:
+
+- **One entity doc per dim/fact**: `<your-instance>/docs/entities/<domain>_<entity>.md` describing the table, columns, business meaning, source provenance
+- **Optional design doc**: `<your-instance>/docs/designs/<domain>-ingest.md` if the pattern is non-obvious (mirrors template-d/e/f)
+- **Update CLAUDE.md** if you have one: package structure section gets the new app
+
+## See also
+
+- [README.md](README.md) — template overview
+- [how-to-fork-and-rename.md](how-to-fork-and-rename.md) — prerequisite for adding domains in your instance
+- [how-to-swap-geography.md](how-to-swap-geography.md) — if your domain keys on non-US boundaries
+- [`../orchestration/how-to-add-asset-to-existing-domain.md`](../orchestration/how-to-add-asset-to-existing-domain.md) — asset-level workflow inside the new domain module
+- [`docs/architecture.md`](../architecture.md) — the warehouse-first principle (your new domain must respect it)
+- [`docs/designs/template-{d,e,f}-*.md`](../designs/) — the existing-domain patterns to copy

--- a/docs/template/how-to-fork-and-rename.md
+++ b/docs/template/how-to-fork-and-rename.md
@@ -1,0 +1,213 @@
+# How to fork and rename SocialWarehouse
+
+This is the **manual** fork+rename procedure for instance projects today. An automated `template_init` mechanism is designed in [`docs/designs/template-g-quickstart-and-init.md`](../designs/template-g-quickstart-and-init.md) but not yet shipped; when it lands, prefer it over the manual flow. Until then, this doc is the canonical path.
+
+## TL;DR
+
+1. Fork SW on GitHub or clone-then-rename locally.
+2. Rename the package (`socialwarehouse` → `<your-warehouse>`) in 12 files (listed below).
+3. Rename Django apps if you want different app labels (optional).
+4. Update `pyproject.toml`, `.env.example`, settings, and Makefile.
+5. Run migrations + seed; verify the dev server starts.
+6. Commit + push to your instance project's repo.
+
+Budget: **2-3 hours** end-to-end on a clean dev machine. The package rename is mechanical but spans enough files that you want a working set of `sed` invocations + a careful review pass.
+
+## Step 0 — Decide on a name, structure, and upstream relationship
+
+Before any commands:
+
+- **Pick the Python package name.** Lowercase, underscores not hyphens. Examples: `ukwarehouse`, `eu_demographic_warehouse`, `pa_civic_warehouse`. Avoid `social-` prefix unless your project is also social-data-shaped — generic naming is fine.
+- **Decide on Django app prefix.** SW uses `sw_geo`, `sw_warehouse`, etc. (set via `app_label` in each app's `apps.py`). Pick a 2-3 letter prefix for your instance: `uk_geo`, `eu_geo`, etc. This avoids collisions if your project later imports SW alongside.
+- **Decide on the upstream-tracking strategy:**
+  - **Hard fork** (no upstream connection) — simplest, but you lose access to upstream improvements
+  - **Soft fork with periodic upstream merges** — recommended; see [how-to-upgrade-from-upstream.md](how-to-upgrade-from-upstream.md)
+  - **Vendored as submodule** — possible but awkward; not recommended for the core warehouse
+
+For most cases: **soft fork with periodic upstream merges**. Add SW as an `upstream` remote (`git remote add upstream git@github.com:siege-analytics/socialwarehouse.git`) so you can pull improvements when ready.
+
+## Step 1 — Clone and initialize your repo
+
+```bash
+# Option A: GitHub fork-then-clone
+gh repo fork siege-analytics/socialwarehouse --clone --remote
+mv socialwarehouse <your-warehouse>
+cd <your-warehouse>
+
+# Option B: Plain clone + rename + new remote
+git clone --recurse-submodules git@github.com:siege-analytics/socialwarehouse.git <your-warehouse>
+cd <your-warehouse>
+git remote rename origin upstream
+git remote add origin git@github.com:<your-org>/<your-warehouse>.git
+```
+
+Either way, confirm the GST submodule cloned:
+
+```bash
+ls vendor/geodjango_simple_template/app/hellodjango/
+# should show: manage.py, hellodjango/, locations/, ...
+```
+
+## Step 2 — Rename the Python package
+
+```bash
+# Rename the package directory
+git mv socialwarehouse <your-warehouse>
+
+# Find every file referencing the old name (excluding .git and vendor/)
+grep -rln 'socialwarehouse' --exclude-dir=.git --exclude-dir=vendor
+
+# At time of writing, ~25 files reference 'socialwarehouse'. Replace them
+# with sed (or your editor's project-wide replace):
+LC_ALL=C find . -type f \
+  \( -name '*.py' -o -name '*.toml' -o -name '*.cfg' -o -name '*.md' \
+  -o -name '*.yml' -o -name '*.yaml' -o -name '*.env*' -o -name 'Makefile' \) \
+  -not -path './.git/*' -not -path './vendor/*' \
+  -exec sed -i.bak 's/socialwarehouse/<your-warehouse>/g' {} \;
+
+# Verify and remove the .bak files
+find . -name '*.bak' -delete
+
+# Sanity-check the rename
+grep -rln 'socialwarehouse' --exclude-dir=.git --exclude-dir=vendor
+# Should return nothing (or only legitimate references like git submodule URLs)
+```
+
+**Files that must end up renamed:**
+
+| File | What changes |
+|---|---|
+| `pyproject.toml` | `[project] name`, `[tool.setuptools.packages.find] include` |
+| `<your-warehouse>/settings/base.py` | `WSGI_APPLICATION`, `ROOT_URLCONF`, app labels in `INSTALLED_APPS` |
+| `<your-warehouse>/settings/{dev,prod,test}.py` | Settings module references |
+| `<your-warehouse>/wsgi.py`, `asgi.py`, `urls.py`, `celery_app.py` | Package-internal imports |
+| `<your-warehouse>/manage.py` | `DJANGO_SETTINGS_MODULE` default |
+| `<your-warehouse>/{geo,warehouse,api,civic,demographic,economic,delta,orchestration}/**/*.py` | Cross-app imports |
+| `Makefile` | `PYTHONPATH` references |
+| `docker-compose.yml` + `docker/*.yml` | Service names + env vars |
+| `.env.example` | `DJANGO_SETTINGS_MODULE` |
+| `conftest.py` | `DJANGO_SETTINGS_MODULE` |
+| `README.md` + `CLAUDE.md` + `docs/**/*.md` | All textual references |
+| `pytest.ini_options` (in `pyproject.toml`) | `DJANGO_SETTINGS_MODULE` |
+
+The trickiest is `INSTALLED_APPS` — Django apps are referenced via their `app_label`, not their module name. If you want different app labels (e.g. `uk_geo` instead of `sw_geo`), update each app's `apps.py` `name` and `label`, then update all `app_label.ModelName` references.
+
+If you keep the SW app labels (`sw_geo`, etc.), `INSTALLED_APPS` doesn't need changes beyond the module-path rename.
+
+## Step 3 — Rename Django apps (optional but recommended)
+
+If you want `your_prefix_geo` instead of `sw_geo`:
+
+```python
+# <your-warehouse>/geo/apps.py
+class GeoConfig(AppConfig):
+    name = "<your-warehouse>.geo"
+    label = "ukgeo"   # was "sw_geo"
+```
+
+Then update every `'sw_geo'` reference (model lookups, migrations, queries) to `'ukgeo'`. This is a one-time pain; afterwards your fork is fully namespace-separated from upstream.
+
+For Django migrations to handle the label change cleanly, you may need to:
+
+1. Squash existing migrations into a single initial migration with the new label
+2. Or write a `RenameApp` data migration
+
+The cleanest path is option 1 if you're forking before going to production. If you've already got data in a deployed SW instance, option 2 is required and warrants its own pre-author inventory ticket.
+
+## Step 4 — Reset migrations (optional)
+
+Forking with a clean migration history makes the long-term upgrade story (see [how-to-upgrade-from-upstream.md](how-to-upgrade-from-upstream.md)) easier:
+
+```bash
+# Delete existing migrations
+find <your-warehouse> -path '*/migrations/*.py' \
+  -not -name '__init__.py' -delete
+
+# Generate fresh initial migrations
+python manage.py makemigrations
+```
+
+This loses git blame on migration files. If that matters, skip this step and live with the longer migration history.
+
+## Step 5 — Configure your `.env`
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` to set:
+
+```env
+DJANGO_SETTINGS_MODULE=<your-warehouse>.settings.dev
+DJANGO_SECRET_KEY=<generate-via-python-secrets-token_urlsafe>
+DATABASE_URL=postgres://localhost/<your_warehouse_dev>
+SW_WAREHOUSE_ROOT=file:///tmp/<your-warehouse>
+SW_CATALOG=<your_warehouse>
+SW_VINTAGE=2020   # or whatever your geography's primary vintage is
+```
+
+The `SW_*` env vars are namespaced for cross-instance clarity even though SW is renamed — they refer to the warehouse contract, not the package name. Keep them as `SW_*` so the orchestration resources work without per-instance code changes.
+
+## Step 6 — Migrate and seed
+
+```bash
+# Create the database
+createdb <your_warehouse_dev>
+psql <your_warehouse_dev> -c "CREATE EXTENSION postgis;"
+
+# Apply migrations
+python manage.py migrate
+
+# Create a superuser for the admin
+python manage.py createsuperuser
+
+# Seed minimal demo data (if SW's seed_demo command exists yet — see SW#195)
+python manage.py seed_demo --state RI
+```
+
+If your instance is non-US, `seed_demo --state RI` won't work — you'll need to author your own per-region seed command following the SW pattern. Track that in your instance project's issue tracker.
+
+## Step 7 — Verify the dev server
+
+```bash
+python manage.py runserver
+# Open http://localhost:8000/admin/ — log in with the superuser
+# Open http://localhost:8000/api/ — DRF browsable API root
+```
+
+If everything responds: your fork is bootstrapped.
+
+If you get `ModuleNotFoundError` for old `socialwarehouse.*` imports, grep again — you missed a rename.
+
+## Step 8 — Commit + push to your instance project's repo
+
+```bash
+git add -A
+git commit -m "feat: rename socialwarehouse -> <your-warehouse> (template fork)"
+git push -u origin main   # or develop, depending on your branch convention
+```
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `ModuleNotFoundError: No module named 'socialwarehouse'` after rename | Missed a rename | `grep -rln 'socialwarehouse' --exclude-dir=.git --exclude-dir=vendor` and finish the pass |
+| Django migrations fail with `LookupError: No installed app with label 'sw_geo'` | Renamed app labels but didn't update fixtures / migrations referencing them | Either don't rename app labels (Step 3 is optional) or write the RenameApp migration |
+| GST submodule didn't clone | Forgot `--recurse-submodules` | `git submodule update --init --recursive` |
+| `pip install -e .` fails | `pyproject.toml` rename was incomplete | Check `[project] name` AND `[tool.setuptools.packages.find] include` |
+| Imports work but Dagster doesn't discover assets | `dagster dev -m socialwarehouse.orchestration` still references old name | Use `-m <your-warehouse>.orchestration` |
+
+## What's next
+
+After the fork+rename lands:
+
+- **Swap geography** if your instance is non-US — see [how-to-swap-geography.md](how-to-swap-geography.md)
+- **Add domains** SW doesn't ship — see [how-to-add-a-new-domain.md](how-to-add-a-new-domain.md)
+- **Set up the upstream-tracking workflow** so you can absorb SW improvements — see [how-to-upgrade-from-upstream.md](how-to-upgrade-from-upstream.md)
+- **Extend the Dagster orchestration** with your domain assets — see [`../orchestration/instance-project-guide.md`](../orchestration/instance-project-guide.md)
+
+## See also
+
+- [README.md](README.md) — template overview
+- [`docs/designs/template-g-quickstart-and-init.md`](../designs/template-g-quickstart-and-init.md) — the design for the automated init mechanism (when shipped, supersedes this manual flow)
+- [`docs/quickstart.md`](../quickstart.md) — the standard quickstart for running SW as-is (US-default; useful as a sanity check before forking)

--- a/docs/template/how-to-swap-geography.md
+++ b/docs/template/how-to-swap-geography.md
@@ -1,0 +1,278 @@
+# How to swap geography
+
+This guide is for instance projects that need to replace SW's US-Census-based boundary catalog with a different geography (UK Ordnance Survey + ONS Census; EU Eurostat NUTS; Canada Statistics Canada; sub-national systems; custom administrative geographies).
+
+The pattern is documented in [`docs/designs/template-c-boundary-catalog.md`](../designs/template-c-boundary-catalog.md); this guide is the procedural counterpart.
+
+## What a "geography" means in SW
+
+SW's geographic substrate is:
+
+- A **boundary catalog** — the set of polygon/multipolygon types the warehouse keys on (`state`, `county`, `tract`, `block_group`, `block`, `vtd`, `cd`, `sldl`, `sldu`, `zcta`, `place`, `cbsa`, `school_district`, etc. for the US)
+- An **Address cache** (`geo.Address`) — denormalized table with one `_geoid` column per boundary type, so address-to-boundary lookups are O(1)
+- An **AddressBoundaryPeriod** (`geo.AddressBoundaryPeriod`) — temporal snapshots so historical "which CD was this address in during 2016?" works across redistricting
+- A **vintage system** (`CensusVintageConfig`) — maps decades to effective year ranges
+- A **Spark+Sedona enrichment library** (`delta/enrichment.py`) — bulk address-to-boundary joins
+
+To swap geography, you replace the *boundary catalog* and the *vintage system* while keeping the *Address cache pattern* and the *enrichment library* intact. The patterns generalize; only the type names and data sources change.
+
+## Step 0 — Pre-author inventory
+
+Before any code change, post a pre-author inventory to the relevant ticket in your instance project's tracker:
+
+```markdown
+## Pre-author inventory — geography swap (US Census → <your geography>)
+
+### Inputs read
+- SW's current `geo.Address._BOUNDARY_TYPES`
+- SW's `geo.AddressBoundaryPeriod` model
+- `docs/designs/template-c-boundary-catalog.md`
+- `docs/entities/boundary_catalog.md`
+- Your geography's authoritative source documentation
+  (ONS / Eurostat / StatCan / etc.)
+
+### Knowledge requirements
+- What boundary types does your geography offer?
+  (List them with the equivalent of GEOID — natural keys)
+- What's the vintage/revision cadence?
+  (US Census is decennial; UK is decennial but ONS revises mid-decade;
+  EU NUTS revises every 3 years; etc.)
+- What's the canonical projection/CRS?
+  (US Census ships in EPSG:4269; your source may differ)
+- Is there a hierarchical containment relationship?
+  (US: state ⊃ county ⊃ tract ⊃ block_group ⊃ block; your geography
+  may have a different tree or none)
+- What's the geocoding source?
+  (US: Census TIGER + commercial; UK: OS AddressBase + Royal Mail PAF;
+  EU: varies per country)
+- Are there electoral boundaries that revise between censuses?
+  (US CDs revise per redistricting cycle; UK constituencies revise per
+  Boundary Commission review)
+
+### Contact-point measurements
+- File a SU ticket (or batched series) for each new boundary type that
+  needs a siege_utilities model (per template-c step 1)
+- Inventory the SRID of every source dataset before any reproject step
+- Measure the row count of the largest source (boundary file for the
+  smallest unit — UK Output Areas, Canadian Dissemination Areas, etc.)
+  to size the Spark cluster
+
+### Surface areas beyond rules 1-5
+- Existing US-specific code in `geo/services/` that needs replacement
+  or generalization
+- Census-specific management commands (`assign_boundaries`,
+  `geocode_addresses --source dual`) that need geography-specific variants
+- ACS/QCEW/NCES ingest patterns that are US-specific — see
+  per-domain swap (template-d/e/f)
+
+### Hypothesis
+"After this swap, `Address._BOUNDARY_TYPES` will contain
+`{your_geo_types}`, `AddressBoundaryPeriod` will track temporal
+snapshots for `{revisable_types}`, and `assign_boundaries --source
+<your-source>` will Spark-join addresses to the new boundaries in
+under {target_time} per million addresses."
+```
+
+## Step 1 — Inventory your geography's boundary catalog
+
+Produce a table mapping your boundary types to SW's pattern:
+
+| SW US type | Your geography equivalent | Natural key format | Vintage cadence | Source |
+|---|---|---|---|---|
+| `state` | `country` (UK) / `nuts1` (EU) / `province` (CA) | (your code system) | (cadence) | (source URL) |
+| `county` | `ltla` (UK) / `nuts3` (EU) / `census_division` (CA) | ... | ... | ... |
+| `tract` | `lsoa` (UK) / `lau` (EU) / `dissemination_area` (CA) | ... | ... | ... |
+| ... | ... | ... | ... | ... |
+
+Not every SW type has an equivalent in your geography (US `vtd` has no clean UK analogue). And your geography may have types SW doesn't track (UK output areas; EU LAU2). The mapping is informational — the next step builds your geography's catalog from scratch, not by translating SW's.
+
+## Step 2 — File upstream siege_utilities tickets for new boundary types
+
+For each type in your geography's catalog (regardless of whether it maps to a SW type), file a `siege_utilities` ticket:
+
+```markdown
+Title: Add <type> boundary model (instance project: <your-warehouse>)
+
+Scope: vintage-aware boundary model for <type>, sourced from <source>.
+Schema: geom (MultiPolygon, EPSG:<srid>), <natural_key>, name,
+        <other attributes>, vintage FK.
+
+Pattern: per template-c, see existing siege_utilities boundary
+models (e.g. CensusState) as the reference.
+```
+
+Some of these may already exist in `siege_utilities` for other instance projects. Grep before filing (per the [check-before-blocking discipline](https://github.com/siege-analytics/siege_utilities)).
+
+## Step 3 — Replace `Address._BOUNDARY_TYPES`
+
+In your instance project's `<your-warehouse>/geo/models/address.py`:
+
+```python
+class Address(models.Model):
+    # ...
+
+    # Your geography's boundary catalog (replace SW's _BOUNDARY_TYPES)
+    _BOUNDARY_TYPES = (
+        "country",
+        "ltla",
+        "msoa",
+        "lsoa",
+        "output_area",
+        "constituency",
+        "ward",
+        # ...
+    )
+
+    # Replace SW's _geoid columns with your natural-key columns.
+    # Match the natural-key format from Step 1's table.
+    country_code = models.CharField(max_length=2, blank=True, db_index=True)
+    ltla_code = models.CharField(max_length=9, blank=True, db_index=True)
+    msoa_code = models.CharField(max_length=9, blank=True, db_index=True)
+    # ...
+```
+
+The `_BOUNDARY_TYPES` tuple drives the F11 helpers (`boundary_history(type=...)`, `boundary_on(type, date)`) — they iterate over the tuple, so the helpers automatically cover your new types.
+
+The per-type CharField on `Address` is the cache column. Naming convention: `<type>_<key-format>` (e.g. `lsoa_code`, not `lsoa_geoid` — the suffix should match the geography's terminology so domain authors can grep for what they expect).
+
+## Step 4 — Replace `AddressBoundaryPeriod` columns
+
+Same pattern in `<your-warehouse>/geo/models/abp.py`:
+
+```python
+class AddressBoundaryPeriod(models.Model):
+    address = models.ForeignKey(Address, on_delete=models.CASCADE)
+    vintage = models.ForeignKey(CensusVintageConfig, on_delete=models.PROTECT)
+
+    # Your geography's revisable boundaries get columns here
+    constituency_code = models.CharField(max_length=9, blank=True)
+    ward_code = models.CharField(max_length=9, blank=True)
+    # ...
+```
+
+Not every boundary type goes in ABP — only the ones that *revise* (US: cd, sldl, sldu, vtd). Stable boundaries (US: state, county, tract) live only on `Address`. Your geography's revisable set differs (UK constituencies revise periodically; LSOAs are revised per census).
+
+## Step 5 — Replace `CensusVintageConfig`
+
+Rename to something geography-neutral or rename to your geography:
+
+```python
+class VintageConfig(models.Model):
+    """Maps decades / revisions to effective year ranges.
+
+    For UK ONS: 2011 census effective 2011-2022; 2021 census effective 2022-onwards.
+    For EU NUTS: NUTS 2010 effective 2008-2012; NUTS 2013 effective 2012-2015; etc.
+    """
+    code = models.CharField(max_length=20, unique=True)  # e.g. "2021", "NUTS_2013"
+    effective_start = models.DateField()
+    effective_end = models.DateField(null=True, blank=True)  # null = current
+    description = models.TextField(blank=True)
+
+    @classmethod
+    def for_year(cls, year):
+        # Return the vintage in effect for the given year
+        ...
+```
+
+The `for_year(year)` API surface stays the same so downstream code (assets, asset graphs, API endpoints) keeps working.
+
+## Step 6 — Replace `delta/enrichment.py` boundary joins
+
+The Spark+Sedona enrichment pattern generalizes; only the table names + join keys change:
+
+```python
+def enrich_addresses_with_boundaries(spark, addresses_table, vintage="2021"):
+    """Spatial-enrich addresses with UK boundary attributes."""
+    addresses = spark.read.table(addresses_table)
+
+    # Replace SW's state/county/cd joins with your boundary set
+    countries = spark.read.format("delta").load(
+        get_table_path("silver", f"countries_{vintage}")
+    )
+    ltlas = spark.read.format("delta").load(
+        get_table_path("silver", f"ltlas_{vintage}")
+    )
+    constituencies = spark.read.format("delta").load(
+        get_table_path("silver", f"constituencies_{vintage}")
+    )
+
+    enriched = addresses
+    for boundary_df, key_col in [
+        (countries, "country_code"),
+        (ltlas, "ltla_code"),
+        (constituencies, "constituency_code"),
+    ]:
+        enriched = enriched.alias("a").join(
+            boundary_df.alias("b"),
+            on=expr("ST_Intersects(a.geom, b.geom)"),
+            how="left",
+        ).select("a.*", col(f"b.{key_col}"))
+
+    return enriched
+```
+
+## Step 7 — Replace management commands
+
+US-specific commands (`assign_boundaries`, `load_warehouse`) need geography-specific variants. The cleanest path is:
+
+- Keep the command names (`assign_boundaries`, `geocode_addresses`, `seed_demo`)
+- Replace the implementation per-geography
+- Use a settings flag (`GEOGRAPHY = "uk"`) or a per-geography subpackage (`<your-warehouse>/geo/uk/services/`) to dispatch
+
+Don't try to make commands "universally geography-aware" — the abstraction layer would be too deep. Geography-specific code is fine; the warehouse architecture (Delta → PostGIS → Django) is what generalizes, not every helper.
+
+## Step 8 — Replace API endpoints' assumptions
+
+`api/geo/` has endpoints that assume US-Census semantics (`geocode --source dual` assumes Census Geocoder + commercial; `civic_lookup` returns US-specific district types). Replace per your geography:
+
+```python
+# <your-warehouse>/api/geo/views/civic_lookup.py
+def civic_lookup(request):
+    """Return UK civic memberships for an address."""
+    addr = geocode(request.GET["address"], source="osab")  # Ordnance Survey AddressBase
+    return JsonResponse({
+        "constituency": addr.constituency_code,
+        "ward": addr.ward_code,
+        "ltla": addr.ltla_code,
+        "msoa": addr.msoa_code,
+    })
+```
+
+## Step 9 — Test end-to-end
+
+```bash
+# Run migrations
+python manage.py migrate
+
+# Seed a small region (one ltla or constituency)
+python manage.py seed_demo --region <your-test-region>
+
+# Hit the API
+curl http://localhost:8000/api/geo/civic_lookup?address=10+Downing+Street
+# Should return {"constituency": "...", "ward": "...", ...}
+```
+
+## What you DON'T replace
+
+- **The medallion architecture** — bronze/silver/gold still applies; only the table contents change
+- **`get_spark_session`, `get_table_path`** — unchanged
+- **Dagster `WarehouseConfig`, `SparkResource`, `PostGISResource`** — unchanged; instance project sets `SW_CATALOG=<your_catalog>` via env
+- **The `delta_table_asset` and `postgis_materialization_asset` factories** — unchanged; your assets use them
+- **The pre-author inventory discipline** — applies to your geography work too
+
+## Common pitfalls
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Spatial joins return empty | SRID mismatch | Inventory source SRID, reproject before join |
+| Geocoding works but boundary lookup fails | `_BOUNDARY_TYPES` tuple not updated | Update `Address._BOUNDARY_TYPES` + the corresponding `_code` columns |
+| Migration fails with FK constraint | `CensusVintageConfig` renamed but referencers not updated | Find every `vintage = models.ForeignKey(...)` and update the target model |
+| ABP queries return no temporal history | Forgot to populate ABP — only `Address` columns updated | Run the per-vintage ABP backfill (model on SW's existing pattern) |
+
+## See also
+
+- [README.md](README.md) — template overview
+- [`docs/designs/template-c-boundary-catalog.md`](../designs/template-c-boundary-catalog.md) — the boundary-catalog design (US-specific but the pattern generalizes)
+- [`docs/entities/boundary_catalog.md`](../entities/boundary_catalog.md) — SW's actual boundary catalog reference
+- [how-to-add-a-new-domain.md](how-to-add-a-new-domain.md) — once geography is swapped, add geography-specific domains
+- [how-to-upgrade-from-upstream.md](how-to-upgrade-from-upstream.md) — how to absorb SW improvements without losing your geography customizations

--- a/docs/template/how-to-upgrade-from-upstream.md
+++ b/docs/template/how-to-upgrade-from-upstream.md
@@ -1,0 +1,263 @@
+# How to upgrade your instance project from upstream SocialWarehouse
+
+Once you've forked SW and customized it, you'll want to periodically absorb upstream improvements — new asset factories, new boundary types, new dim/fact patterns, security fixes, dependency bumps — without losing your instance-specific changes. This guide covers the soft-fork upgrade workflow.
+
+If your fork has zero upstream-tracking and you don't want to absorb upstream improvements, you can skip this — but expect to re-discover bugs SW fixes and to drift from the broader template's contract over time.
+
+## Mental model
+
+Your instance project relates to upstream SW in three ways:
+
+| Category | Examples | Upgrade behavior |
+|---|---|---|
+| **Inherited verbatim** | `delta/config.py`, `orchestration/asset_factories.py`, `orchestration/resources.py`, `warehouse/models/dimensions.py` core dims | Pull from upstream periodically; rare conflicts |
+| **Forked + diverged** | Boundary catalog (geography swap), Django app labels (rename), seed_demo command | Stable divergence; cherry-pick non-conflicting upstream changes |
+| **Instance-owned** | Your new domains, your API endpoints, your settings, your asset modules | Never pulled from upstream |
+
+The upgrade goal: pull the "inherited verbatim" set, evaluate the "forked + diverged" set per upstream change, leave "instance-owned" alone.
+
+## Setup (once, after forking)
+
+Add SW as an `upstream` remote in your instance project:
+
+```bash
+cd <your-warehouse>
+git remote add upstream git@github.com:siege-analytics/socialwarehouse.git
+git fetch upstream
+```
+
+Confirm both remotes:
+
+```bash
+git remote -v
+# origin    git@github.com:<your-org>/<your-warehouse>.git (fetch + push)
+# upstream  git@github.com:siege-analytics/socialwarehouse.git (fetch + push)
+```
+
+## The upgrade workflow
+
+### Step 0 — Pre-author inventory
+
+Before any upgrade, post a pre-author inventory to the instance project's tracker:
+
+```markdown
+## Pre-author inventory — upstream sync from SW <upstream-ref>
+
+### Inputs read
+- Upstream changelog / release notes: <link>
+- Upstream commits between <last-sync-ref> and <upstream-ref>:
+  `git log --oneline <last-sync-ref>..upstream/main`
+- This guide
+
+### Knowledge requirements
+- Which upstream commits touch files in the "Inherited verbatim" set?
+- Which touch files in the "Forked + diverged" set?
+  (these require per-commit decision)
+- Are any breaking changes flagged in upstream's release notes?
+  (API changes to factories, resource fields, asset key formats)
+- Does upstream introduce new template-readiness tracks (B/C/D/E/F/G+)
+  that your instance project should adopt?
+
+### Contact-point measurements
+- Run upstream's tests against the upstream code (sanity check)
+- Run YOUR test suite after each conflict resolution
+- Run `dagster dev -m <your-warehouse>.orchestration` after the sync
+  to verify asset graph loads
+
+### Surface areas
+- Migrations: any upstream Django migration that adds columns to
+  shared models (DimGeography, Address, ABP) needs to flow into
+  your instance project; conflicts likely if you've extended those
+  models
+- pyproject deps: upstream version bumps may collide with your
+  pins; review the lockfile change
+- Settings: any new env var upstream introduces needs to land in
+  your `.env.example` + ops env
+
+### Hypothesis
+"After this sync, my instance project will be at upstream parity
+on the {inherited_verbatim} set, will have resolved {N} conflicts in
+the {forked_diverged} set, and will have absorbed {M} upstream commits.
+My instance-owned code is unchanged."
+```
+
+### Step 1 — Choose the upstream reference to sync to
+
+Don't sync to `upstream/main` blindly. Sync to a specific tag or commit so the upgrade is reproducible:
+
+```bash
+git fetch upstream --tags
+git log --oneline upstream/main | head -20
+# Pick a tag (e.g. v2.3.0) or a specific commit (e.g. 463d014)
+```
+
+For most cases: sync to the latest upstream release tag, not `main` (which may have unreleased work).
+
+### Step 2 — Create a sync branch
+
+```bash
+git checkout main   # or develop, per your branch convention
+git pull origin main
+git checkout -b sync/upstream-<ref>
+```
+
+### Step 3 — Merge upstream
+
+```bash
+git merge upstream/<ref> --no-ff --no-commit
+```
+
+`--no-ff` to keep a merge commit (audit trail of the sync).
+`--no-commit` to inspect conflicts before committing.
+
+### Step 4 — Resolve conflicts by category
+
+For each conflicted file:
+
+#### Category A: Inherited verbatim — take upstream
+
+```bash
+git checkout --theirs <file>
+git add <file>
+```
+
+Examples: `socialwarehouse/delta/config.py` (if you didn't customize it), `socialwarehouse/orchestration/asset_factories.py`, `pyproject.toml` (resolve carefully — see Step 5).
+
+#### Category B: Forked + diverged — manual merge
+
+Open the file in your editor; resolve conflicts per-hunk. Keep your divergence (e.g. your boundary catalog in `Address._BOUNDARY_TYPES`); take upstream's new methods if they don't conflict with your overrides.
+
+```bash
+# After manual edit
+git add <file>
+```
+
+#### Category C: Instance-owned — should not conflict
+
+If a conflict appears in instance-owned files (your new domains, your settings overrides), something is wrong. Either:
+
+- Upstream added a file with the same path (rare; investigate)
+- You renamed an upstream file but forgot to remove the upstream version (your initial fork+rename was incomplete; re-check Step 2 of `how-to-fork-and-rename.md`)
+
+### Step 5 — Carefully resolve `pyproject.toml`
+
+This always conflicts because both you and upstream version-bump it. Resolution pattern:
+
+```toml
+# Take upstream's:
+# - version (their canonical version)
+# - dependencies that you didn't override
+# - new optional-extras they added
+
+# Keep your:
+# - [project] name (your instance name, NOT 'socialwarehouse')
+# - [tool.setuptools.packages.find] include (your renamed package)
+# - any dep version overrides you set deliberately
+```
+
+Test the resolved pyproject:
+
+```bash
+pip install -e ".[full]" --upgrade
+```
+
+### Step 6 — Run migrations
+
+Upstream Django migrations need to apply on your instance project's DB. If upstream added a column to `DimGeography` and you've extended `DimGeography` in your instance:
+
+```bash
+python manage.py makemigrations --dry-run
+# Should show no new migrations needed if upstream's migration was absorbed cleanly
+
+python manage.py migrate
+# Should apply the upstream migrations on top of your divergent ones
+```
+
+If `makemigrations` shows pending migrations, you may need a manual data migration to reconcile your local schema with upstream's.
+
+### Step 7 — Run your test suite
+
+```bash
+pytest
+
+# Plus orchestration:
+pytest tests/orchestration/
+
+# Plus a Dagster smoke test:
+dagster dev -m <your-warehouse>.orchestration
+# Verify asset graph renders + a representative asset materializes
+```
+
+If tests fail: the upstream change broke a contract your instance relies on. Either:
+
+- File an issue upstream (if the change is unintentional or under-documented)
+- Pin to the previous upstream version (`git reset --hard <last-known-good>`) and skip this sync cycle
+- Adapt your instance code to the new upstream contract (most common; check upstream's release notes for migration guidance)
+
+### Step 8 — Commit + PR
+
+```bash
+git commit -m "chore: sync upstream SocialWarehouse @ <ref>
+
+Absorbs upstream commits <range>. Resolved conflicts:
+- pyproject.toml (took upstream version, kept instance name)
+- Address.py (kept instance boundary catalog, took new F11 method)
+- ...
+
+Tests pass. Dagster asset graph loads.
+"
+
+git push -u origin sync/upstream-<ref>
+gh pr create --base main ...
+```
+
+The PR is for your instance project's review process; reviewers should focus on the conflict resolutions (Category A is mechanical; Category B is where bugs land).
+
+## How often to sync
+
+Recommended cadence:
+
+- **At every upstream release tag** — if upstream releases monthly, sync monthly. Smaller per-sync diffs = easier review.
+- **Always at major version bumps** — `v2.x` → `v3.x` likely has breaking changes; don't skip.
+- **Within 1 week of security fixes** — upstream tags security-relevant releases; treat as urgent.
+
+Don't let your fork drift more than 6 months from upstream. Beyond that, the conflict-resolution cost compounds and the upgrade becomes its own initiative.
+
+## When NOT to sync
+
+- **Upstream is in active flux** (e.g. mid-template-readiness work that hasn't stabilized) — wait for the dust to settle
+- **You're in the middle of your own major refactor** — don't compound merge complexity
+- **The upstream change is irrelevant to your instance** (e.g. US-Census-specific work and you're a UK instance) — skip with a note in your sync log
+
+## What about upstream PRs that affect "forked + diverged" files heavily
+
+If upstream lands a big change to a Category B file (e.g. they re-architect `Address` significantly), you have three options:
+
+1. **Adopt the upstream architecture in full** — undo your divergence, re-apply your geography customization on top of upstream's new shape. Cleanest long-term; expensive short-term.
+2. **Skip the upstream change** — pin to the pre-change upstream ref; absorb everything else. Works once or twice; long-term you drift unsustainably.
+3. **Engage upstream** — open an issue / discussion explaining your instance's constraint; ask if there's a path to make the upstream change instance-friendly (extension point, hook, config). Often the right move for instance-shape concerns the upstream maintainer didn't consider.
+
+## Sync log
+
+Maintain a `docs/sync-log.md` in your instance project tracking sync history:
+
+```markdown
+# Upstream sync log
+
+## 2026-09-15 — synced to upstream v2.5.0 (commit abc1234)
+- Took upstream's new postgis_materialization_asset COPY threshold (SW#280)
+- Kept instance UK boundary catalog
+- Pyproject: bumped dagster pin to match upstream; kept instance celery override
+- Tests pass; dagster smoke passes
+- PR #42 in instance repo
+```
+
+The sync log is the audit trail when a regression appears 6 months later and you need to identify which sync introduced it.
+
+## See also
+
+- [README.md](README.md) — template overview
+- [how-to-fork-and-rename.md](how-to-fork-and-rename.md) — prerequisite (sets up `upstream` remote)
+- [how-to-swap-geography.md](how-to-swap-geography.md) + [how-to-add-a-new-domain.md](how-to-add-a-new-domain.md) — produce the divergence you'll be resolving against
+- SW release tags: https://github.com/siege-analytics/socialwarehouse/releases
+- SW changelog: [`CHANGELOG.md`](../../CHANGELOG.md) (when it exists; see SW#xxx)


### PR DESCRIPTION
Follow-on to SW#276 (orchestration scaffold). Closes the doc-surface gaps for users landing in \`docs/orchestration/\`: index, narrowly-scoped how-tos, reference, visual asset graph.

## Summary

4 new docs (~880 lines) + CLAUDE.md update (12 lines):

| File | Purpose |
|---|---|
| \`docs/orchestration/README.md\` | Index + Mermaid asset graph + quick reference + source module map |
| \`docs/orchestration/how-to-add-asset-to-existing-domain.md\` | 8-step author workflow with pre-author inventory as Step 0 |
| \`docs/orchestration/how-to-operate.md\` | Local dev / debugging / production deployment |
| \`docs/orchestration/reference.md\` | Env var matrix, resource fields, asset key conventions, factory API, errors→fixes |
| \`CLAUDE.md\` | Package structure tree updated; new docs pointer |

## Doc audience split

- \`how-to-add-asset-to-existing-domain.md\` — for **SW maintainers** extending SW's own asset graph
- \`instance-project-guide.md\` (existing from #276) — for **downstream forks** adding their own domains or overriding SW's

Deliberately separate because conflating produces one bloated doc that serves neither audience well.

## Verification

- Mermaid asset graph validated via \`mermaid_validate\` tool → valid
- Reference doc tables cross-checked against the actual signatures in \`resources.py\` + \`asset_factories.py\`
- Every doc has a "See also" section linking to siblings; round-trip closes from any landing point
- README \`Documentation\` table maps \"your situation → which doc to read\" so users discover the right entry point

## Test plan

- [ ] Render \`docs/orchestration/README.md\` on GitHub — confirm Mermaid renders + all internal links resolve
- [ ] Spot-check the \`how-to-add-asset-to-existing-domain.md\` Step-by-step against an actual asset addition (you can dry-run mentally against the demo \`geo\` asset graph in PR #276)
- [ ] Confirm \`how-to-operate.md\`'s production deployment shape matches your intended deployment target (or flag the deltas)
- [ ] Read \`reference.md\` end-to-end — flag any env var, resource field, or factory signature that drifted from the actual code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added orchestration documentation self-review guide with detailed checklists, assumptions, and validation procedures for documentation deliverables.
  * Updated package structure documentation to reflect new Dagster-based orchestration layer with component inventory and updated installation instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/siege-analytics/socialwarehouse/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->