### PR TITLE
feat(sw_geo): add tribal_area and county_subdivision GEOID fields

### DIFF
--- a/.self-review-sw305-abp-boundary-fields.md
+++ b/.self-review-sw305-abp-boundary-fields.md
@@ -1,0 +1,36 @@
+## Self-Review: tribal_area + county_subdivision GEOID fields (SW#305)
+
+### Role declarations
+- Author: AI agent
+- Reviewer: AI agent (self-review)
+
+Working as: software engineer
+
+## Assumptions
+
+Goal source: SW#305 — add tribal_area_geoid and county_subdivision_geoid to AddressBoundaryPeriod and Address models, following SU PR #553 which added TribalArea and CountySubdivision to siege_geo.
+
+- ABP GEOID fields use `null=True, blank=True` (verified: lines 75-105 of address_boundary.py)
+- Address GEOID fields use `blank=True, default=""` (verified: lines 174-254 of address.py)
+- SU CensusTIGERBoundary.geoid uses max_length=20 (verified: line 182-186 of SU base.py)
+- Next migration number is 0010 (verified: 0009 is the latest existing migration)
+- Address._BOUNDARY_TYPES must include the new types for F11 helpers to cover them
+
+## Peer review
+
+writing-code:1 — both models follow their respective existing GEOID field patterns exactly. ABP: `CharField(max_length=20, null=True, blank=True)`. Address: `CharField(max_length=20, blank=True, default="", help_text=...)`.
+
+writing-code:2 — migration follows the established pattern from 0007 (medium-priority batch): _NEW_TYPES list, separate AddField operations for Address (blank+default) vs ABP (blank+null).
+
+writing-claims:1 — max_length=20 matches SU CensusTIGERBoundary.geoid. Field placement follows the existing grouping (after medium-priority batch, before siege_geo ForeignKeys on ABP; after medium-priority batch, before census_units_assigned_at on Address).
+
+## Lead review
+
+- [x] AddressBoundaryPeriod gains tribal_area_geoid and county_subdivision_geoid
+- [x] Address gains tribal_area_geoid and county_subdivision_geoid
+- [x] Address._BOUNDARY_TYPES includes "tribal_area" and "county_subdivision"
+- [x] Migration 0010 depends on 0009, follows existing _NEW_TYPES pattern
+- [x] Field conventions match existing patterns per model
+- [x] max_length=20 matches upstream SU CensusTIGERBoundary.geoid
+- [x] No AI attribution in any file
+- [x] Commit references SW#305

--- a/socialwarehouse/geo/migrations/0010_tribal_area_county_subdivision_geoids.py
+++ b/socialwarehouse/geo/migrations/0010_tribal_area_county_subdivision_geoids.py
@@ -1,0 +1,43 @@
+"""SW#305: add tribal_area_geoid and county_subdivision_geoid cache fields
+on Address and AddressBoundaryPeriod.
+
+Upstream siege_utilities models (TribalArea, CountySubdivision) were added
+in SU PR #553. These cache fields mirror the upstream geoid convention
+(max_length=20, matching CensusTIGERBoundary.geoid).
+"""
+
+from django.db import migrations, models
+
+
+_NEW_TYPES = [
+    ("tribal_area_geoid", 20),
+    ("county_subdivision_geoid", 20),
+]
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_geo", "0009_precinct_vtd_intersection"),
+    ]
+
+    operations = [
+        # Address: blank-default CharFields.
+        *[
+            migrations.AddField(
+                model_name="address",
+                name=field_name,
+                field=models.CharField(blank=True, default="", max_length=max_len),
+            )
+            for (field_name, max_len) in _NEW_TYPES
+        ],
+        # AddressBoundaryPeriod: nullable CharFields (matches existing ABP convention).
+        *[
+            migrations.AddField(
+                model_name="addressboundaryperiod",
+                name=field_name,
+                field=models.CharField(blank=True, max_length=max_len, null=True),
+            )
+            for (field_name, max_len) in _NEW_TYPES
+        ],
+    ]

--- a/socialwarehouse/geo/models/address.py
+++ b/socialwarehouse/geo/models/address.py
@@ -253,6 +253,17 @@ class Address(models.Model):
         ),
     )
 
+    # SW#305: tribal area and county subdivision boundary types.
+    # Upstream models added in SU PR #553.
+    tribal_area_geoid = models.CharField(
+        max_length=20, blank=True, default="",
+        help_text="American Indian/Alaska Native/Native Hawaiian Area GEOID.",
+    )
+    county_subdivision_geoid = models.CharField(
+        max_length=20, blank=True, default="",
+        help_text="County Subdivision (township, borough, etc.) GEOID.",
+    )
+
     census_units_assigned_at = models.DateTimeField(null=True, blank=True)
 
     # ── Address construction timeline (TIGER ADDRFEAT) ──────────────────
@@ -420,6 +431,8 @@ class Address(models.Model):
         "fire_district", "water_district", "hospital_district",
         "library_district", "cemetery_district", "mosquito_district",
         "other_special_district",
+        # SW#305: tribal area and county subdivision (SU PR #553)
+        "tribal_area", "county_subdivision",
     )
 
     # SW#198: boundary types that are subject to redistricting, mapped

--- a/socialwarehouse/geo/models/address_boundary.py
+++ b/socialwarehouse/geo/models/address_boundary.py
@@ -104,6 +104,11 @@ class AddressBoundaryPeriod(models.Model):
     mosquito_district_geoid = models.CharField(max_length=10, null=True, blank=True)
     other_special_district_geoid = models.CharField(max_length=10, null=True, blank=True)
 
+    # SW#305: tribal area and county subdivision boundary types.
+    # Upstream models added in SU PR #553.
+    tribal_area_geoid = models.CharField(max_length=20, null=True, blank=True)
+    county_subdivision_geoid = models.CharField(max_length=20, null=True, blank=True)
+
     # siege_geo ForeignKeys (optional, for rich queries)
     siege_state = models.ForeignKey(
         "siege_geo.State", on_delete=models.SET_NULL,


### PR DESCRIPTION
## Summary

- Adds `tribal_area_geoid` and `county_subdivision_geoid` cache fields to **AddressBoundaryPeriod** (nullable) and **Address** (blank+default)
- Updates `Address._BOUNDARY_TYPES` so F11 helpers (boundary_history, boundaries_on, boundary_timeline) cover the new types
- Migration 0010 follows the established `_NEW_TYPES` pattern from 0007

Upstream: SU PR #553 added TribalArea and CountySubdivision models to siege_geo.

Closes SW#305

## Test plan

- [ ] Migration applies cleanly: `python manage.py migrate sw_geo`
- [ ] Migration rolls back cleanly: `python manage.py migrate sw_geo 0009`
- [ ] `Address._BOUNDARY_TYPES` includes `"tribal_area"` and `"county_subdivision"`
- [ ] `addr.boundary_history(boundary_type="tribal_area")` does not raise
- [ ] Fields match existing GEOID conventions per model

Self-Review: `.self-review-sw305-abp-boundary-fields.md`