### PR TITLE
feat(#328): declarative range partitioning for fact tables

### DIFF
--- a/docs/production-operations.md
+++ b/docs/production-operations.md
@@ -133,7 +133,43 @@ To apply: mount a custom `postgresql.conf` via Docker volume or pass parameters 
 
 **Default-safe recommendation:** Start without partitioning — PostgreSQL handles large tables well with proper indexes. When a specific table hits the triggers above, partition by the dimension that most closely matches your query patterns (usually time-based). Add jurisdiction sub-partitioning only if your queries are consistently state-scoped and the partition count stays manageable (rule of thumb: under 500 partitions per table).
 
-**Implementation pointer:** Partitioning is a PostgreSQL DDL concern. Implement via Django migrations (using `RunSQL` for `CREATE TABLE ... PARTITION BY`) or raw SQL in your infrastructure provisioning. SW's Django models don't need to change — Django 5.x works transparently with partitioned tables.
+**Implementation:** SW ships migration `0006_partition_fact_tables` which partitions three high-volume tables:
+
+| Table | Partition Key | Range |
+|---|---|---|
+| `sw_fact_redistricting_plan` | `cycle_id` | Per redistricting cycle (10-year) |
+| `sw_fact_vote_history` | `election_date` | Per calendar year (2016-2026) |
+| `sw_fact_person_score` | `scored_at` | Per calendar year (2020-2027) |
+
+Each table gets a `DEFAULT` partition as a safety net. Future partitions can be created manually or via pg_partman.
+
+**pg_partman setup (production):**
+
+```sql
+CREATE EXTENSION pg_partman;
+
+SELECT partman.create_parent(
+    p_parent_table := 'public.sw_fact_vote_history',
+    p_control := 'election_date',
+    p_type := 'range',
+    p_interval := '1 year',
+    p_premake := 2
+);
+```
+
+This auto-creates partitions 2 years ahead. Run `partman.run_maintenance()` on a schedule (daily cron or Dagster sensor) to create forward partitions and optionally detach old ones.
+
+**Adding partitions manually (without pg_partman):**
+
+```sql
+CREATE TABLE sw_fact_vote_history_2027
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2027-01-01') TO ('2028-01-01');
+```
+
+**Non-FEC adopters:** The cycle concept is domain-specific. Electoral warehouses use redistricting cycles; fiscal warehouses might use fiscal years; environmental warehouses might use monitoring periods. The partition key should match your domain's natural lifecycle boundary. Update the migration's partition ranges to match your domain.
+
+**Not yet partitioned:** FactACSEstimate, FactDecennialCount, FactUrbanicity, FactElectionResult, FactPrecinctResult. These can be partitioned when they hit the triggers above — follow the same `RunSQL` migration pattern.
 
 ---
 

--- a/socialwarehouse/warehouse/migrations/0006_partition_fact_tables.py
+++ b/socialwarehouse/warehouse/migrations/0006_partition_fact_tables.py
@@ -1,0 +1,237 @@
+"""Declarative range partitioning for high-volume fact tables (#328).
+
+Partitions three tables:
+- sw_fact_redistricting_plan: by cycle_id (FK to DimRedistrictingCycle)
+- sw_fact_vote_history: by election_date (per year)
+- sw_fact_person_score: by scored_at (per year)
+
+Forward-only: creates partitioned tables, migrates data from
+originals, drops originals, renames partitioned tables into place.
+Each table gets a default partition as a safety net for data outside
+defined ranges.
+
+pg_partman for automatic forward partition creation is a production
+add-on documented in docs/production-operations.md section 4.
+"""
+
+from django.db import migrations
+
+
+PARTITION_REDISTRICTING_PLAN = """
+-- Step 1: Rename original table
+ALTER TABLE sw_fact_redistricting_plan RENAME TO sw_fact_redistricting_plan_old;
+
+-- Step 2: Create partitioned table with same schema
+CREATE TABLE sw_fact_redistricting_plan (
+    id bigserial,
+    geography_id bigint NOT NULL REFERENCES sw_dim_geography(id) ON DELETE CASCADE,
+    cycle_id bigint NOT NULL REFERENCES sw_dim_redistricting_cycle(id) ON DELETE CASCADE,
+    chamber varchar(16) NOT NULL,
+    plan_type varchar(32) NOT NULL,
+    district_number varchar(8) NOT NULL,
+    total_population bigint,
+    vap bigint,
+    cvap bigint,
+    deviation_pct double precision,
+    polsby_popper double precision,
+    reock double precision,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (id, cycle_id),
+    UNIQUE (geography_id, cycle_id, chamber, plan_type, district_number)
+) PARTITION BY RANGE (cycle_id);
+
+-- Step 3: Default partition (catches anything outside defined ranges)
+CREATE TABLE sw_fact_redistricting_plan_default
+    PARTITION OF sw_fact_redistricting_plan DEFAULT;
+
+-- Step 4: Migrate data
+INSERT INTO sw_fact_redistricting_plan
+    (id, geography_id, cycle_id, chamber, plan_type, district_number,
+     total_population, vap, cvap, deviation_pct, polsby_popper, reock, created_at)
+SELECT id, geography_id, cycle_id, chamber, plan_type, district_number,
+       total_population, vap, cvap, deviation_pct, polsby_popper, reock, created_at
+FROM sw_fact_redistricting_plan_old;
+
+-- Step 5: Update sequence
+SELECT setval(
+    pg_get_serial_sequence('sw_fact_redistricting_plan', 'id'),
+    COALESCE((SELECT MAX(id) FROM sw_fact_redistricting_plan), 0) + 1,
+    false
+);
+
+-- Step 6: Drop old table
+DROP TABLE sw_fact_redistricting_plan_old;
+"""
+
+PARTITION_VOTE_HISTORY = """
+ALTER TABLE sw_fact_vote_history RENAME TO sw_fact_vote_history_old;
+
+CREATE TABLE sw_fact_vote_history (
+    id bigserial,
+    person_id bigint NOT NULL REFERENCES sw_dim_person(id) ON DELETE CASCADE,
+    election_date date NOT NULL,
+    election_type varchar(16) NOT NULL,
+    voted_method varchar(16) NOT NULL DEFAULT 'unknown',
+    source_vendor varchar(16) NOT NULL,
+    loaded_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (id, election_date),
+    UNIQUE (person_id, election_date, election_type, source_vendor)
+) PARTITION BY RANGE (election_date);
+
+CREATE TABLE sw_fact_vote_history_default
+    PARTITION OF sw_fact_vote_history DEFAULT;
+
+-- Initial partitions: 2016-2026 (two full cycles)
+CREATE TABLE sw_fact_vote_history_2016
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2016-01-01') TO ('2017-01-01');
+CREATE TABLE sw_fact_vote_history_2017
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2017-01-01') TO ('2018-01-01');
+CREATE TABLE sw_fact_vote_history_2018
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2018-01-01') TO ('2019-01-01');
+CREATE TABLE sw_fact_vote_history_2019
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2019-01-01') TO ('2020-01-01');
+CREATE TABLE sw_fact_vote_history_2020
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+CREATE TABLE sw_fact_vote_history_2021
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+CREATE TABLE sw_fact_vote_history_2022
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2022-01-01') TO ('2023-01-01');
+CREATE TABLE sw_fact_vote_history_2023
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2023-01-01') TO ('2024-01-01');
+CREATE TABLE sw_fact_vote_history_2024
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+CREATE TABLE sw_fact_vote_history_2025
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+CREATE TABLE sw_fact_vote_history_2026
+    PARTITION OF sw_fact_vote_history
+    FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+
+INSERT INTO sw_fact_vote_history
+    (id, person_id, election_date, election_type, voted_method, source_vendor, loaded_at)
+SELECT id, person_id, election_date, election_type, voted_method, source_vendor, loaded_at
+FROM sw_fact_vote_history_old;
+
+SELECT setval(
+    pg_get_serial_sequence('sw_fact_vote_history', 'id'),
+    COALESCE((SELECT MAX(id) FROM sw_fact_vote_history), 0) + 1,
+    false
+);
+
+DROP TABLE sw_fact_vote_history_old;
+"""
+
+PARTITION_PERSON_SCORE = """
+ALTER TABLE sw_fact_person_score RENAME TO sw_fact_person_score_old;
+
+CREATE TABLE sw_fact_person_score (
+    id bigserial,
+    person_id bigint NOT NULL REFERENCES sw_dim_person(id) ON DELETE CASCADE,
+    score_type varchar(128) NOT NULL,
+    value double precision NOT NULL,
+    source_vendor varchar(16) NOT NULL,
+    methodology_version varchar(64) NOT NULL DEFAULT '',
+    scored_at timestamptz NOT NULL,
+    loaded_at timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (id, scored_at),
+    UNIQUE (person_id, score_type, source_vendor, methodology_version)
+) PARTITION BY RANGE (scored_at);
+
+CREATE TABLE sw_fact_person_score_default
+    PARTITION OF sw_fact_person_score DEFAULT;
+
+-- Initial partitions: 2020-2027
+CREATE TABLE sw_fact_person_score_2020
+    PARTITION OF sw_fact_person_score
+    FOR VALUES FROM ('2020-01-01') TO ('2021-01-01');
+CREATE TABLE sw_fact_person_score_2021
+    PARTITION OF sw_fact_person_score
+    FOR VALUES FROM ('2021-01-01') TO ('2022-01-01');
+CREATE TABLE sw_fact_person_score_2022
+    PARTITION OF sw_fact_person_score
+    FOR VALUES FROM ('2022-01-01') TO ('2023-01-01');
+CREATE TABLE sw_fact_person_score_2023
+    PARTITION OF sw_fact_person_score
+    FOR VALUES FROM ('2023-01-01') TO ('2024-01-01');
+CREATE TABLE sw_fact_person_score_2024
+    PARTITION OF sw_fact_person_score
+    FOR VALUES FROM ('2024-01-01') TO ('2025-01-01');
+CREATE TABLE sw_fact_person_score_2025
+    PARTITION OF sw_fact_person_score
+    FOR VALUES FROM ('2025-01-01') TO ('2026-01-01');
+CREATE TABLE sw_fact_person_score_2026
+    PARTITION OF sw_fact_person_score
+    FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+CREATE TABLE sw_fact_person_score_2027
+    PARTITION OF sw_fact_person_score
+    FOR VALUES FROM ('2027-01-01') TO ('2028-01-01');
+
+INSERT INTO sw_fact_person_score
+    (id, person_id, score_type, value, source_vendor, methodology_version, scored_at, loaded_at)
+SELECT id, person_id, score_type, value, source_vendor, methodology_version, scored_at, loaded_at
+FROM sw_fact_person_score_old;
+
+SELECT setval(
+    pg_get_serial_sequence('sw_fact_person_score', 'id'),
+    COALESCE((SELECT MAX(id) FROM sw_fact_person_score), 0) + 1,
+    false
+);
+
+DROP TABLE sw_fact_person_score_old;
+"""
+
+# Reverse: recreate non-partitioned tables from partitioned ones
+REVERSE_REDISTRICTING = """
+CREATE TABLE sw_fact_redistricting_plan_flat AS
+    SELECT * FROM sw_fact_redistricting_plan;
+DROP TABLE sw_fact_redistricting_plan CASCADE;
+ALTER TABLE sw_fact_redistricting_plan_flat RENAME TO sw_fact_redistricting_plan;
+ALTER TABLE sw_fact_redistricting_plan ADD PRIMARY KEY (id);
+"""
+
+REVERSE_VOTE_HISTORY = """
+CREATE TABLE sw_fact_vote_history_flat AS
+    SELECT * FROM sw_fact_vote_history;
+DROP TABLE sw_fact_vote_history CASCADE;
+ALTER TABLE sw_fact_vote_history_flat RENAME TO sw_fact_vote_history;
+ALTER TABLE sw_fact_vote_history ADD PRIMARY KEY (id);
+"""
+
+REVERSE_PERSON_SCORE = """
+CREATE TABLE sw_fact_person_score_flat AS
+    SELECT * FROM sw_fact_person_score;
+DROP TABLE sw_fact_person_score CASCADE;
+ALTER TABLE sw_fact_person_score_flat RENAME TO sw_fact_person_score;
+ALTER TABLE sw_fact_person_score ADD PRIMARY KEY (id);
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("warehouse", "0005_fact_electoral_contest_fk"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=PARTITION_REDISTRICTING_PLAN,
+            reverse_sql=REVERSE_REDISTRICTING,
+        ),
+        migrations.RunSQL(
+            sql=PARTITION_VOTE_HISTORY,
+            reverse_sql=REVERSE_VOTE_HISTORY,
+        ),
+        migrations.RunSQL(
+            sql=PARTITION_PERSON_SCORE,
+            reverse_sql=REVERSE_PERSON_SCORE,
+        ),
+    ]


### PR DESCRIPTION
Closes #328
Parent epic: #325

## Summary

- Ships migration `0006_partition_fact_tables` converting 3 high-volume fact tables to PostgreSQL declarative range partitioning
- Updates production-operations.md section 4 with implementation details + pg_partman guide

## Partitioned tables

| Table | Key | Partitions |
|---|---|---|
| sw_fact_redistricting_plan | cycle_id | Default only (cycles created dynamically) |
| sw_fact_vote_history | election_date | 2016-2026 yearly + default |
| sw_fact_person_score | scored_at | 2020-2027 yearly + default |

## Migration safety

- Forward-only RunSQL with reverse_sql for rollback
- Default partition catches data outside defined ranges
- Django ORM reads transparently from partitioned tables
- Sequence continuity preserved via setval()

## Test plan

- [ ] `python manage.py migrate warehouse 0006` succeeds on empty DB
- [ ] `python manage.py migrate warehouse 0005` reverse migration works
- [ ] Django ORM queries (filter, aggregate) work unchanged on partitioned tables
- [ ] COPY operations through PostGISResource.raw_connection() work
- [ ] pg_partman setup instructions work on a test instance