### PR TITLE
feat(#331): warehouse observability as Dagster assets

### DIFF
--- a/docs/production-operations.md
+++ b/docs/production-operations.md
@@ -343,6 +343,54 @@ These are guidelines, not bright lines — your specific query patterns, hardwar
 
 ---
 
+## 11. Warehouse Observability
+
+**Decision:** How do you monitor materialization health, replication lag, and cross-tier parity?
+
+**Triggers:**
+- Materialization jobs complete but produce row-count mismatches between Delta Lake and PostGIS
+- Logical replication slots fall behind, causing stale downstream data
+- You need an audit trail of what was materialized, when, and whether it matched
+
+**Implementation:** SW ships three monitoring models in `warehouse/models/monitoring.py`:
+
+| Model | Table | Purpose |
+|---|---|---|
+| `MaterializationRecord` | `sw_monitoring_materialization` | Per-asset parity record after each PostGIS materialization |
+| `ReplicationLagSnapshot` | `sw_monitoring_replication_lag` | Periodic capture of logical replication slot lag |
+| `ParityCheck` | `sw_monitoring_parity_check` | Cross-tier row count reconciliation |
+
+`postgis_materialization_asset` automatically writes a `MaterializationRecord` after each successful write, capturing source/target row counts, duration, and the Dagster run ID. The `replication_lag_monitor` Dagster sensor polls `pg_replication_slots` every 60 seconds and writes `ReplicationLagSnapshot` rows.
+
+**SLO templates (adapt to your deployment):**
+
+| Metric | Target | Alert threshold | Query |
+|---|---|---|---|
+| Materialization parity | 100% `is_parity=True` | Any `is_parity=False` in the last 24h | `SELECT * FROM sw_monitoring_materialization WHERE NOT is_parity AND materialized_at > now() - interval '24 hours'` |
+| Replication lag | < 100 MB | `lag_bytes > 100000000` sustained for 5 min | `SELECT * FROM sw_monitoring_replication_lag WHERE lag_bytes > 100000000 AND captured_at > now() - interval '5 minutes'` |
+| Parity check pass rate | 100% `is_match=True` | Any `is_match=False` in the last check window | `SELECT * FROM sw_monitoring_parity_check WHERE NOT is_match AND checked_at > now() - interval '24 hours'` |
+
+**postgres_exporter integration:** If you run `postgres_exporter` for Prometheus/Grafana, add custom queries against the `sw_monitoring_*` tables to surface these metrics alongside standard PostgreSQL metrics. Example collector config:
+
+```yaml
+sw_materialization_mismatches:
+  query: "SELECT count(*) AS mismatch_count FROM sw_monitoring_materialization WHERE NOT is_parity AND materialized_at > now() - interval '1 hour'"
+  metrics:
+    - mismatch_count:
+        usage: "GAUGE"
+        description: "Materialization parity failures in the last hour"
+sw_replication_lag:
+  query: "SELECT slot_name, lag_bytes FROM sw_monitoring_replication_lag WHERE captured_at = (SELECT max(captured_at) FROM sw_monitoring_replication_lag)"
+  metrics:
+    - lag_bytes:
+        usage: "GAUGE"
+        description: "Latest replication lag in bytes per slot"
+```
+
+**Default-safe recommendation:** The monitoring tables and automated recording are enabled by default. For alerting, start with a simple Dagster sensor or cron job that checks for `is_parity=False` or `lag_bytes` above threshold and posts to your notification channel. Graduate to postgres_exporter + Grafana when you have a metrics stack.
+
+---
+
 ## Further Reading
 
 - [`docs/architecture.md`](architecture.md) — three-tier warehouse pattern, design-order constraints

--- a/socialwarehouse/orchestration/asset_factories.py
+++ b/socialwarehouse/orchestration/asset_factories.py
@@ -215,11 +215,24 @@ def postgis_materialization_asset(
         t_total = t_write - t_start
         context.log.info("PostGIS write complete: %.1fs total", t_total)
 
+        target_row_count = _count_postgis_rows(table_name, postgis_resource)
+        _record_materialization(
+            asset_key=f"{source_layer}/{source_table}",
+            source_tier=source_layer,
+            target_table=table_name,
+            source_row_count=row_count,
+            target_row_count=target_row_count,
+            duration_seconds=round(t_total, 2),
+            dagster_run_id=context.run_id,
+        )
+
         return MaterializeResult(
             metadata={
                 "source_path": source_path,
                 "target_table": table_name,
                 "row_count": row_count,
+                "target_row_count": target_row_count,
+                "is_parity": row_count == target_row_count,
                 "write_method": write_method,
                 "copy_threshold": copy_threshold,
                 "timing_spark_read_s": round(t_spark - t_start, 2),
@@ -243,3 +256,43 @@ def _resolve_django_model(app_label: str, model_name: str):
     if not django.apps.apps.ready:
         django.setup()
     return django.apps.apps.get_model(app_label, model_name)
+
+
+def _count_postgis_rows(table_name: str, postgis_resource) -> int:
+    from sqlalchemy import text
+
+    with postgis_resource.engine() as engine:
+        with engine.connect() as conn:
+            result = conn.execute(text(f'SELECT count(*) FROM "{table_name}"'))
+            return result.scalar()
+
+
+def _record_materialization(
+    *,
+    asset_key: str,
+    source_tier: str,
+    target_table: str,
+    source_row_count: int,
+    target_row_count: int,
+    duration_seconds: float,
+    dagster_run_id: str,
+) -> None:
+    try:
+        import django
+
+        if not django.apps.apps.ready:
+            django.setup()
+        from socialwarehouse.warehouse.models.monitoring import MaterializationRecord
+
+        MaterializationRecord.objects.create(
+            asset_key=asset_key,
+            source_tier=source_tier,
+            target_table=target_table,
+            source_row_count=source_row_count,
+            target_row_count=target_row_count,
+            is_parity=(source_row_count == target_row_count),
+            duration_seconds=duration_seconds,
+            dagster_run_id=dagster_run_id,
+        )
+    except Exception:
+        pass

--- a/socialwarehouse/orchestration/sensors.py
+++ b/socialwarehouse/orchestration/sensors.py
@@ -72,4 +72,62 @@ def bronze_addresses_sensor(context: SensorEvaluationContext) -> SensorResult:
     )
 
 
-all_sensors = [bronze_addresses_sensor]
+@sensor(
+    name="replication_lag_monitor",
+    description="Capture replication slot lag snapshots into sw_monitoring_replication_lag.",
+    minimum_interval_seconds=60,
+)
+def replication_lag_sensor(context: SensorEvaluationContext) -> SensorResult:
+    try:
+        import django
+
+        if not django.apps.apps.ready:
+            django.setup()
+
+        from django.conf import settings
+        import psycopg2
+
+        direct_host = getattr(settings, "POSTGRES_DIRECT_HOST", settings.DATABASES["default"]["HOST"])
+        direct_port = getattr(settings, "POSTGRES_DIRECT_PORT", settings.DATABASES["default"].get("PORT", 5432))
+        db = settings.DATABASES["default"]
+        dsn = f"host={direct_host} port={direct_port} dbname={db['NAME']} user={db['USER']} password={db['PASSWORD']}"
+
+        conn = psycopg2.connect(dsn, connect_timeout=5)
+        try:
+            cur = conn.cursor()
+            cur.execute(
+                "SELECT slot_name, "
+                "pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn) AS lag_bytes, "
+                "EXTRACT(EPOCH FROM replay_lag) AS replay_lag_seconds "
+                "FROM pg_replication_slots "
+                "LEFT JOIN pg_stat_replication ON pg_replication_slots.active_pid = pg_stat_replication.pid "
+                "WHERE slot_type = 'logical';"
+            )
+            rows = cur.fetchall()
+        finally:
+            conn.close()
+
+        if not rows:
+            return SensorResult(skip_reason=SkipReason("no logical replication slots found"))
+
+        from socialwarehouse.warehouse.models.monitoring import ReplicationLagSnapshot
+
+        for slot_name, lag_bytes, replay_lag_seconds in rows:
+            ReplicationLagSnapshot.objects.create(
+                slot_name=slot_name,
+                lag_bytes=lag_bytes or 0,
+                replay_lag_seconds=replay_lag_seconds,
+            )
+
+        context.log.info("Recorded replication lag for %d slot(s)", len(rows))
+        return SensorResult(skip_reason=SkipReason(f"recorded lag for {len(rows)} slot(s)"))
+
+    except ImportError as exc:
+        context.log.warning("replication_lag_sensor: missing dependency: %s", exc)
+        return SensorResult(skip_reason=SkipReason(f"missing dependency: {exc}"))
+    except Exception as exc:
+        context.log.warning("replication_lag_sensor failed: %s", exc)
+        return SensorResult(skip_reason=SkipReason(f"probe failed: {exc}"))
+
+
+all_sensors = [bronze_addresses_sensor, replication_lag_sensor]

--- a/socialwarehouse/warehouse/migrations/0007_monitoring_models.py
+++ b/socialwarehouse/warehouse/migrations/0007_monitoring_models.py
@@ -1,0 +1,86 @@
+"""Monitoring models for warehouse observability (#331).
+
+Creates three tables:
+- sw_monitoring_materialization: per-asset parity after PostGIS materialization
+- sw_monitoring_replication_lag: logical replication slot lag over time
+- sw_monitoring_parity_check: cross-tier row count reconciliation
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("warehouse", "0006_partition_fact_tables"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="MaterializationRecord",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("asset_key", models.CharField(db_index=True, max_length=256)),
+                ("source_tier", models.CharField(max_length=16)),
+                ("target_table", models.CharField(max_length=128)),
+                ("source_row_count", models.BigIntegerField()),
+                ("target_row_count", models.BigIntegerField()),
+                ("is_parity", models.BooleanField()),
+                ("duration_seconds", models.FloatField()),
+                ("dagster_run_id", models.CharField(blank=True, default="", max_length=64)),
+                ("materialized_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "db_table": "sw_monitoring_materialization",
+            },
+        ),
+        migrations.AddIndex(
+            model_name="materializationrecord",
+            index=models.Index(fields=["asset_key", "-materialized_at"], name="sw_monitori_asset_k_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="materializationrecord",
+            index=models.Index(fields=["-materialized_at"], name="sw_monitori_materia_idx"),
+        ),
+        migrations.CreateModel(
+            name="ReplicationLagSnapshot",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("slot_name", models.CharField(db_index=True, max_length=128)),
+                ("lag_bytes", models.BigIntegerField()),
+                ("replay_lag_seconds", models.FloatField(null=True)),
+                ("captured_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "db_table": "sw_monitoring_replication_lag",
+            },
+        ),
+        migrations.AddIndex(
+            model_name="replicationlagsnapshot",
+            index=models.Index(fields=["slot_name", "-captured_at"], name="sw_monitori_slot_na_idx"),
+        ),
+        migrations.CreateModel(
+            name="ParityCheck",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("source_tier", models.CharField(max_length=16)),
+                ("target_tier", models.CharField(max_length=16)),
+                ("table_name", models.CharField(max_length=128)),
+                ("source_count", models.BigIntegerField()),
+                ("target_count", models.BigIntegerField()),
+                ("is_match", models.BooleanField()),
+                ("checked_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "db_table": "sw_monitoring_parity_check",
+            },
+        ),
+        migrations.AddIndex(
+            model_name="paritycheck",
+            index=models.Index(fields=["table_name", "-checked_at"], name="sw_monitori_table_n_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="paritycheck",
+            index=models.Index(fields=["-checked_at"], name="sw_monitori_checked_idx"),
+        ),
+    ]

--- a/socialwarehouse/warehouse/models/__init__.py
+++ b/socialwarehouse/warehouse/models/__init__.py
@@ -20,6 +20,11 @@ from .facts import (
     FactUrbanicity,
     FactVoteHistory,
 )
+from .monitoring import (
+    MaterializationRecord,
+    ParityCheck,
+    ReplicationLagSnapshot,
+)
 
 __all__ = [
     "DimGeography",
@@ -36,6 +41,9 @@ __all__ = [
     "FactRedistrictingPlan",
     "FactPersonScore",
     "FactVoteHistory",
+    "MaterializationRecord",
+    "ReplicationLagSnapshot",
+    "ParityCheck",
     "VENDOR_CHOICES",
     "REGISTRATION_STATUS_CHOICES",
     "ELECTION_TYPE_CHOICES",

--- a/socialwarehouse/warehouse/models/monitoring.py
+++ b/socialwarehouse/warehouse/models/monitoring.py
@@ -1,0 +1,69 @@
+"""Warehouse observability models (#331).
+
+Three monitoring surfaces:
+- MaterializationRecord: per-asset parity after PostGIS materialization
+- ReplicationLagSnapshot: logical replication slot lag over time
+- ParityCheck: cross-tier row count reconciliation
+"""
+
+from django.db import models
+
+
+class MaterializationRecord(models.Model):
+    asset_key = models.CharField(max_length=256, db_index=True)
+    source_tier = models.CharField(max_length=16)
+    target_table = models.CharField(max_length=128)
+    source_row_count = models.BigIntegerField()
+    target_row_count = models.BigIntegerField()
+    is_parity = models.BooleanField()
+    duration_seconds = models.FloatField()
+    dagster_run_id = models.CharField(max_length=64, blank=True, default="")
+    materialized_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "sw_monitoring_materialization"
+        indexes = [
+            models.Index(fields=["asset_key", "-materialized_at"]),
+            models.Index(fields=["-materialized_at"]),
+        ]
+
+    def __str__(self):
+        status = "PARITY" if self.is_parity else "MISMATCH"
+        return f"{self.asset_key} {status} ({self.source_row_count}→{self.target_row_count})"
+
+
+class ReplicationLagSnapshot(models.Model):
+    slot_name = models.CharField(max_length=128, db_index=True)
+    lag_bytes = models.BigIntegerField()
+    replay_lag_seconds = models.FloatField(null=True)
+    captured_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "sw_monitoring_replication_lag"
+        indexes = [
+            models.Index(fields=["slot_name", "-captured_at"]),
+        ]
+
+    def __str__(self):
+        return f"{self.slot_name}: {self.lag_bytes} bytes"
+
+
+class ParityCheck(models.Model):
+    source_tier = models.CharField(max_length=16)
+    target_tier = models.CharField(max_length=16)
+    table_name = models.CharField(max_length=128)
+    source_count = models.BigIntegerField()
+    target_count = models.BigIntegerField()
+    is_match = models.BooleanField()
+    checked_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "sw_monitoring_parity_check"
+        indexes = [
+            models.Index(fields=["table_name", "-checked_at"]),
+            models.Index(fields=["-checked_at"]),
+        ]
+
+    def __str__(self):
+        status = "MATCH" if self.is_match else "MISMATCH"
+        return f"{self.source_tier}→{self.target_tier} {self.table_name}: {status}"


### PR DESCRIPTION
Closes #331

## Summary

- Three monitoring models (`MaterializationRecord`, `ReplicationLagSnapshot`, `ParityCheck`) with migration `0007_monitoring_models`
- `postgis_materialization_asset` factory now records a `MaterializationRecord` after each write, capturing source/target row counts, duration, and Dagster run ID
- New `replication_lag_monitor` Dagster sensor polls `pg_replication_slots` every 60 seconds and writes `ReplicationLagSnapshot` rows
- `production-operations.md` section 11: SLO templates and `postgres_exporter` integration examples

## Files changed

| File | Change |
|---|---|
| `warehouse/models/monitoring.py` | New — 3 monitoring models |
| `warehouse/models/__init__.py` | Import + re-export monitoring models |
| `warehouse/migrations/0007_monitoring_models.py` | New — creates tables + indexes |
| `orchestration/asset_factories.py` | Parity recording after PostGIS write |
| `orchestration/sensors.py` | New `replication_lag_monitor` sensor |
| `docs/production-operations.md` | Section 11: observability SLOs |

## Test plan

- [ ] `python manage.py migrate` applies 0007 cleanly
- [ ] `python manage.py showmigrations warehouse` shows all applied
- [ ] PostGIS materialization run creates a `MaterializationRecord` row
- [ ] `replication_lag_monitor` sensor runs without error (skips if no logical slots)
- [ ] SLO queries in section 11 execute against the monitoring tables