### PR TITLE
fix: scrub internal project name from public content

### DIFF
--- a/.self-review-v230-promote.md
+++ b/.self-review-v230-promote.md
@@ -14,7 +14,7 @@ Goal source: User directive "Yes" to proceed with v2.3.0 promotion after develop
 - Version bumped from 2.2.1-dev to 2.3.0 in pyproject.toml and socialwarehouse/__init__.py
 - All 511 tests passing on CI (per A-9 PR #304)
 - No breaking changes to existing APIs — all ontology models and endpoints are additive
-- Downstream consumers (Reverberator) are aware via cross-agent message
+- Downstream consumers are aware via cross-agent message
 
 ## Peer review
 

--- a/swh/__init__.py
+++ b/swh/__init__.py
@@ -8,7 +8,6 @@ geospatial datasets.
 Architecture:
     Social Warehouse = infrastructure (Docker containers: PostGIS, Spark, Sedona)
     siege_utilities  = the "verbs" that populate the warehouse
-    reverberator     = a second set of "verbs" that analyze the data
 """
 
 __version__ = "1.0.0"

--- a/swh/voters/_legacy_raw.py
+++ b/swh/voters/_legacy_raw.py
@@ -326,7 +326,7 @@ def voter_file_to_geodataframe(
 ) -> gpd.GeoDataFrame:
     """Read a voter file CSV into a GeoDataFrame (in-memory, no PostGIS).
 
-    Useful for Tier 3 (GeoPandas-only) processing in Reverberator.
+    Useful for Tier 3 (GeoPandas-only) processing in downstream consumers.
 
     Args:
         filepath: Path to the voter file CSV.


### PR DESCRIPTION
## Summary

- Removes references to an internal Siege Analytics project that has no formal public relationship to SocialWarehouse
- Replaces with generic language ("downstream consumers", "internal tooling") in 3 files:
  - `.self-review-v230-promote.md` — removed parenthetical project name
  - `swh/__init__.py` — removed architecture docstring line naming the project
  - `swh/voters/_legacy_raw.py` — replaced project name with "downstream consumers"

## Test plan

- [x] `rg -i` confirms no remaining references on this branch
- [ ] Verify no references in GitHub issue/PR comments (separate from code)