### PR TITLE
feat(#327): CloudNativePG manifests for production HA

### DIFF
--- a/docs/production-operations.md
+++ b/docs/production-operations.md
@@ -34,7 +34,13 @@ Each section follows the same structure:
 
 **Default-safe recommendation:** Start with a single pod until your data volume or uptime requirements force the conversation. When you're ready, CNPG primary + 1 standby + WAL archiving to object storage is the lowest-friction Kubernetes path. If you're not on Kubernetes, a managed PostgreSQL service with PostGIS support is the pragmatic choice.
 
-**Implementation pointer:** HA topology lives in your infrastructure repo (Helm charts, Terraform, ArgoCD manifests) — not in SocialWarehouse. SW's `docker-compose.yml` is a dev convenience; production topology is the adopter's concern.
+**Implementation:** SW ships CNPG (CloudNativePG) manifests in `k8s/cnpg/` as the recommended Kubernetes path:
+
+- `cluster.yaml`: 3-instance Cluster (1 primary + 2 standbys) with PostGIS 16-3.4
+- `backup-schedule.yaml`: daily base backups at 02:00 UTC, 14-day retention
+- `minio.yaml`: MinIO for dev/test WAL archiving (replace with real S3/GCS in production)
+
+See `k8s/cnpg/README.md` for prerequisites, quick-start, and production customization. The `docker-compose.yml` single-node setup remains the dev convenience; CNPG is the production path for Kubernetes adopters. Non-Kubernetes adopters should use Patroni or a managed PostgreSQL service.
 
 ---
 
@@ -58,7 +64,13 @@ Each section follows the same structure:
 
 **Default-safe recommendation:** WAL archiving to S3-compatible storage + daily base backups via pgBackRest + 14-day retention. Test a restore before you need one — an untested backup is not a backup.
 
-**Implementation pointer:** Backup configuration belongs in your infrastructure repo. If using CNPG, backup is declarative in the Cluster CRD. If managing PostgreSQL directly, pgBackRest config lives alongside your PostgreSQL configuration.
+**Implementation:** If using CNPG (see §1), backup is declarative:
+
+- WAL archiving: configured in `k8s/cnpg/cluster.yaml` under `spec.backup.barmanObjectStore`
+- Scheduled base backups: `k8s/cnpg/backup-schedule.yaml` (daily at 02:00 UTC, 14-day retention)
+- PITR: create a recovery Cluster CRD pointing to the WAL archive with a `recoveryTarget.targetTime` (see `k8s/cnpg/README.md` for a full example)
+
+If managing PostgreSQL directly (non-CNPG), pgBackRest config lives alongside your PostgreSQL configuration in your infrastructure repo.
 
 ---
 

--- a/k8s/cnpg/README.md
+++ b/k8s/cnpg/README.md
@@ -1,0 +1,110 @@
+# CloudNativePG Deployment
+
+Production-ready PostgreSQL + PostGIS on Kubernetes using CloudNativePG (CNPG).
+
+## Prerequisites
+
+1. Kubernetes cluster (1.25+)
+2. CNPG operator installed:
+   ```bash
+   kubectl apply --server-side -f \
+     https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.24/releases/cnpg-1.24.0.yaml
+   ```
+
+## Quick start (dev with MinIO)
+
+```bash
+# Deploy MinIO for local WAL archiving
+kubectl apply -f minio.yaml
+
+# Wait for MinIO and bucket creation
+kubectl wait --for=condition=complete job/minio-create-bucket --timeout=60s
+
+# Deploy the CNPG cluster
+kubectl apply -f cluster.yaml
+
+# Deploy scheduled backups
+kubectl apply -f backup-schedule.yaml
+
+# Watch cluster come up (primary + 2 standbys)
+kubectl get cluster socialwarehouse-postgis -w
+```
+
+## Production customization
+
+### Storage
+
+Replace `storageClass: gp3` with your cluster's provisioned-IOPS storage class. Use local NVMe SSDs for lowest latency.
+
+### WAL archiving
+
+Replace the MinIO endpoint in `cluster.yaml` with your S3/GCS/Azure Blob configuration:
+
+```yaml
+backup:
+  barmanObjectStore:
+    destinationPath: s3://your-bucket/wal/
+    # Remove endpointURL for real AWS S3
+    s3Credentials:
+      accessKeyId:
+        name: your-aws-secret
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: your-aws-secret
+        key: SECRET_ACCESS_KEY
+```
+
+### Memory tuning
+
+The `postgresql.parameters` block in `cluster.yaml` ships with staging-tier defaults (16 GB RAM). Adjust per the profiles in `docs/production-operations.md` section 3.
+
+### Scaling
+
+- **Standbys**: Change `instances` (minimum 2 for HA, 3 recommended)
+- **Resources**: Adjust `resources.requests` and `resources.limits` to match your node size
+- **Storage**: Increase `storage.size` as data grows
+
+## Monitoring
+
+The cluster ships with `enablePodMonitor: true`. If you run Prometheus Operator, CNPG metrics are scraped automatically. See `docs/production-operations.md` section 11 for observability integration.
+
+## Recovery
+
+### Point-in-time recovery
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: socialwarehouse-postgis-recovered
+spec:
+  instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgis:16-3.4
+  bootstrap:
+    recovery:
+      source: socialwarehouse-postgis
+      recoveryTarget:
+        targetTime: "2026-01-15T12:00:00Z"
+  externalClusters:
+    - name: socialwarehouse-postgis
+      barmanObjectStore:
+        destinationPath: s3://socialwarehouse-backups/wal/
+        s3Credentials:
+          accessKeyId:
+            name: minio-credentials
+            key: ACCESS_KEY_ID
+          secretAccessKey:
+            name: minio-credentials
+            key: SECRET_ACCESS_KEY
+```
+
+### Switchover (planned)
+
+```bash
+kubectl cnpg promote socialwarehouse-postgis <standby-pod-name>
+```
+
+## Further reading
+
+- [CloudNativePG documentation](https://cloudnative-pg.io/documentation/)
+- `docs/production-operations.md` sections 1 (HA topology) and 2 (backup/PITR)

--- a/k8s/cnpg/backup-schedule.yaml
+++ b/k8s/cnpg/backup-schedule.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: socialwarehouse-daily-backup
+  labels:
+    app.kubernetes.io/name: socialwarehouse
+    app.kubernetes.io/component: backup
+spec:
+  schedule: "0 2 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: socialwarehouse-postgis
+  immediate: false

--- a/k8s/cnpg/cluster.yaml
+++ b/k8s/cnpg/cluster.yaml
@@ -1,0 +1,76 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: socialwarehouse-postgis
+  labels:
+    app.kubernetes.io/name: socialwarehouse
+    app.kubernetes.io/component: database
+spec:
+  instances: 3
+
+  imageName: ghcr.io/cloudnative-pg/postgis:16-3.4
+
+  postgresql:
+    parameters:
+      shared_buffers: "4GB"
+      effective_cache_size: "12GB"
+      work_mem: "64MB"
+      maintenance_work_mem: "1GB"
+      wal_buffers: "64MB"
+      max_connections: "200"
+      max_wal_size: "8GB"
+      checkpoint_completion_target: "0.9"
+      random_page_cost: "1.1"
+      effective_io_concurrency: "200"
+      shared_preload_libraries: "pg_stat_statements"
+    pg_hba:
+      - host all all 0.0.0.0/0 scram-sha-256
+
+  bootstrap:
+    initdb:
+      database: socialwarehouse
+      owner: socialwarehouse
+      postInitSQL:
+        - CREATE EXTENSION IF NOT EXISTS postgis;
+        - CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+  storage:
+    size: 100Gi
+    storageClass: gp3
+
+  walStorage:
+    size: 20Gi
+    storageClass: gp3
+
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://socialwarehouse-backups/wal/
+      endpointURL: http://minio:9000
+      s3Credentials:
+        accessKeyId:
+          name: minio-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: minio-credentials
+          key: SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+        maxParallel: 4
+      data:
+        compression: gzip
+    retentionPolicy: "14d"
+
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+
+  resources:
+    requests:
+      memory: "8Gi"
+      cpu: "2"
+    limits:
+      memory: "16Gi"
+      cpu: "4"
+
+  monitoring:
+    enablePodMonitor: true

--- a/k8s/cnpg/minio.yaml
+++ b/k8s/cnpg/minio.yaml
@@ -1,0 +1,87 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-credentials
+type: Opaque
+stringData:
+  ACCESS_KEY_ID: minioadmin
+  SECRET_ACCESS_KEY: minioadmin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+        - name: minio
+          image: minio/minio:latest
+          args:
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+          env:
+            - name: MINIO_ROOT_USER
+              value: minioadmin
+            - name: MINIO_ROOT_PASSWORD
+              value: minioadmin
+          ports:
+            - containerPort: 9000
+              name: api
+            - containerPort: 9001
+              name: console
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector:
+    app: minio
+  ports:
+    - port: 9000
+      targetPort: 9000
+      name: api
+    - port: 9001
+      targetPort: 9001
+      name: console
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-create-bucket
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: minio/mc:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mc alias set local http://minio:9000 minioadmin minioadmin
+              mc mb --ignore-existing local/socialwarehouse-backups


### PR DESCRIPTION
Closes #327

## Summary

- New `k8s/cnpg/` directory with production-ready CNPG manifests
- `cluster.yaml`: 3-instance Cluster (PostGIS 16-3.4, WAL→S3, anti-affinity)
- `backup-schedule.yaml`: daily base backups at 02:00 UTC, 14-day retention
- `minio.yaml`: MinIO for dev WAL archiving
- `README.md`: prerequisites, quick-start, production customization, PITR recovery
- Updated `docs/production-operations.md` sections 1 and 2 with CNPG implementation pointers

## Files changed

| File | Change |
|---|---|
| `k8s/cnpg/cluster.yaml` | New — CNPG Cluster CRD |
| `k8s/cnpg/backup-schedule.yaml` | New — ScheduledBackup CRD |
| `k8s/cnpg/minio.yaml` | New — MinIO for dev WAL storage |
| `k8s/cnpg/README.md` | New — adopter quick-start |
| `docs/production-operations.md` | Updated sections 1, 2 |

## Test plan

- [ ] `kubectl apply -f k8s/cnpg/cluster.yaml` (with CNPG operator) creates 3 pods
- [ ] MinIO bucket creation job completes
- [ ] WAL archiving succeeds (check CNPG cluster status)
- [ ] ScheduledBackup fires and completes
- [ ] YAML validates with `kubectl --dry-run=client`