### PR TITLE
feat(#334): swh reconcile CLI subcommand

### DIFF
--- a/swh/cli.py
+++ b/swh/cli.py
@@ -721,5 +721,95 @@ def audit_indexes_cmd(as_json, bloat_threshold, min_size_mb):
             sys.exit(1)
 
 
+@cli.command("reconcile")
+@click.option("--json", "as_json", is_flag=True, help="Output results as JSON")
+@click.option("--all-tables", is_flag=True, help="Check all tables, not just sw_* prefixed")
+def reconcile_cmd(as_json, all_tables):
+    """Diff live PG schema against Django models and report mismatches.
+
+    Compares column names, types, and nullability for SW tables (or all
+    tables with --all-tables). Report-only — no mutations.
+
+    Examples:
+        swh reconcile
+        swh reconcile --json
+        swh reconcile --all-tables
+    """
+    import json as json_mod
+
+    from swh.reconcile import DiffKind, reconcile
+
+    dsn = settings.database.direct_psycopg2_dsn
+
+    try:
+        report = reconcile(dsn, sw_only=not all_tables)
+    except Exception as exc:
+        click.echo(click.style(f"  [FAIL]  could not connect: {exc}", fg="red"), err=True)
+        sys.exit(1)
+
+    if as_json:
+        data = {
+            "table_diffs": [
+                {"table": d.table, "kind": d.kind.value, "detail": d.detail}
+                for d in report.table_diffs
+            ],
+            "column_diffs": [
+                {
+                    "table": d.table,
+                    "column": d.column,
+                    "kind": d.kind.value,
+                    "model_type": d.model_type,
+                    "db_type": d.db_type,
+                    "detail": d.detail,
+                }
+                for d in report.column_diffs
+            ],
+            "issue_count": report.issue_count,
+        }
+        click.echo(json_mod.dumps(data, indent=2))
+    else:
+        click.echo("Schema Reconciliation")
+        click.echo("=" * 60)
+
+        if not report.has_issues:
+            click.echo(click.style("  No schema drift detected.", fg="green"))
+        else:
+            if report.table_diffs:
+                click.echo("\n  TABLE-LEVEL:")
+                for d in report.table_diffs:
+                    color = "red" if d.kind == DiffKind.MISSING_TABLE else "yellow"
+                    click.echo(
+                        click.style(f"    [{d.kind.value}]", fg=color)
+                        + f"  {d.table}: {d.detail}"
+                    )
+
+            if report.column_diffs:
+                by_table = {}
+                for d in report.column_diffs:
+                    by_table.setdefault(d.table, []).append(d)
+
+                click.echo("\n  COLUMN-LEVEL:")
+                for table in sorted(by_table):
+                    click.echo(f"\n    {table}:")
+                    for d in by_table[table]:
+                        colors = {
+                            DiffKind.MISSING_IN_DB: "red",
+                            DiffKind.EXTRA_IN_DB: "yellow",
+                            DiffKind.TYPE_MISMATCH: "red",
+                            DiffKind.NULLABLE_MISMATCH: "cyan",
+                        }
+                        color = colors.get(d.kind, "white")
+                        click.echo(
+                            click.style(f"      [{d.kind.value}]", fg=color)
+                            + f"  {d.column}: {d.detail}"
+                        )
+
+        click.echo(f"\n  {report.issue_count} issue(s)")
+
+        if any(d.kind == DiffKind.MISSING_IN_DB for d in report.column_diffs) or \
+           any(d.kind == DiffKind.MISSING_TABLE for d in report.table_diffs):
+            sys.exit(1)
+
+
 if __name__ == "__main__":
     cli()

--- a/swh/reconcile.py
+++ b/swh/reconcile.py
@@ -1,0 +1,250 @@
+"""Schema reconciliation for ``swh reconcile`` (#334).
+
+Compares live PostgreSQL schema against Django model definitions and
+reports column-level diffs: missing columns, extra columns, type
+mismatches, and constraint mismatches.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+
+class DiffKind(Enum):
+    MISSING_IN_DB = "missing_in_db"
+    EXTRA_IN_DB = "extra_in_db"
+    TYPE_MISMATCH = "type_mismatch"
+    NULLABLE_MISMATCH = "nullable_mismatch"
+    MISSING_TABLE = "missing_table"
+    EXTRA_TABLE = "extra_table"
+
+
+@dataclass
+class ColumnDiff:
+    table: str
+    column: str
+    kind: DiffKind
+    model_type: Optional[str] = None
+    db_type: Optional[str] = None
+    detail: str = ""
+
+
+@dataclass
+class TableDiff:
+    table: str
+    kind: DiffKind
+    detail: str = ""
+
+
+@dataclass
+class ReconcileReport:
+    table_diffs: list[TableDiff] = field(default_factory=list)
+    column_diffs: list[ColumnDiff] = field(default_factory=list)
+
+    @property
+    def has_issues(self) -> bool:
+        return bool(self.table_diffs or self.column_diffs)
+
+    @property
+    def issue_count(self) -> int:
+        return len(self.table_diffs) + len(self.column_diffs)
+
+
+DJANGO_TO_PG_TYPES = {
+    "AutoField": {"integer"},
+    "BigAutoField": {"bigint"},
+    "SmallAutoField": {"smallint"},
+    "BooleanField": {"boolean"},
+    "CharField": {"character varying"},
+    "TextField": {"text"},
+    "IntegerField": {"integer"},
+    "BigIntegerField": {"bigint"},
+    "SmallIntegerField": {"smallint"},
+    "PositiveIntegerField": {"integer"},
+    "PositiveBigIntegerField": {"bigint"},
+    "PositiveSmallIntegerField": {"smallint"},
+    "FloatField": {"double precision"},
+    "DecimalField": {"numeric"},
+    "DateField": {"date"},
+    "DateTimeField": {"timestamp with time zone"},
+    "TimeField": {"time without time zone"},
+    "UUIDField": {"uuid"},
+    "BinaryField": {"bytea"},
+    "JSONField": {"jsonb"},
+    "SlugField": {"character varying"},
+    "URLField": {"character varying"},
+    "EmailField": {"character varying"},
+    "FilePathField": {"character varying"},
+    "IPAddressField": {"character varying", "inet"},
+    "GenericIPAddressField": {"character varying", "inet"},
+    "ForeignKey": {"integer", "bigint"},
+    "OneToOneField": {"integer", "bigint"},
+    "MultiPolygonField": {"USER-DEFINED"},
+    "PolygonField": {"USER-DEFINED"},
+    "PointField": {"USER-DEFINED"},
+    "LineStringField": {"USER-DEFINED"},
+    "MultiPointField": {"USER-DEFINED"},
+    "MultiLineStringField": {"USER-DEFINED"},
+    "GeometryField": {"USER-DEFINED"},
+    "GeometryCollectionField": {"USER-DEFINED"},
+    "RasterField": {"USER-DEFINED"},
+}
+
+INTROSPECT_COLUMNS_SQL = """\
+SELECT
+    table_name,
+    column_name,
+    data_type,
+    is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = ANY(%s)
+ORDER BY table_name, ordinal_position;
+"""
+
+INTROSPECT_TABLES_SQL = """\
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
+  AND table_type = 'BASE TABLE';
+"""
+
+
+def _get_django_models():
+    import django
+
+    if not django.apps.apps.ready:
+        django.setup()
+
+    from django.apps import apps
+
+    models = []
+    for model in apps.get_models():
+        if model._meta.managed is False:
+            continue
+        models.append(model)
+    return models
+
+
+def _model_columns(model) -> dict[str, dict]:
+    columns = {}
+    for f in model._meta.get_fields():
+        if not hasattr(f, "column"):
+            continue
+        col_name = f.column
+        field_type = type(f).__name__
+        nullable = getattr(f, "null", False)
+        columns[col_name] = {
+            "field_type": field_type,
+            "nullable": nullable,
+        }
+    return columns
+
+
+def reconcile(dsn: str, *, sw_only: bool = True) -> ReconcileReport:
+    import psycopg2
+
+    report = ReconcileReport()
+    models = _get_django_models()
+
+    model_tables = {}
+    for m in models:
+        table = m._meta.db_table
+        if sw_only and not table.startswith("sw_"):
+            continue
+        model_tables[table] = m
+
+    conn = psycopg2.connect(dsn, connect_timeout=10)
+    try:
+        cur = conn.cursor()
+
+        cur.execute(INTROSPECT_TABLES_SQL)
+        db_tables = {row[0] for row in cur.fetchall()}
+
+        for table in sorted(model_tables.keys()):
+            if table not in db_tables:
+                report.table_diffs.append(TableDiff(
+                    table=table,
+                    kind=DiffKind.MISSING_TABLE,
+                    detail="defined in Django models but not in database",
+                ))
+
+        target_tables = [t for t in model_tables if t in db_tables]
+
+        if sw_only:
+            extra_sw_tables = {t for t in db_tables if t.startswith("sw_")} - set(model_tables.keys())
+            for table in sorted(extra_sw_tables):
+                report.table_diffs.append(TableDiff(
+                    table=table,
+                    kind=DiffKind.EXTRA_TABLE,
+                    detail="exists in database but no Django model",
+                ))
+
+        if not target_tables:
+            return report
+
+        cur.execute(INTROSPECT_COLUMNS_SQL, (target_tables,))
+        db_columns: dict[str, dict[str, dict]] = {}
+        for table_name, col_name, data_type, is_nullable in cur.fetchall():
+            db_columns.setdefault(table_name, {})[col_name] = {
+                "data_type": data_type,
+                "nullable": is_nullable == "YES",
+            }
+
+        for table, model in sorted(model_tables.items()):
+            if table not in db_columns:
+                continue
+
+            model_cols = _model_columns(model)
+            db_cols = db_columns[table]
+
+            for col_name, col_info in model_cols.items():
+                if col_name not in db_cols:
+                    report.column_diffs.append(ColumnDiff(
+                        table=table,
+                        column=col_name,
+                        kind=DiffKind.MISSING_IN_DB,
+                        model_type=col_info["field_type"],
+                        detail=f"Django field {col_info['field_type']} has no column in DB",
+                    ))
+                    continue
+
+                db_col = db_cols[col_name]
+                expected_types = DJANGO_TO_PG_TYPES.get(col_info["field_type"], set())
+                if expected_types and db_col["data_type"] not in expected_types:
+                    report.column_diffs.append(ColumnDiff(
+                        table=table,
+                        column=col_name,
+                        kind=DiffKind.TYPE_MISMATCH,
+                        model_type=col_info["field_type"],
+                        db_type=db_col["data_type"],
+                        detail=f"Django={col_info['field_type']} expects {expected_types}, DB={db_col['data_type']}",
+                    ))
+
+                if col_info["nullable"] != db_col["nullable"]:
+                    if col_name == "id":
+                        continue
+                    report.column_diffs.append(ColumnDiff(
+                        table=table,
+                        column=col_name,
+                        kind=DiffKind.NULLABLE_MISMATCH,
+                        model_type=f"null={col_info['nullable']}",
+                        db_type=f"nullable={db_col['nullable']}",
+                        detail=f"Django null={col_info['nullable']}, DB nullable={db_col['nullable']}",
+                    ))
+
+            for col_name in db_cols:
+                if col_name not in model_cols:
+                    report.column_diffs.append(ColumnDiff(
+                        table=table,
+                        column=col_name,
+                        kind=DiffKind.EXTRA_IN_DB,
+                        db_type=db_cols[col_name]["data_type"],
+                        detail=f"column exists in DB ({db_cols[col_name]['data_type']}) but no Django field",
+                    ))
+    finally:
+        conn.close()
+
+    return report


### PR DESCRIPTION
Closes #334

## Summary

- New `swh/reconcile.py` module with schema introspection and diff logic
- New `swh reconcile` CLI subcommand with `--json` and `--all-tables` flags
- Detects: missing tables, extra tables, missing columns, extra columns, type mismatches, nullable mismatches
- Report-only — no mutations to the database
- Exits non-zero when missing columns or tables are detected (CI-friendly)
- Connects directly to PostgreSQL (bypasses PgBouncer)

## Files changed

| File | Change |
|---|---|
| `swh/reconcile.py` | New — schema reconciliation logic |
| `swh/cli.py` | New `reconcile` subcommand |

## Test plan

- [ ] `swh reconcile --help` shows usage
- [ ] `swh reconcile` against a live DB with all migrations applied reports no drift
- [ ] `swh reconcile --json` produces valid JSON
- [ ] `swh reconcile --all-tables` includes non-sw_ tables
- [ ] Adding a model field without migrating → detected as `missing_in_db`