### PR TITLE
docs: production-operations guide for template adopters

### DIFF
--- a/.self-review-sw309-production-operations.md
+++ b/.self-review-sw309-production-operations.md
@@ -1,0 +1,32 @@
+## Self-Review: production-operations guide (SW#309)
+
+### Role declarations
+- Author: AI agent
+- Reviewer: AI agent (self-review)
+
+Working as: software engineer
+
+## Assumptions
+
+Goal source: SW#309 — docs: ship production-operations guidance for adopters of the template. Accepted with scope note: doc must be generic template guidance, not electinfo-specific.
+
+- Docs-only change; no model, view, or behavioral changes
+- 10-section decision guide structure per ticket specification
+- Scope guardrail applied: electinfo-specific items (UC metadata isolation, cycle-based partitioning) framed as options not defaults
+- Generic metrics (row count, DB size, WAL throughput) used for triggers/scale targets
+
+## Peer review
+
+writing-prose:1 — each section follows consistent Decision/Triggers/Options/Default/Pointer template. No prescriptive language; all recommendations framed as "if unsure" defaults with explicit trade-offs.
+
+writing-claims:1 — all technical claims are standard PostgreSQL operational knowledge (PITR, PgBouncer modes, partitioning semantics, REINDEX CONCURRENTLY). No novel claims requiring verification.
+
+writing-code:1 — SQL snippets in §9 (index hygiene) are standard pg_stat queries. No application code changes.
+
+## Lead review
+
+- [x] `docs/production-operations.md` covers all 10 gap areas from the ticket
+- [x] CLAUDE.md references the new doc with instructions for agents
+- [x] `docs/quickstart.md` "What's next" links to the new doc
+- [x] No electinfo-specific defaults — UC metadata isolation and domain-specific partitioning framed as "one possible approach"
+- [x] No code changes beyond documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ python manage.py compute_geographic_intersections --year 2020 --type all
 | `/api/warehouse/election-results/` | GET | Election results by geography |
 | `/api/warehouse/acs-estimates/` | GET | ACS demographic estimates |
 
+## Production Operations
+
+When working on an adopter's production deployment (infrastructure, scaling, backup, partitioning), read [`docs/production-operations.md`](docs/production-operations.md) first. It covers the 10 operational decisions adopters face when outgrowing the single-node defaults: HA topology, backup/PITR, connection pooling, partitioning, cold-tier storage, hub-to-downstream distribution, metadata store isolation, node placement, index hygiene, and scale triggers.
+
 ## Development
 
 ```bash

--- a/docs/production-operations.md
+++ b/docs/production-operations.md
@@ -1,0 +1,289 @@
+# Production Operations Guide
+
+This guide covers the operational decisions adopters need to make when their SocialWarehouse deployment outgrows the single-node defaults. It is a **decision framework**, not a prescription — each adopter's scale, hardware, compliance posture, and cloud provider will differ.
+
+The guide assumes familiarity with [`docs/architecture.md`](architecture.md) (the three-tier warehouse pattern) and [`docs/quickstart.md`](quickstart.md) (the single-node dev setup).
+
+Each section follows the same structure:
+
+- **Decision** — what you're deciding
+- **Triggers** — signals that you need to make this decision now
+- **Options** — approaches with trade-offs
+- **Default-safe recommendation** — what to do if you're unsure
+- **Implementation pointer** — where the work lives (your infra repo, not here)
+
+---
+
+## 1. High-Availability Topology
+
+**Decision:** Should the PostGIS tier run as a single pod, or as a primary + standby cluster?
+
+**Triggers:**
+- Unplanned downtime costs more than the operational overhead of a replica
+- Database size exceeds what you can restore from backup within your RTO (recovery time objective)
+- Multiple services (Django, Spark materializations, Dagster sensors) contend for the same primary
+
+**Options:**
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Single pod | Simple, no replication lag, easy to reason about | Single point of failure; restore-from-backup is your only recovery path |
+| CloudNativePG (CNPG) | Kubernetes-native, ArgoCD-friendly, automated failover, WAL archiving built in | Learning curve if you haven't operated CRDs; CNPG-specific debugging |
+| Patroni + etcd | Battle-tested, cloud-agnostic, rich ecosystem | More moving parts (etcd/consul cluster); manual ArgoCD integration |
+| Managed service (RDS/CloudSQL) | Zero operational burden for HA | Vendor lock-in; less control over PostGIS extensions and versions |
+
+**Default-safe recommendation:** Start with a single pod until your data volume or uptime requirements force the conversation. When you're ready, CNPG primary + 1 standby + WAL archiving to object storage is the lowest-friction Kubernetes path. If you're not on Kubernetes, a managed PostgreSQL service with PostGIS support is the pragmatic choice.
+
+**Implementation pointer:** HA topology lives in your infrastructure repo (Helm charts, Terraform, ArgoCD manifests) — not in SocialWarehouse. SW's `docker-compose.yml` is a dev convenience; production topology is the adopter's concern.
+
+---
+
+## 2. Backup and Point-in-Time Recovery (PITR)
+
+**Decision:** Where do WAL archives go, how often do you take base backups, how long do you retain them, and can you actually restore?
+
+**Triggers:**
+- You have data you can't re-derive from source (geocoding results, vendor-ingested records, user-contributed data)
+- Database size exceeds what you can casually recreate by re-running ingest pipelines
+- Compliance requires auditable backup history
+
+**Options:**
+
+| Component | Choices |
+|-----------|---------|
+| WAL archive target | S3/GCS/Azure Blob (most common); local NFS (small deployments); pgBackRest repository |
+| Base backup tool | `pg_basebackup` (simple), pgBackRest (incremental + parallel), Barman (feature-rich) |
+| Retention policy | Time-based (e.g., 30 days), count-based (e.g., last 7 base backups), or both |
+| Restore testing | Automated periodic restore to a scratch instance (gold standard) vs. manual quarterly drills |
+
+**Default-safe recommendation:** WAL archiving to S3-compatible storage + daily base backups via pgBackRest + 14-day retention. Test a restore before you need one — an untested backup is not a backup.
+
+**Implementation pointer:** Backup configuration belongs in your infrastructure repo. If using CNPG, backup is declarative in the Cluster CRD. If managing PostgreSQL directly, pgBackRest config lives alongside your PostgreSQL configuration.
+
+---
+
+## 3. Connection Pooling
+
+**Decision:** Do you need a connection pooler between your application tier and PostgreSQL, and if so, what pool mode?
+
+**Triggers:**
+- Connection count from Django workers + Celery workers + Spark executors + Dagster ops exceeds `max_connections` (default 100)
+- Short-lived connections (Django request cycle) create connection churn visible in `pg_stat_activity`
+- You're running multiple replicas of the Django web tier
+
+**Options:**
+
+| Pooler | Mode | Fits |
+|--------|------|------|
+| PgBouncer (transaction mode) | Releases server connection at transaction boundary | Django + DRF (short transactions, no prepared statements by default) |
+| PgBouncer (session mode) | Holds server connection for client session lifetime | Spark JDBC (long-lived connections, may use prepared statements) |
+| pgpool-II | Connection pooling + load balancing + replication | Overkill for most SW deployments; useful if you need query-level read/write splitting |
+| Application-side pooling (SQLAlchemy pool, Django CONN_MAX_AGE) | No external component | Sufficient for small deployments; doesn't help with cross-service connection sharing |
+
+**Default-safe recommendation:** PgBouncer in transaction mode for Django/Celery traffic. Spark and Dagster typically open fewer, longer-lived connections — route them directly to PostgreSQL (or through a separate PgBouncer instance in session mode) to avoid prepared-statement conflicts.
+
+**Implementation pointer:** PgBouncer deployment lives in your infrastructure repo. SW's Django settings use standard `DATABASES` configuration; point `HOST` at PgBouncer instead of directly at PostgreSQL.
+
+---
+
+## 4. Partitioning Strategy
+
+**Decision:** When and how to partition large fact tables and transaction tables in the PostGIS star schema.
+
+**Triggers:**
+- A single table exceeds ~100M rows or ~50 GB (query planning overhead becomes measurable)
+- Sequential scans on fact tables dominate query time despite indexes
+- Bulk loads (Spark→PostGIS materialization) contend with read queries on the same table
+- You need to drop or archive old data without `DELETE` + `VACUUM` overhead
+
+**Options:**
+
+| Strategy | Partition key | Fits |
+|----------|---------------|------|
+| Range by time dimension | `vintage_year`, `effective_year`, `created_at` | Good default for most fact tables; aligns with how data arrives and ages |
+| Range by domain-specific key | A domain FK that represents natural lifecycle boundaries | Good when your domain has a clear lifecycle concept (e.g., legislative sessions, fiscal years) |
+| List by jurisdiction | `state_fips` or equivalent | Good for multi-state deployments where queries are almost always state-scoped |
+| Composite (range + list) | Two-level: jurisdiction × time | Maximum partition pruning; operational complexity of managing the partition matrix |
+
+**Default-safe recommendation:** Start without partitioning — PostgreSQL handles large tables well with proper indexes. When a specific table hits the triggers above, partition by the dimension that most closely matches your query patterns (usually time-based). Add jurisdiction sub-partitioning only if your queries are consistently state-scoped and the partition count stays manageable (rule of thumb: under 500 partitions per table).
+
+**Implementation pointer:** Partitioning is a PostgreSQL DDL concern. Implement via Django migrations (using `RunSQL` for `CREATE TABLE ... PARTITION BY`) or raw SQL in your infrastructure provisioning. SW's Django models don't need to change — Django 5.x works transparently with partitioned tables.
+
+---
+
+## 5. Cold-Tier and Columnar Storage
+
+**Decision:** What happens to historical data that's rarely queried but must remain accessible?
+
+**Triggers:**
+- Historical partitions consume significant storage but see <1% of queries
+- Storage costs on fast SSDs become meaningful relative to the value of instant access to old data
+- You need to retain data for compliance but queries against it are rare and can tolerate latency
+
+**Options:**
+
+| Approach | Latency | Storage cost | Complexity |
+|----------|---------|--------------|------------|
+| Keep everything on the primary (do nothing) | Instant | Full SSD cost | None |
+| Columnar extension (hydra_columnar, Citus columnar) | Sub-second (still in PostgreSQL) | 3-10× compression | Medium — need to manage columnar access methods per table |
+| Detach partition + move to cheaper storage class | Seconds (re-attach on demand) | Reduced (HDD/object store) | Medium — operational runbook for detach/attach |
+| Archive to Delta Lake on object storage | Minutes (query via Spark) | Lowest (S3/GCS lifecycle policies) | Low — data is already in Delta format in the warehouse's bronze/silver tiers |
+
+**Default-safe recommendation:** The simplest path for SW adopters: historical data that's past your active query window already exists in Delta Lake (tier 1 of the warehouse). Stop materializing it to PostGIS. PostGIS holds the hot window; Delta holds everything. When you need historical data, query it via Spark. No columnar extensions, no partition gymnastics — just stop pushing old data into the serving tier.
+
+**Implementation pointer:** Adjust your Dagster asset graph or materialization jobs to only materialize recent data into PostGIS. The Delta tables remain the source of truth for historical queries.
+
+---
+
+## 6. Hub-to-Downstream Distribution
+
+**Decision:** How do downstream consumers (web app, analytical databases, search indexes, graph databases) get data from the PostGIS warehouse hub without querying the primary directly?
+
+**Triggers:**
+- Read traffic from the web app competes with Spark materialization writes
+- You're adding consumers (OpenSearch for full-text, Neo4j for graph queries, BI tools) that shouldn't touch the primary
+- You need per-consumer data subsets (e.g., one engagement gets one state's data)
+
+**Options:**
+
+| Pattern | Freshness | Complexity | Fits |
+|---------|-----------|------------|------|
+| Read replica (streaming replication) | Near-real-time | Low | Django reads; point `DATABASES['readonly']` at the replica |
+| Logical replication / filtered publications | Near-real-time, subset-able | Medium | Per-consumer slices; e.g., publish only `sw_geo` tables to the web-app DB |
+| `pg_dump` by partition / table | Batch (scheduled) | Low | Per-engagement analytical snapshots; cold handoffs |
+| Debezium CDC → Kafka → consumers | Real-time, event-driven | High | When you need event-driven downstream updates (search index, graph sync) |
+| Direct Delta Lake reads | Batch (already available) | None | Consumers that can read Parquet/Delta directly (BI tools, notebooks, Spark jobs) |
+
+**Default-safe recommendation:** Start with a streaming read replica for Django and API traffic (`DATABASES['readonly']`). For non-PostgreSQL consumers (search, graph, BI), read from Delta Lake directly — the data is already there in a format optimized for analytical access. Logical replication and CDC are powerful but operationally expensive; defer until you have a concrete freshness requirement that batch can't meet.
+
+**Implementation pointer:** Read replica setup is part of your HA topology (see §1). Django database routing is a settings change (`DATABASE_ROUTERS`). Delta Lake access is already built into SW's architecture.
+
+---
+
+## 7. Metadata Store Isolation
+
+**Decision:** Should catalog/metadata infrastructure (Unity Catalog, Hive Metastore, or equivalent) share the same PostgreSQL instance as the warehouse data?
+
+**Triggers:**
+- You're running a Spark-based catalog (Unity Catalog, Hive Metastore) that uses PostgreSQL as its backing store
+- A bad migration or schema corruption in one system could affect the other
+- You want independent backup/restore and lifecycle management for metadata vs. data
+
+**Options:**
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Shared PostgreSQL instance, separate databases | Simple; one PostgreSQL to manage | Coupled blast radius; backup/restore is all-or-nothing at the instance level |
+| Separate PostgreSQL instances | Independent lifecycle, backup, scaling | Two PostgreSQL deployments to operate |
+| Managed metadata service (e.g., AWS Glue, Databricks-hosted UC) | Zero operational burden for metadata | Vendor coupling; may limit Spark/Sedona version choices |
+
+**Default-safe recommendation:** Start with separate databases on the same PostgreSQL instance (low overhead). If you find that metadata operations (catalog queries, schema evolution) interfere with warehouse queries, or if you need independent backup/restore schedules, split to a separate PostgreSQL instance. The cost of splitting later is low — metadata stores are small and easy to `pg_dump`/`pg_restore`.
+
+**Implementation pointer:** Catalog configuration lives in your Spark/Sedona configuration (`spark.sql.catalog.*` properties) and your infrastructure provisioning. SW's `docker-compose.yml` runs a single PostGIS instance for dev convenience; production topology is the adopter's decision.
+
+---
+
+## 8. Scheduling and Node Placement
+
+**Decision:** What kind of compute node should the PostgreSQL pod run on, and how do you prevent it from competing with Spark/Dagster workloads for resources?
+
+**Triggers:**
+- Spark executors or Dagster ops consume memory/CPU on the same node as PostgreSQL
+- WAL write latency spikes during Spark job execution
+- You're running on Kubernetes and need to declare resource requests/limits
+
+**Options:**
+
+| Concern | Recommendation |
+|---------|----------------|
+| Node type | PostgreSQL benefits from fast local storage (NVMe SSDs) and consistent memory. Don't co-locate with Spark workers, which are CPU/memory-hungry and bursty. |
+| Storage class | Use a storage class backed by local SSDs or provisioned IOPS (e.g., `gp3` on AWS, `pd-ssd` on GCP). Network-attached storage (EBS `gp2`, standard PDs) adds latency to WAL writes. |
+| Node affinity | Label dedicated database nodes (e.g., `role=database`) and use `nodeAffinity` to pin PostgreSQL pods. Use taints to prevent Spark/Dagster from scheduling on database nodes. |
+| Resource requests | Request enough memory for `shared_buffers` + `work_mem` × expected parallel queries + OS cache. PostgreSQL is memory-hungry but predictable; size generously and don't overcommit. |
+
+**Default-safe recommendation:** Dedicate at least one node (or node group) to PostgreSQL with local SSD storage and a taint that excludes non-database workloads. Spark and Dagster get their own node pool. This prevents the most common production issue: Spark consuming all available memory on a shared node, causing PostgreSQL to OOM or swap.
+
+**Implementation pointer:** Node pools, taints, affinities, and storage classes are Kubernetes infrastructure concerns. Configure in your cluster provisioning (Terraform, eksctl, GKE config) and reference in your PostgreSQL deployment manifests.
+
+---
+
+## 9. Index Hygiene
+
+**Decision:** How do you detect and manage unused, duplicate, and bloated indexes before they dominate storage and slow down writes?
+
+**Triggers:**
+- Index storage exceeds table data storage (visible in `pg_stat_user_tables`)
+- Write-heavy operations (bulk loads, Spark materializations) are slower than expected
+- `pg_stat_user_indexes` shows indexes with zero or near-zero `idx_scan` counts over a multi-week window
+- You've accumulated indexes from development/experimentation that production queries don't use
+
+**Audit process:**
+
+```sql
+-- Find unused indexes (zero scans since last stats reset).
+-- Run this AFTER your database has been serving production traffic
+-- for at least 2 weeks. Dev-only indexes will show zero scans.
+SELECT
+    schemaname, tablename, indexname,
+    idx_scan,
+    pg_size_pretty(pg_relation_size(indexrelid)) AS index_size
+FROM pg_stat_user_indexes
+WHERE idx_scan = 0
+  AND indexrelid NOT IN (
+      SELECT conindid FROM pg_constraint
+      WHERE contype IN ('p', 'u')  -- skip primary keys and unique constraints
+  )
+ORDER BY pg_relation_size(indexrelid) DESC;
+
+-- Find duplicate indexes (same columns, same order).
+SELECT
+    a.indexrelid::regclass AS index_a,
+    b.indexrelid::regclass AS index_b,
+    pg_size_pretty(pg_relation_size(a.indexrelid)) AS size_a
+FROM pg_index a
+JOIN pg_index b ON a.indrelid = b.indrelid
+    AND a.indexrelid < b.indexrelid
+    AND a.indkey::text = b.indkey::text
+WHERE a.indrelid::regclass::text NOT LIKE 'pg_%';
+```
+
+**Default-safe recommendation:** Run the unused-index audit quarterly. Before dropping any index:
+1. Confirm zero scans over a representative traffic window (not just overnight)
+2. Check that no index is required by a unique or foreign key constraint
+3. Drop with `CONCURRENTLY` to avoid locking the table
+4. Monitor query performance for 48 hours after dropping
+
+For bloated indexes, `REINDEX CONCURRENTLY` is safe in PostgreSQL 14+ and doesn't lock the table.
+
+**Implementation pointer:** Index auditing is an operational runbook in your team's playbook. Consider scheduling the audit query as a Dagster sensor or cron job that alerts when unused index storage exceeds a threshold.
+
+---
+
+## 10. Scale Targets and Tier Triggers
+
+**Decision:** At what thresholds should you move from one operational tier to the next?
+
+These are guidelines, not bright lines — your specific query patterns, hardware, and latency requirements will shift them. The goal is to give adopters a rough map so they can plan ahead rather than react to outages.
+
+| Signal | Threshold (approximate) | Action |
+|--------|------------------------|--------|
+| Database size | > 50 GB | Enable WAL archiving and automated backups if not already (§2) |
+| Database size | > 200 GB | Evaluate partitioning for largest tables (§4); consider connection pooling (§3) |
+| Database size | > 1 TB | HA topology is strongly recommended (§1); cold-tier strategy needed (§5) |
+| Connection count | > 80% of `max_connections` | Deploy PgBouncer (§3) or increase `max_connections` (but prefer pooling) |
+| Write contention | Materialization jobs visibly slow down read queries | Read replica for Django/API traffic (§6); dedicated database node (§8) |
+| Index storage | > 50% of table data storage | Run index hygiene audit (§9) |
+| WAL generation rate | > 1 GB/hour sustained | Ensure WAL archive target can keep up; evaluate whether bulk loads should use `COPY` with `wal_level=minimal` in a maintenance window |
+| Restore time | > RTO | More frequent base backups; consider CNPG with continuous archiving (§1, §2) |
+| Historical partitions | Queried < 1% of the time | Stop materializing to PostGIS; query via Delta Lake (§5) |
+
+**Default-safe recommendation:** Most SW adopters will operate comfortably in the sub-200 GB range for months or years. The single-node `docker-compose.yml` setup handles this well. Start planning for the next tier when you consistently see two or more of the signals above. The cheapest intervention is almost always "stop putting old data in PostGIS" (§5) — it reduces database size, index bloat, and write contention simultaneously.
+
+---
+
+## Further Reading
+
+- [`docs/architecture.md`](architecture.md) — three-tier warehouse pattern, design-order constraints
+- [`docs/quickstart.md`](quickstart.md) — single-node dev setup
+- [`docs/orchestration/`](orchestration/) — Dagster asset graphs, scheduling, how-to-operate
+- [`docs/warehouse-schema-evolution.md`](warehouse-schema-evolution.md) — schema migration playbook

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -153,6 +153,7 @@ You've got:
 - **Add an ingest path for a data source we don't ship.** Use D/E/F's existing patterns as the template — each domain's `services/` and `management/commands/` directories show the shape.
 - **Bring your own boundary types.** SU's `geo.django.models.*` is the upstream home for new boundary models; SW adds the `{type}_geoid` cache field on Address + ABP.
 - **Cron a TIGER vintage refresh.** SU ships `siege_utilities.geo.providers.CensusTIGERProvider.list_available_vintages()` and `siege_utilities.geo.census.tiger_state.check_for_updates(state_file)` for "is a new TIGER vintage published?" checks. Wire those into your scheduler; on a "yes," call `CensusTIGERProvider.get_boundary(...)` for the levels you want. (SW used to ship `scripts/fetch_census_tiger.py` for this; deleted in favor of the SU helpers.)
+- **Plan for production scale.** When your database outgrows the single-node dev setup, see [`docs/production-operations.md`](production-operations.md) for the operational decisions you'll need to make — HA topology, backup, connection pooling, partitioning, and more.
 
 ## Fork-and-rename ergonomics
 


### PR DESCRIPTION
## Summary

- Adds `docs/production-operations.md` — a 10-section decision guide for adopters who outgrow the single-node defaults
- Updates CLAUDE.md with reference + instructions for agents working on adopter deployments
- Adds "Plan for production scale" link in quickstart's "What's next"

Covers: HA topology, backup/PITR, connection pooling, partitioning, cold-tier storage, hub-to-downstream distribution, metadata isolation, node placement, index hygiene, scale triggers.

Each section follows: Decision → Triggers → Options with trade-offs → Default-safe recommendation → Implementation pointer (adopter's infra repo).

Closes #309

## Test plan

- [ ] Verify all internal doc links resolve
- [ ] Verify CLAUDE.md reference is accurate
- [ ] Verify quickstart link works
- [ ] Review for electinfo-specific language (should be generic template guidance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a self-review checklist for the production operations guide, including role declarations, stated assumptions, scope guardrails, and peer and lead review confirmation items.
  * Added a Production Operations section to contributor documentation, directing contributors to reference the production operations guide when working on adopter production deployments, covering key operational decision areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->