### PR TITLE
feat(tests/docs): integration tests + design doc + entity docs (A-9 / #294)

### DIFF
--- a/.self-review-sw294-tests-docs-ci.md
+++ b/.self-review-sw294-tests-docs-ci.md
@@ -1,0 +1,30 @@
+## Self-Review: SW#294 — Tests, documentation, and CI
+
+### Role declarations
+- Author: AI agent
+- Reviewer: AI agent (self-review)
+
+### Goal source
+Epic A-9 / SW#294: final quality pass — comprehensive tests, documentation, CI green with 500+ tests.
+
+### Assumptions
+- A-0 through A-8 are all merged to develop
+- CI environment has PostGIS + GDAL (tests can't run locally)
+- The 27 new tests + existing 484 = 511 will exceed the 500 target
+
+### Peer review
+
+**writing-code:1** — all test data uses actual field names from model source files, verified by grep.
+
+**writing-tests:1** — mixin inheritance tests are structural (no DB), cross-model tests use `@pytest.mark.django_db`. No unused imports.
+
+**writing-claims:1** — entity docs describe only fields that exist in the models. API endpoint docs match actual router registrations.
+
+**writing-code:7** — no blocking I/O in tests; all model creates go through ORM.
+
+### Lead review
+
+- [ ] Architecture.md app structure table is complete and accurate
+- [ ] Design doc captures actual design decisions (not aspirational)
+- [ ] Test count exceeds 500 after merge
+- [ ] Entity docs are readable by someone who hasn't seen the code

--- a/docs/api/ontology-endpoints.md
+++ b/docs/api/ontology-endpoints.md
@@ -1,0 +1,46 @@
+# Ontology API Endpoints
+
+All endpoints require authentication (DRF Session or Basic). Read-only (GET only). Paginated (100 per page, max 1000).
+
+## Agents (`/api/agents/`)
+
+| Endpoint | ViewSet | Query params |
+|---|---|---|
+| `/api/agents/persons/` | PersonViewSet | `?search=`, `?jurisdiction_state=`, `?data_source=` |
+| `/api/agents/committees/` | CommitteeViewSet | `?search=` |
+| `/api/agents/organizations/` | OrganizationViewSet | `?search=` |
+| `/api/agents/classifications/` | ClassificationViewSet | `?agent_uuid=`, `?as_of=YYYY-MM-DD` |
+| `/api/agents/roles/` | RoleViewSet | `?agent_uuid=`, `?as_of=YYYY-MM-DD` |
+
+### Temporal queries
+
+Classification and Role viewsets support `as_of` filtering: returns records where `effective_from <= as_of` and (`effective_to >= as_of` or `effective_to IS NULL`).
+
+## Political (`/api/political/`)
+
+| Endpoint | ViewSet |
+|---|---|
+| `/api/political/offices/` | OfficeViewSet |
+| `/api/political/seats/` | SeatViewSet |
+| `/api/political/elections/` | ElectionViewSet |
+| `/api/political/contests/` | ElectoralContestViewSet |
+| `/api/political/terms/` | OfficeTermViewSet |
+
+## Transactions (`/api/transactions/`)
+
+| Endpoint | ViewSet | Query params |
+|---|---|---|
+| `/api/transactions/contributions/` | ContributionViewSet | `?from_agent_uuid=`, `?to_agent_uuid=`, `?jurisdiction_state=` |
+| `/api/transactions/expenditures/` | ExpenditureViewSet | `?from_agent_uuid=`, `?to_agent_uuid=`, `?jurisdiction_state=` |
+| `/api/transactions/transfers/` | TransferViewSet | `?from_agent_uuid=`, `?to_agent_uuid=`, `?jurisdiction_state=` |
+| `/api/transactions/obligations/` | ObligationViewSet | `?agent_uuid=`, `?status=` |
+
+## Events (`/api/events/`)
+
+| Endpoint | ViewSet | Query params |
+|---|---|---|
+| `/api/events/` | EventViewSet | `?agent_uuid=`, `?event_type=` |
+
+### Event detail response
+
+The detail endpoint includes nested `participants`, `corporate_detail`, `spatiotemporal_detail`, and `electoral_detail` (each null if not applicable). The list endpoint includes a `participant_count` annotation instead of nested data.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -63,8 +63,43 @@ This means:
 - The web app is replaceable. The warehouse is not. A future Phoenix / Next.js / etc. UI would consume the same star schema; the data model doesn't move.
 - Web-app schema changes are downstream of warehouse schema changes, never the reverse.
 
+## App structure
+
+### Domain apps (ontology)
+
+| App | Purpose | Key models |
+|---|---|---|
+| `socialwarehouse.core` | Abstract mixins and UUID generation | `SourceAwareModel`, `IdentifiableModel` |
+| `socialwarehouse.agents` | Entity-resolved actors | `Committee`, `Organization`, `Classification`, `Role`, `Relationship*` (6 types) |
+| `socialwarehouse.political` | Political structure | `Office`, `Seat`, `Election`, `ElectoralContest`, `OfficeTerm` |
+| `socialwarehouse.transactions` | Financial flows | `Contribution`, `Expenditure`, `Transfer`, `Obligation`, `ObligationEvent`, `TransactionGroup` |
+| `socialwarehouse.events` | Unified event supertype | `Event`, `EventParticipant`, `CorporateEvent`, `SpatioTemporalEvent`, `ElectoralEvent` |
+| `socialwarehouse.geo` | Geography, boundaries, vintages | `Address`, `AddressBoundaryPeriod`, `PrecinctVTDIntersection`, `Vintage` (7 subtypes) |
+
+### Infrastructure apps
+
+| App | Purpose |
+|---|---|
+| `socialwarehouse.warehouse` | PostGIS star schema (dims + facts) |
+| `socialwarehouse.delta` | Delta Lake table definitions and config |
+| `socialwarehouse.demographic` | Census/ACS ingest pipelines |
+| `socialwarehouse.economic` | BLS QCEW / BEA / IRS SOI ingest |
+| `socialwarehouse.civic` | NCES school data ingest |
+
+### API surface
+
+| Prefix | App | Endpoints |
+|---|---|---|
+| `/api/geo/` | `socialwarehouse.api.geo` | civic_lookup, boundary queries |
+| `/api/warehouse/` | `socialwarehouse.api.warehouse` | dimension/fact read API |
+| `/api/agents/` | `socialwarehouse.api.agents` | person, committee, organization, classification, role |
+| `/api/political/` | `socialwarehouse.api.political` | office, seat, election, contest, term |
+| `/api/transactions/` | `socialwarehouse.api.transactions` | contribution, expenditure, transfer, obligation |
+| `/api/events/` | `socialwarehouse.api.events` | event (with participants + subtype details) |
+
 ## Cross-references
 
+- Initiative SW#284 (General Civic Ontology) — design doc: [`docs/designs/ontology.md`](designs/ontology.md).
 - Initiative SW#250 (US Civic/Electoral template) — first initiative to be explicitly constrained by this principle.
 - Sub-issue SW#251 design note (`sessions/260502-vital-channel/plans/think-sw251-person-model.md` in the workspace) — the canonical example of a warehouse-first design (v2 supersedes a v1 that was web-app-first).
 - Per-initiative design notes: [`docs/designs/`](designs/).

--- a/docs/designs/ontology.md
+++ b/docs/designs/ontology.md
@@ -1,0 +1,81 @@
+# General Civic Ontology — Design
+
+**Epic**: SW#284
+**Tickets**: A-0 (#285) through A-9 (#294)
+**Status**: Complete
+
+## Problem
+
+SocialWarehouse has strong geographic and demographic infrastructure (Delta Lake + PostGIS + Census ingest) but no canonical models for the actors, events, and financial flows that animate civic life. Questions like "who donated to which committee, in which election cycle, and what events was that committee involved in" require stitching together data from multiple external sources with no shared identity layer.
+
+## Design principles
+
+1. **Warehouse-first**: Delta schemas defined before PostGIS star schema, PostGIS before Django ORM. The web app is downstream.
+2. **UUID-based agent linkage**: No FKs across app boundaries. Agents are identified by `entity_uuid` (UUID5 for identity entities, UUID4 for resolved artifacts). Cross-app queries join on UUID columns.
+3. **Effective-dated temporality**: `effective_from`/`effective_to` on entities that change over time (classifications, roles, office terms). Enables "as-of" queries without SCD2 complexity at the Django layer.
+4. **Event supertype with shared query surface**: All events (financial transactions, corporate events, redistricting, elections) are subtypes of a single `Event` model. `EventParticipant` bridges agents to events, enabling "all events involving Agent X" as a single query.
+5. **SourceAwareModel mixin**: Every data-bearing model tracks its provenance (`data_source`, `jurisdiction_level`, `jurisdiction_state`, `source_record_id`, `ingested_at`).
+6. **IdentifiableModel mixin**: Identity entities carry a `entity_uuid` field with `assign_uuid5()` / `assign_uuid4()` methods.
+
+## Domain model
+
+### Agents (A-2, A-3)
+
+- **DimPerson** — warehouse dimension; lives in `socialwarehouse.warehouse`
+- **Committee** — PAC, party committee, JFC. Entity-resolved by `entity_uuid`
+- **Organization** — corporate entity with NAICS classification
+- **Classification** — effective-dated type tags (PAC type, org sector, etc.)
+- **Role** — effective-dated role assignments (treasurer, chair, agent)
+- **Relationships** — 6 typed relationship models (simple, sponsor, control, subsidiary, corporate succession, DAF conduit)
+
+### Political structure (A-4)
+
+- **Office** — elected office (President, Governor, State Rep, etc.)
+- **Seat** — specific seat within an office (e.g., TX HD-45)
+- **Election** — election event (2024 General, 2026 Primary, etc.)
+- **ElectoralContest** — specific race (TX HD-45 2024 General)
+- **OfficeTerm** — who held which seat, when
+
+### Transactions (A-5)
+
+- **Contribution** — person/org → committee
+- **Expenditure** — committee → vendor/org
+- **Transfer** — committee → committee
+- **Obligation** — stateful balance tracking (loan, payable)
+- **ObligationEvent** — drawdown, repayment, forgiveness
+- **TransactionGroup** — links multi-leg transactions (JFC distributions)
+
+### Events (A-6)
+
+- **Event** — supertype (SourceAwareModel)
+- **EventParticipant** — bridge table (agent_uuid + role)
+- **CorporateEvent** — merger, spinoff, acquisition, dissolution
+- **SpatioTemporalEvent** — redistricting, annexation, boundary correction
+- **ElectoralEvent** — certification, recount, contest resolution
+
+### Plan-keyed boundaries (A-7)
+
+- **PrecinctVTDIntersection** — pre-computed precinct/VTD overlaps by election cycle
+- **Delta schemas**: `SILVER_REDISTRICTING_PLANS`, `SILVER_ADDRESS_BOUNDARY_PERIODS`, `SILVER_PRECINCT_VTD_INTERSECTIONS`
+
+### API endpoints (A-8)
+
+DRF read-only API for all ontology models. DefaultRouter + ReadOnlyModelViewSet pattern. Endpoints under `/api/agents/`, `/api/political/`, `/api/transactions/`, `/api/events/`.
+
+## UUID strategy
+
+| Entity type | UUID version | Generation |
+|---|---|---|
+| Person, Committee, Organization, Office, Seat | UUID5 | Deterministic from identity components via `generate_entity_uuid5()` |
+| Transaction, Event, Obligation, ObligationEvent | UUID4 | Random via `generate_entity_uuid4()` |
+
+UUID5 uses `SW_NAMESPACE = uuid5(NAMESPACE_URL, "socialwarehouse.siegeanalytics.com")` as the namespace. Input normalization: lowercase, strip whitespace, join with pipe separator.
+
+## Delta Lake schemas
+
+All schemas declared in `socialwarehouse/delta/tables.py` as PySpark `StructType`. Registered in the `TABLES` dict with path, schema, and partition_by. Silver-tier schemas added:
+
+- `silver.contributions`, `silver.expenditures`, `silver.transfers`, `silver.obligations`
+- `silver.events`, `silver.event_participants`, `silver.events_corporate`, `silver.events_spatiotemporal`, `silver.events_electoral`
+- `silver.political_offices`, `silver.political_seats`, `silver.political_elections`, `silver.political_electoral_contests`, `silver.political_office_terms`
+- `silver.redistricting_plans`, `silver.address_boundary_periods`, `silver.precinct_vtd_intersections`

--- a/docs/entities/committee.md
+++ b/docs/entities/committee.md
@@ -1,0 +1,32 @@
+# Committee
+
+**App**: `socialwarehouse.agents`
+**Table**: `sw_committee`
+**Mixins**: `SourceAwareModel`, `IdentifiableModel`
+
+A regulatory fundraising vehicle with lifecycle tracking. Covers PACs, party committees, campaign committees, and similar entities that register with regulatory bodies to raise and spend money. General civic concept — not FEC-specific. FEC-specific subtypes live in the enterprise layer.
+
+## Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `entity_uuid` | UUID | Deterministic UUID5 from identity components. Immutable. |
+| `name` | CharField(255) | Current legal name |
+| `committee_type` | CharField(20) | pac, super_pac, party, campaign, leadership, hybrid, other |
+| `source_system_id` | CharField(100) | Registration ID from source regulatory body |
+| `formation_date` | DateField | Nullable |
+| `termination_date` | DateField | NULL = active |
+| `name_history` | JSONField | List of `{name, effective_from, effective_to}` |
+
+## Natural key
+
+`(data_source, source_system_id)` — unique together.
+
+## Related models
+
+- **Classification** — effective-dated type tags (via `agent_uuid`)
+- **Role** — effective-dated role assignments (via `agent_uuid` or `counterparty_uuid`)
+- **RelationshipSponsor** — connected organization sponsorship
+- **Contribution** — as `to_agent_uuid`
+- **Expenditure** — as `from_agent_uuid`
+- **Transfer** — as either side

--- a/docs/entities/event.md
+++ b/docs/entities/event.md
@@ -1,0 +1,34 @@
+# Event
+
+**App**: `socialwarehouse.events`
+**Table**: `sw_event`
+**Mixin**: `SourceAwareModel`
+
+Unified event supertype. The shared query surface that ties the entire ontology together. "All events involving Agent X" is answered by querying EventParticipant joined to Event.
+
+## Event types
+
+| Type | Subtype model | Table |
+|---|---|---|
+| `transaction` | (none — linked via transactions) | — |
+| `corporate` | `CorporateEvent` | `sw_event_corporate` |
+| `spatiotemporal` | `SpatioTemporalEvent` | `sw_event_spatiotemporal` |
+| `electoral` | `ElectoralEvent` | `sw_event_electoral` |
+
+## Shared query surface
+
+```python
+EventParticipant.objects.filter(agent_uuid=some_uuid)
+    .select_related("event")
+    .order_by("-event__event_date")
+```
+
+Returns all events involving an agent across all event types.
+
+## EventParticipant roles
+
+source, target, subject, witness, candidate, winner, predecessor, successor, affected, other.
+
+## Auto-derived fields
+
+- `year` — derived from `event_date` on save

--- a/docs/entities/organization.md
+++ b/docs/entities/organization.md
@@ -1,0 +1,24 @@
+# Organization
+
+**App**: `socialwarehouse.agents`
+**Table**: `sw_organization`
+**Mixins**: `SourceAwareModel`, `IdentifiableModel`
+
+Employer, vendor, consultant, union, corporation, or other non-committee organizational entity. Matched by name + jurisdiction + industry across sources. Unlike Committee, Organization does not have regulatory registration IDs as a universal natural key — matching is softer.
+
+## Fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `entity_uuid` | UUID | UUID5 from (name, jurisdiction_state, industry_code) |
+| `name` | CharField(255) | Legal or commonly-known name |
+| `industry_code` | CharField(20) | NAICS or SIC code |
+| `industry_system` | CharField(10) | naics, sic, other |
+
+## Related models
+
+- **Classification** — effective-dated type tags (via `agent_uuid`)
+- **RelationshipSponsor** — as sponsor of a committee
+- **RelationshipSubsidiary** — parent/child corporate relationships
+- **RelationshipCorporateSuccession** — merger, spinoff, split, rename
+- **Expenditure** — as `to_agent_uuid` (vendor payments)

--- a/docs/entities/political-structure.md
+++ b/docs/entities/political-structure.md
@@ -1,0 +1,33 @@
+# Political Structure
+
+**App**: `socialwarehouse.political`
+
+## Office → Seat → Election → Contest → Term
+
+Five models form the political structure graph:
+
+### Office (`sw_office`)
+
+Persistent identity for a political office. "US House TX-07" persists across redistricting. Inherits `SourceAwareModel` + `IdentifiableModel`.
+
+Merge key: `(jurisdiction_level, jurisdiction_state, chamber, district_number)`.
+
+### Seat (`sw_seat`)
+
+Plan-specific geographic realization of an Office. When redistricting changes boundaries, a new Seat is created for the same Office. The Office persists; the Seat is temporal.
+
+### Election (`sw_election`)
+
+An election event with date, jurisdiction, and type (general, primary, special, runoff). Inherits `SourceAwareModel`. Auto-derives `year` from `election_date`.
+
+### ElectoralContest (`sw_electoral_contest`)
+
+What is being contested in a specific election. Links an Office/Seat to an Election. Candidates are Persons with Role "candidate" pointing at this contest's office.
+
+### OfficeTerm (`sw_office_term`)
+
+Who holds an office and when. Handles regular terms, special election remainder terms, and appointments. `congress_number` field supports federal chamber numbering.
+
+## Term types
+
+elected, appointed, special_election, acting.

--- a/docs/entities/transactions.md
+++ b/docs/entities/transactions.md
@@ -1,0 +1,31 @@
+# Transactions
+
+**App**: `socialwarehouse.transactions`
+
+## Transaction types
+
+All transaction types share the `_TransactionBase` abstract model (`SourceAwareModel`) with directed edges: `from_agent_uuid` → `to_agent_uuid`.
+
+| Model | Table | Flow |
+|---|---|---|
+| `Contribution` | `sw_contribution` | Person/Org → Committee |
+| `Expenditure` | `sw_expenditure` | Committee → Vendor/Org |
+| `Transfer` | `sw_transfer` | Committee → Committee |
+| `ObligationEvent` | `sw_obligation_event` | Drawdown, repayment, forgiveness |
+
+Each subclass auto-sets `transaction_type` on save.
+
+## Obligation (`sw_obligation`)
+
+Stateful balance tracking for loans, accounts payable, and refund payables. Balance updated via `apply_event()`:
+
+- `drawdown` → increases balance
+- `repayment` → decreases balance
+- `forgiveness` → decreases balance, sets status to "forgiven" if zeroed
+- `adjustment` → increases balance
+
+Balance floors at zero. Status transitions: active → paid/forgiven.
+
+## TransactionGroup (`sw_transaction_group`)
+
+Links multiple transactions into a single logical event (e.g., JFC receives $100K, distributes to 5 committees = 6 transactions in one group). Uses M2M relationships to all transaction types.

--- a/tests/unit/ontology/test_cross_model_queries.py
+++ b/tests/unit/ontology/test_cross_model_queries.py
@@ -1,0 +1,190 @@
+"""Cross-model query tests for the ontology.
+
+These tests verify the shared query surface works: agents linked by
+UUID across transactions and events, the event participant bridge,
+and temporal queries across models.
+"""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.db import models
+from django.test import TestCase
+
+from socialwarehouse.core.mixins import generate_entity_uuid4, generate_entity_uuid5
+
+
+@pytest.mark.django_db
+class TestSharedQuerySurface(TestCase):
+    """Agent UUID links span across transaction and event tables."""
+
+    def setUp(self):
+        self.donor_uuid = generate_entity_uuid5("John", "Doe", "1980-01-01")
+        self.committee_uuid = generate_entity_uuid5("Friends of Progress", "TX")
+
+    def test_contributions_by_agent_uuid(self):
+        from socialwarehouse.transactions.models import Contribution
+
+        Contribution.objects.create(
+            from_agent_uuid=self.donor_uuid,
+            from_agent_type="person",
+            to_agent_uuid=self.committee_uuid,
+            to_agent_type="committee",
+            amount=Decimal("500.00"),
+            transaction_date=date(2024, 3, 15),
+        )
+        Contribution.objects.create(
+            from_agent_uuid=self.donor_uuid,
+            from_agent_type="person",
+            to_agent_uuid=self.committee_uuid,
+            to_agent_type="committee",
+            amount=Decimal("1000.00"),
+            transaction_date=date(2024, 6, 1),
+        )
+        qs = Contribution.objects.filter(from_agent_uuid=self.donor_uuid)
+        assert qs.count() == 2
+        assert qs.aggregate(total=models.Sum("amount"))["total"] == Decimal("1500.00")
+
+    def test_events_by_agent_uuid(self):
+        from socialwarehouse.events.models import Event, EventParticipant
+
+        e = Event.objects.create(
+            event_type="transaction",
+            event_date=date(2024, 3, 15),
+        )
+        EventParticipant.objects.create(
+            event=e,
+            agent_uuid=self.donor_uuid,
+            agent_type="person",
+            role_in_event="source",
+        )
+        qs = EventParticipant.objects.filter(agent_uuid=self.donor_uuid)
+        assert qs.count() == 1
+        assert qs.first().event.event_type == "transaction"
+
+    def test_all_events_for_agent_across_types(self):
+        from socialwarehouse.events.models import Event, EventParticipant
+
+        e1 = Event.objects.create(
+            event_type="transaction",
+            event_date=date(2024, 3, 15),
+        )
+        e2 = Event.objects.create(
+            event_type="electoral",
+            event_date=date(2024, 11, 5),
+        )
+        for event in [e1, e2]:
+            EventParticipant.objects.create(
+                event=event,
+                agent_uuid=self.committee_uuid,
+                agent_type="committee",
+                role_in_event="target" if event == e1 else "candidate",
+            )
+        events = Event.objects.filter(
+            participants__agent_uuid=self.committee_uuid,
+        ).distinct()
+        assert events.count() == 2
+        types = set(events.values_list("event_type", flat=True))
+        assert types == {"transaction", "electoral"}
+
+
+@pytest.mark.django_db
+class TestEventAutoYear(TestCase):
+    """Event.save() auto-derives year from event_date."""
+
+    def test_year_derived_on_save(self):
+        from socialwarehouse.events.models import Event
+
+        e = Event.objects.create(
+            event_type="corporate",
+            event_date=date(2024, 7, 15),
+        )
+        assert e.year == 2024
+
+    def test_year_updates_on_date_change(self):
+        from socialwarehouse.events.models import Event
+
+        e = Event.objects.create(
+            event_type="corporate",
+            event_date=date(2024, 7, 15),
+        )
+        e.event_date = date(2025, 1, 1)
+        e.save()
+        e.refresh_from_db()
+        assert e.year == 2025
+
+
+@pytest.mark.django_db
+class TestObligationLifecycle(TestCase):
+    """Obligation balance tracking via apply_event."""
+
+    def setUp(self):
+        from socialwarehouse.transactions.models import Obligation
+
+        self.obligation = Obligation.objects.create(
+            obligation_type="loan",
+            original_amount=Decimal("10000.00"),
+            current_balance=Decimal("10000.00"),
+            counterparty_uuid=generate_entity_uuid4(),
+            counterparty_type="person",
+            agent_uuid=generate_entity_uuid4(),
+            agent_type="committee",
+        )
+
+    def test_repayment_reduces_balance(self):
+        self.obligation.apply_event("repayment", Decimal("3000.00"))
+        assert self.obligation.current_balance == Decimal("7000.00")
+        assert self.obligation.status == "active"
+
+    def test_full_repayment_sets_paid(self):
+        self.obligation.apply_event("repayment", Decimal("10000.00"))
+        assert self.obligation.current_balance == Decimal("0.00")
+        assert self.obligation.status == "paid"
+
+    def test_forgiveness_sets_forgiven(self):
+        self.obligation.apply_event("forgiveness", Decimal("10000.00"))
+        assert self.obligation.current_balance == Decimal("0.00")
+        assert self.obligation.status == "forgiven"
+
+    def test_drawdown_increases_balance(self):
+        self.obligation.apply_event("drawdown", Decimal("5000.00"))
+        assert self.obligation.current_balance == Decimal("15000.00")
+
+    def test_overpayment_floors_at_zero(self):
+        self.obligation.apply_event("repayment", Decimal("15000.00"))
+        assert self.obligation.current_balance == Decimal("0.00")
+        assert self.obligation.status == "paid"
+
+
+@pytest.mark.django_db
+class TestTransactionAutoType(TestCase):
+    """Each transaction subclass auto-sets transaction_type on save."""
+
+    def _make_tx_kwargs(self):
+        return {
+            "from_agent_uuid": generate_entity_uuid4(),
+            "from_agent_type": "person",
+            "to_agent_uuid": generate_entity_uuid4(),
+            "to_agent_type": "committee",
+            "amount": Decimal("100.00"),
+            "transaction_date": date(2024, 6, 1),
+        }
+
+    def test_contribution_type(self):
+        from socialwarehouse.transactions.models import Contribution
+
+        c = Contribution.objects.create(**self._make_tx_kwargs())
+        assert c.transaction_type == "contribution"
+
+    def test_expenditure_type(self):
+        from socialwarehouse.transactions.models import Expenditure
+
+        e = Expenditure.objects.create(**self._make_tx_kwargs())
+        assert e.transaction_type == "expenditure"
+
+    def test_transfer_type(self):
+        from socialwarehouse.transactions.models import Transfer
+
+        t = Transfer.objects.create(**self._make_tx_kwargs())
+        assert t.transaction_type == "transfer"

--- a/tests/unit/ontology/test_mixin_inheritance.py
+++ b/tests/unit/ontology/test_mixin_inheritance.py
@@ -1,0 +1,104 @@
+"""Verify every ontology model inherits from the correct abstract mixins.
+
+These are structural tests: they assert the class hierarchy is correct
+and that expected fields are present on each model. They don't need
+a database — they inspect the Django meta layer.
+"""
+
+import uuid
+
+from django.test import TestCase
+
+from socialwarehouse.core.mixins import (
+    IdentifiableModel,
+    SourceAwareModel,
+    generate_entity_uuid5,
+)
+
+
+class TestSourceAwareInheritance(TestCase):
+    """Every model that inherits SourceAwareModel gets its fields."""
+
+    def _assert_source_aware(self, model_class):
+        field_names = {f.name for f in model_class._meta.get_fields()}
+        assert "data_source" in field_names
+        assert "jurisdiction_level" in field_names
+        assert "jurisdiction_state" in field_names
+        assert "source_record_id" in field_names
+        assert "ingested_at" in field_names
+        assert issubclass(model_class, SourceAwareModel)
+
+    def test_committee(self):
+        from socialwarehouse.agents.models import Committee
+        self._assert_source_aware(Committee)
+
+    def test_organization(self):
+        from socialwarehouse.agents.models import Organization
+        self._assert_source_aware(Organization)
+
+    def test_contribution(self):
+        from socialwarehouse.transactions.models import Contribution
+        self._assert_source_aware(Contribution)
+
+    def test_expenditure(self):
+        from socialwarehouse.transactions.models import Expenditure
+        self._assert_source_aware(Expenditure)
+
+    def test_transfer(self):
+        from socialwarehouse.transactions.models import Transfer
+        self._assert_source_aware(Transfer)
+
+    def test_obligation(self):
+        from socialwarehouse.transactions.models import Obligation
+        self._assert_source_aware(Obligation)
+
+    def test_event(self):
+        from socialwarehouse.events.models import Event
+        self._assert_source_aware(Event)
+
+
+class TestIdentifiableInheritance(TestCase):
+    """Every identity-bearing model inherits IdentifiableModel."""
+
+    def _assert_identifiable(self, model_class):
+        field_names = {f.name for f in model_class._meta.get_fields()}
+        assert "entity_uuid" in field_names
+        assert issubclass(model_class, IdentifiableModel)
+
+    def test_committee(self):
+        from socialwarehouse.agents.models import Committee
+        self._assert_identifiable(Committee)
+
+    def test_organization(self):
+        from socialwarehouse.agents.models import Organization
+        self._assert_identifiable(Organization)
+
+
+class TestUUID5Determinism(TestCase):
+    """UUID5 generation is deterministic across calls."""
+
+    def test_same_inputs_same_uuid(self):
+        u1 = generate_entity_uuid5("John", "Doe", "1980-01-01")
+        u2 = generate_entity_uuid5("John", "Doe", "1980-01-01")
+        assert u1 == u2
+
+    def test_case_insensitive(self):
+        u1 = generate_entity_uuid5("JOHN", "DOE")
+        u2 = generate_entity_uuid5("john", "doe")
+        assert u1 == u2
+
+    def test_whitespace_insensitive(self):
+        u1 = generate_entity_uuid5("  John ", " Doe  ")
+        u2 = generate_entity_uuid5("John", "Doe")
+        assert u1 == u2
+
+    def test_none_handled(self):
+        u1 = generate_entity_uuid5("John", None, "TX")
+        u2 = generate_entity_uuid5("John", None, "TX")
+        assert u1 == u2
+        assert isinstance(u1, uuid.UUID)
+
+    def test_different_inputs_different_uuid(self):
+        u1 = generate_entity_uuid5("John", "Doe")
+        u2 = generate_entity_uuid5("Jane", "Doe")
+        assert u1 != u2


### PR DESCRIPTION
## Summary

Final quality pass for the ontology epic (SW#284). Closes #294.

- **27 new tests** across two files:
  - `test_mixin_inheritance.py`: structural verification that all ontology models inherit from correct abstract mixins (SourceAwareModel, IdentifiableModel), UUID5 determinism properties
  - `test_cross_model_queries.py`: shared query surface (agent UUID spans across transactions and events), event auto-year derivation, obligation lifecycle (apply_event balance tracking), transaction auto-type
- **Design doc** (`docs/designs/ontology.md`): domain model, UUID strategy, Delta Lake schemas
- **Entity docs**: committee, organization, event, political-structure, transactions
- **API endpoint reference** (`docs/api/ontology-endpoints.md`)
- **Architecture.md updated** with app structure and API surface tables

Test count target: 500+ (471 baseline + 13 from A-8 + 27 new = 511).

## Test plan

- [ ] CI test suite green (all 511+ tests pass)
- [ ] No regressions in existing tests
- [ ] Documentation readable by someone who hasn't seen the code