### PR TITLE
feat(#333): swh audit-indexes CLI subcommand

### DIFF
--- a/swh/audit_indexes.py
+++ b/swh/audit_indexes.py
@@ -1,0 +1,170 @@
+"""Index audit for ``swh audit-indexes`` (#333).
+
+Detects unused, duplicate, and bloated indexes in the PostGIS tier
+using pg_stat_user_indexes and pg_index catalog views.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class Finding(Enum):
+    UNUSED = "unused"
+    DUPLICATE = "duplicate"
+    BLOATED = "bloated"
+
+
+@dataclass
+class IndexIssue:
+    finding: Finding
+    schema_name: str
+    table_name: str
+    index_name: str
+    index_size_bytes: int
+    detail: str
+    recommendation: str
+
+    @property
+    def index_size_pretty(self) -> str:
+        return pretty_size(self.index_size_bytes)
+
+
+def pretty_size(size_bytes: int) -> str:
+    size = float(size_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if abs(size) < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} PB"
+
+
+UNUSED_INDEX_SQL = """\
+SELECT
+    schemaname,
+    relname AS tablename,
+    indexrelname AS indexname,
+    idx_scan,
+    pg_relation_size(indexrelid) AS index_size_bytes
+FROM pg_stat_user_indexes
+WHERE idx_scan = 0
+  AND indexrelid NOT IN (
+      SELECT conindid FROM pg_constraint
+      WHERE contype IN ('p', 'u')
+  )
+ORDER BY pg_relation_size(indexrelid) DESC;
+"""
+
+DUPLICATE_INDEX_SQL = """\
+SELECT
+    a.indexrelid::regclass AS index_a,
+    b.indexrelid::regclass AS index_b,
+    a.indrelid::regclass AS tablename,
+    pg_relation_size(a.indexrelid) AS size_a,
+    pg_relation_size(b.indexrelid) AS size_b,
+    n.nspname AS schemaname
+FROM pg_index a
+JOIN pg_index b ON a.indrelid = b.indrelid
+    AND a.indexrelid < b.indexrelid
+    AND a.indkey::text = b.indkey::text
+JOIN pg_class c ON c.oid = a.indrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+ORDER BY pg_relation_size(a.indexrelid) DESC;
+"""
+
+BLOAT_ESTIMATE_SQL = """\
+SELECT
+    nspname AS schemaname,
+    tblname AS tablename,
+    idxname AS indexname,
+    real_size AS index_size_bytes,
+    CASE WHEN real_size > 0
+         THEN round(100.0 * (real_size - estimated_size) / real_size, 1)
+         ELSE 0
+    END AS bloat_pct
+FROM (
+    SELECT
+        n.nspname,
+        ct.relname AS tblname,
+        ci.relname AS idxname,
+        pg_relation_size(ci.oid) AS real_size,
+        COALESCE(
+            (8192 * ci.relpages *
+             CASE WHEN ct.reltuples > 0
+                  THEN (ci.reltuples / ct.reltuples)
+                  ELSE 1
+             END)::bigint,
+            pg_relation_size(ci.oid)
+        ) AS estimated_size
+    FROM pg_index i
+    JOIN pg_class ci ON ci.oid = i.indexrelid
+    JOIN pg_class ct ON ct.oid = i.indrelid
+    JOIN pg_namespace n ON n.oid = ct.relnamespace
+    WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+      AND pg_relation_size(ci.oid) > 0
+) sub
+WHERE real_size > 0
+  AND (real_size - estimated_size) > 0
+ORDER BY bloat_pct DESC;
+"""
+
+
+def audit_indexes(
+    dsn: str,
+    *,
+    bloat_threshold_pct: float = 50.0,
+    min_size_bytes: int = 1_048_576,
+) -> list[IndexIssue]:
+    import psycopg2
+
+    issues: list[IndexIssue] = []
+    conn = psycopg2.connect(dsn, connect_timeout=10)
+    try:
+        cur = conn.cursor()
+
+        cur.execute(UNUSED_INDEX_SQL)
+        for schema, table, index, scans, size_bytes in cur.fetchall():
+            if size_bytes < min_size_bytes:
+                continue
+            issues.append(IndexIssue(
+                finding=Finding.UNUSED,
+                schema_name=schema,
+                table_name=table,
+                index_name=index,
+                index_size_bytes=size_bytes,
+                detail=f"{scans} scans since stats reset",
+                recommendation=f"DROP INDEX CONCURRENTLY {index};",
+            ))
+
+        cur.execute(DUPLICATE_INDEX_SQL)
+        for idx_a, idx_b, table, size_a, size_b, schema in cur.fetchall():
+            issues.append(IndexIssue(
+                finding=Finding.DUPLICATE,
+                schema_name=schema,
+                table_name=str(table),
+                index_name=str(idx_b),
+                index_size_bytes=size_b,
+                detail=f"duplicates {idx_a}",
+                recommendation=f"DROP INDEX CONCURRENTLY {idx_b};",
+            ))
+
+        cur.execute(BLOAT_ESTIMATE_SQL)
+        for schema, table, index, size_bytes, bloat_pct in cur.fetchall():
+            if bloat_pct < bloat_threshold_pct or size_bytes < min_size_bytes:
+                continue
+            issues.append(IndexIssue(
+                finding=Finding.BLOATED,
+                schema_name=schema,
+                table_name=table,
+                index_name=index,
+                index_size_bytes=size_bytes,
+                detail=f"{bloat_pct}% estimated bloat",
+                recommendation=f"REINDEX INDEX CONCURRENTLY {index};",
+            ))
+    finally:
+        conn.close()
+
+    return issues

--- a/swh/cli.py
+++ b/swh/cli.py
@@ -643,5 +643,83 @@ def doctor(as_json, verbose):
             sys.exit(1)
 
 
+@cli.command("audit-indexes")
+@click.option("--json", "as_json", is_flag=True, help="Output results as JSON")
+@click.option("--bloat-threshold", type=float, default=50.0, help="Bloat percentage threshold (default: 50)")
+@click.option("--min-size-mb", type=float, default=1.0, help="Minimum index size in MB to report (default: 1)")
+def audit_indexes_cmd(as_json, bloat_threshold, min_size_mb):
+    """Audit PostGIS indexes for unused, duplicate, and bloated entries.
+
+    Connects directly to PostgreSQL (bypassing PgBouncer) and queries
+    pg_stat_user_indexes and pg_index catalog views.
+
+    Examples:
+        swh audit-indexes
+        swh audit-indexes --json
+        swh audit-indexes --bloat-threshold 30 --min-size-mb 10
+    """
+    import json as json_mod
+
+    from swh.audit_indexes import Finding, audit_indexes, pretty_size
+
+    dsn = settings.database.direct_psycopg2_dsn
+    min_size_bytes = int(min_size_mb * 1024 * 1024)
+
+    try:
+        issues = audit_indexes(
+            dsn,
+            bloat_threshold_pct=bloat_threshold,
+            min_size_bytes=min_size_bytes,
+        )
+    except Exception as exc:
+        click.echo(click.style(f"  [FAIL]  could not connect: {exc}", fg="red"), err=True)
+        sys.exit(1)
+
+    if as_json:
+        data = [
+            {
+                "finding": i.finding.value,
+                "schema": i.schema_name,
+                "table": i.table_name,
+                "index": i.index_name,
+                "size_bytes": i.index_size_bytes,
+                "size_pretty": i.index_size_pretty,
+                "detail": i.detail,
+                "recommendation": i.recommendation,
+            }
+            for i in issues
+        ]
+        click.echo(json_mod.dumps(data, indent=2))
+    else:
+        click.echo("Index Audit")
+        click.echo("=" * 60)
+
+        if not issues:
+            click.echo(click.style("  No issues found.", fg="green"))
+        else:
+            for finding_type in Finding:
+                group = [i for i in issues if i.finding == finding_type]
+                if not group:
+                    continue
+                color = {"unused": "yellow", "duplicate": "red", "bloated": "cyan"}[finding_type.value]
+                click.echo(f"\n  {finding_type.value.upper()} ({len(group)}):")
+                for i in group:
+                    click.echo(
+                        click.style(f"    [{finding_type.value.upper()}]", fg=color)
+                        + f"  {i.index_name} on {i.table_name} ({i.index_size_pretty})"
+                    )
+                    click.echo(f"           {i.detail}")
+                    click.echo(click.style(f"           → {i.recommendation}", fg="white"))
+
+        total_waste = sum(i.index_size_bytes for i in issues)
+        if total_waste > 0:
+            click.echo(f"\n  {len(issues)} issue(s), ~{pretty_size(total_waste)} reclaimable")
+        else:
+            click.echo(f"\n  {len(issues)} issue(s)")
+
+        if any(i.finding == Finding.UNUSED for i in issues):
+            sys.exit(1)
+
+
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
Closes #333

## Summary

- New `swh/audit_indexes.py` module with detection logic for unused, duplicate, and bloated indexes
- New `swh audit-indexes` CLI subcommand with `--json`, `--bloat-threshold`, `--min-size-mb` flags
- Connects directly to PostgreSQL (bypasses PgBouncer) using `direct_psycopg2_dsn`
- Exits non-zero when unused indexes are found (CI-friendly)

## Files changed

| File | Change |
|---|---|
| `swh/audit_indexes.py` | New — index audit logic (unused, duplicate, bloated detection) |
| `swh/cli.py` | New `audit-indexes` subcommand |

## Test plan

- [ ] `swh audit-indexes --help` shows usage
- [ ] `swh audit-indexes` against a live DB produces table output
- [ ] `swh audit-indexes --json` produces valid JSON
- [ ] `--bloat-threshold 0 --min-size-mb 0` surfaces all indexes (stress test)
- [ ] Non-zero exit when unused indexes found