### PR TITLE
feat(#329): hot/warm/cold partition tiering

### DIFF
--- a/docs/production-operations.md
+++ b/docs/production-operations.md
@@ -205,7 +205,54 @@ CREATE TABLE sw_fact_vote_history_2027
 
 **Default-safe recommendation:** The simplest path for SW adopters: historical data that's past your active query window already exists in Delta Lake (tier 1 of the warehouse). Stop materializing it to PostGIS. PostGIS holds the hot window; Delta holds everything. When you need historical data, query it via Spark. No columnar extensions, no partition gymnastics — just stop pushing old data into the serving tier.
 
-**Implementation pointer:** Adjust your Dagster asset graph or materialization jobs to only materialize recent data into PostGIS. The Delta tables remain the source of truth for historical queries.
+**Implementation:** SW ships a three-tier model for partitioned fact tables:
+
+| Tier | Tablespace | Indexes | Partitions |
+|---|---|---|---|
+| Hot | `pg_default` (NVMe) | Full indexes | Current + previous cycle/year |
+| Warm | `warm_ts` (SSD) | Reduced (non-essential dropped) | N-2 through N-5 |
+| Cold | `cold_ts` (HDD/columnar) | Minimal (PK only) | Older than N-5 |
+
+**Tablespace setup (host-specific — run once per deployment):**
+
+```sql
+-- Create tablespaces pointing to your storage mount points
+CREATE TABLESPACE warm_ts LOCATION '/mnt/ssd/pg_warm';
+CREATE TABLESPACE cold_ts LOCATION '/mnt/hdd/pg_cold';
+```
+
+**Tier assessment and advancement:**
+
+- `swh tier-status` shows current partition placement vs recommended tier
+- `swh tier-status --json` for machine-readable output
+- The `tier_advancement_monitor` Dagster sensor runs daily and logs recommendations for misplaced partitions
+
+**Moving a partition to a different tier:**
+
+```sql
+ALTER TABLE sw_fact_vote_history_2018 SET TABLESPACE warm_ts;
+```
+
+**Index reduction for warm partitions:**
+
+```sql
+-- Drop non-essential indexes on warm/cold partitions
+-- Keep only primary key and unique constraints
+DROP INDEX CONCURRENTLY idx_vote_history_2018_person_date;
+```
+
+**hydra_columnar for cold tier (optional):**
+
+```sql
+CREATE EXTENSION IF NOT EXISTS columnar;
+
+-- Convert a cold partition to columnar storage
+SELECT columnar.alter_table_set_access_method('sw_fact_vote_history_2016', 'columnar');
+```
+
+Install hydra_columnar when your warehouse exceeds 5 TB or 5 redistricting cycles. Below that threshold, the three-tier tablespace model is sufficient.
+
+**Decision trigger:** if warehouse > 5 TB or > 5 cycles, install columnar. Below that, the simplest approach remains "stop materializing old data to PostGIS" and query historical data via Delta Lake/Spark.
 
 ---
 

--- a/socialwarehouse/orchestration/sensors.py
+++ b/socialwarehouse/orchestration/sensors.py
@@ -130,4 +130,45 @@ def replication_lag_sensor(context: SensorEvaluationContext) -> SensorResult:
         return SensorResult(skip_reason=SkipReason(f"probe failed: {exc}"))
 
 
-all_sensors = [bronze_addresses_sensor, replication_lag_sensor]
+@sensor(
+    name="tier_advancement_monitor",
+    description="Check partition tier placement and log recommendations for misplaced partitions.",
+    minimum_interval_seconds=86400,
+)
+def tier_advancement_sensor(context: SensorEvaluationContext) -> SensorResult:
+    try:
+        from swh.config import settings as swh_settings
+        from swh.tiering import assess_tiers
+
+        dsn = swh_settings.database.direct_psycopg2_dsn
+        partitions = assess_tiers(dsn, hot_window=1)
+        needs_move = [p for p in partitions if p.needs_move]
+
+        if not needs_move:
+            return SensorResult(
+                skip_reason=SkipReason(f"all {len(partitions)} partitions correctly placed")
+            )
+
+        for p in needs_move:
+            context.log.warning(
+                "Partition %s (%s) is on tablespace '%s' but should be on '%s'. "
+                "Run: ALTER TABLE %s SET TABLESPACE %s;",
+                p.partition_name, p.tier.value, p.tablespace,
+                p.recommended_tablespace, p.partition_name, p.recommended_tablespace,
+            )
+
+        return SensorResult(
+            skip_reason=SkipReason(
+                f"{len(needs_move)} partition(s) need tier advancement (logged recommendations)"
+            )
+        )
+
+    except ImportError as exc:
+        context.log.warning("tier_advancement_sensor: missing dependency: %s", exc)
+        return SensorResult(skip_reason=SkipReason(f"missing dependency: {exc}"))
+    except Exception as exc:
+        context.log.warning("tier_advancement_sensor failed: %s", exc)
+        return SensorResult(skip_reason=SkipReason(f"probe failed: {exc}"))
+
+
+all_sensors = [bronze_addresses_sensor, replication_lag_sensor, tier_advancement_sensor]

--- a/swh/cli.py
+++ b/swh/cli.py
@@ -811,5 +811,83 @@ def reconcile_cmd(as_json, all_tables):
             sys.exit(1)
 
 
+@cli.command("tier-status")
+@click.option("--json", "as_json", is_flag=True, help="Output results as JSON")
+@click.option("--hot-window", type=int, default=1, help="Number of recent years considered 'hot' (default: 1)")
+def tier_status_cmd(as_json, hot_window):
+    """Show partition tier placement for partitioned fact tables.
+
+    Classifies each partition as hot, warm, or cold based on its range
+    boundary relative to the current year and flags partitions that
+    should be moved to a different tablespace.
+
+    Examples:
+        swh tier-status
+        swh tier-status --json
+        swh tier-status --hot-window 2
+    """
+    import json as json_mod
+
+    from swh.tiering import Tier, assess_tiers
+
+    dsn = settings.database.direct_psycopg2_dsn
+
+    try:
+        partitions = assess_tiers(dsn, hot_window=hot_window)
+    except Exception as exc:
+        click.echo(click.style(f"  [FAIL]  could not connect: {exc}", fg="red"), err=True)
+        sys.exit(1)
+
+    if as_json:
+        data = [
+            {
+                "parent_table": p.parent_table,
+                "partition": p.partition_name,
+                "tier": p.tier.value,
+                "range_start": p.range_start,
+                "range_end": p.range_end,
+                "tablespace": p.tablespace,
+                "recommended_tablespace": p.recommended_tablespace,
+                "needs_move": p.needs_move,
+                "size_bytes": p.size_bytes,
+                "size_pretty": p.size_pretty,
+                "index_count": p.index_count,
+                "is_default": p.is_default,
+            }
+            for p in partitions
+        ]
+        click.echo(json_mod.dumps(data, indent=2))
+    else:
+        click.echo("Partition Tier Status")
+        click.echo("=" * 70)
+
+        if not partitions:
+            click.echo("  No partitioned fact tables found.")
+        else:
+            by_parent = {}
+            for p in partitions:
+                by_parent.setdefault(p.parent_table, []).append(p)
+
+            for parent in sorted(by_parent):
+                click.echo(f"\n  {parent}:")
+                for p in by_parent[parent]:
+                    tier_colors = {"hot": "red", "warm": "yellow", "cold": "cyan"}
+                    color = tier_colors[p.tier.value]
+                    range_str = f"{p.range_start} → {p.range_end}" if not p.is_default else "DEFAULT"
+                    move_flag = " ← MOVE" if p.needs_move else ""
+                    click.echo(
+                        click.style(f"    [{p.tier.value.upper():4s}]", fg=color)
+                        + f"  {p.partition_name} ({range_str}) {p.size_pretty}"
+                        + f" [{p.index_count} idx] @ {p.tablespace}"
+                        + click.style(move_flag, fg="red")
+                    )
+
+            needs_move = [p for p in partitions if p.needs_move]
+            if needs_move:
+                click.echo(f"\n  {len(needs_move)} partition(s) should be moved:")
+                for p in needs_move:
+                    click.echo(f"    ALTER TABLE {p.partition_name} SET TABLESPACE {p.recommended_tablespace};")
+
+
 if __name__ == "__main__":
     cli()

--- a/swh/tiering.py
+++ b/swh/tiering.py
@@ -1,0 +1,155 @@
+"""Partition tiering assessment for ``swh tier-status`` (#329).
+
+Inspects partitioned fact tables and classifies each partition into
+hot, warm, or cold based on its range boundary relative to the current
+date and the configured hot window.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from enum import Enum
+from typing import Optional
+
+
+class Tier(Enum):
+    HOT = "hot"
+    WARM = "warm"
+    COLD = "cold"
+
+
+@dataclass
+class PartitionInfo:
+    parent_table: str
+    partition_name: str
+    tier: Tier
+    range_start: Optional[str]
+    range_end: Optional[str]
+    tablespace: str
+    size_bytes: int
+    index_count: int
+    is_default: bool
+
+    @property
+    def size_pretty(self) -> str:
+        from swh.audit_indexes import pretty_size
+        return pretty_size(self.size_bytes)
+
+    @property
+    def recommended_tablespace(self) -> str:
+        return {"hot": "pg_default", "warm": "warm_ts", "cold": "cold_ts"}[self.tier.value]
+
+    @property
+    def needs_move(self) -> bool:
+        if self.is_default:
+            return False
+        return self.tablespace != self.recommended_tablespace
+
+
+PARTITIONED_TABLES_SQL = """\
+SELECT
+    nmsp_parent.nspname AS parent_schema,
+    parent.relname AS parent_table,
+    nmsp_child.nspname AS child_schema,
+    child.relname AS partition_name,
+    child.reltablespace,
+    ts.spcname AS tablespace_name,
+    pg_relation_size(child.oid) AS size_bytes,
+    (SELECT count(*) FROM pg_index WHERE indrelid = child.oid) AS index_count,
+    pg_get_expr(child.relpartbound, child.oid) AS partition_bound
+FROM pg_inherits
+JOIN pg_class parent ON pg_inherits.inhparent = parent.oid
+JOIN pg_class child ON pg_inherits.inhrelid = child.oid
+JOIN pg_namespace nmsp_parent ON parent.relnamespace = nmsp_parent.oid
+JOIN pg_namespace nmsp_child ON child.relnamespace = nmsp_child.oid
+LEFT JOIN pg_tablespace ts ON child.reltablespace = ts.oid
+WHERE nmsp_parent.nspname = 'public'
+  AND parent.relname = ANY(%s)
+ORDER BY parent.relname, child.relname;
+"""
+
+PARTITIONED_FACT_TABLES = [
+    "sw_fact_redistricting_plan",
+    "sw_fact_vote_history",
+    "sw_fact_person_score",
+]
+
+
+def _parse_range_year(partition_bound: str) -> Optional[int]:
+    if partition_bound is None or "DEFAULT" in partition_bound.upper():
+        return None
+    import re
+    match = re.search(r"FROM \('([^']+)'\)", partition_bound)
+    if not match:
+        return None
+    val = match.group(1)
+    try:
+        if "-" in val:
+            return int(val[:4])
+        return int(val)
+    except (ValueError, IndexError):
+        return None
+
+
+def _classify_tier(range_year: Optional[int], current_year: int, hot_window: int) -> Tier:
+    if range_year is None:
+        return Tier.HOT
+    age = current_year - range_year
+    if age <= hot_window:
+        return Tier.HOT
+    if age <= hot_window + 4:
+        return Tier.WARM
+    return Tier.COLD
+
+
+def assess_tiers(
+    dsn: str,
+    *,
+    hot_window: int = 1,
+    reference_year: Optional[int] = None,
+) -> list[PartitionInfo]:
+    import psycopg2
+
+    current_year = reference_year or date.today().year
+    results: list[PartitionInfo] = []
+
+    conn = psycopg2.connect(dsn, connect_timeout=10)
+    try:
+        cur = conn.cursor()
+        cur.execute(PARTITIONED_TABLES_SQL, (PARTITIONED_FACT_TABLES,))
+
+        for (parent_schema, parent_table, child_schema, partition_name,
+             reltablespace, tablespace_name, size_bytes, index_count,
+             partition_bound) in cur.fetchall():
+
+            is_default = partition_bound is not None and "DEFAULT" in partition_bound.upper()
+            range_year = _parse_range_year(partition_bound)
+            tier = _classify_tier(range_year, current_year, hot_window)
+
+            range_start = None
+            range_end = None
+            if partition_bound and not is_default:
+                import re
+                from_match = re.search(r"FROM \('([^']+)'\)", partition_bound)
+                to_match = re.search(r"TO \('([^']+)'\)", partition_bound)
+                if from_match:
+                    range_start = from_match.group(1)
+                if to_match:
+                    range_end = to_match.group(1)
+
+            results.append(PartitionInfo(
+                parent_table=parent_table,
+                partition_name=partition_name,
+                tier=tier,
+                range_start=range_start,
+                range_end=range_end,
+                tablespace=tablespace_name or "pg_default",
+                size_bytes=size_bytes,
+                index_count=index_count,
+                is_default=is_default,
+            ))
+    finally:
+        conn.close()
+
+    return results


### PR DESCRIPTION
Closes #329

## Summary

- New `swh/tiering.py` module with partition tier assessment logic (hot/warm/cold)
- New `swh tier-status` CLI subcommand showing partition placement vs recommended tier
- New `tier_advancement_monitor` Dagster sensor (daily, recommend-only mode)
- Updated `docs/production-operations.md` section 5 with tablespace setup, tier advancement runbook, and hydra_columnar guide

## Tier model

| Tier | Tablespace | Indexes | Partitions |
|---|---|---|---|
| Hot | `pg_default` (NVMe) | Full | Current + previous year |
| Warm | `warm_ts` (SSD) | Reduced | N-2 through N-5 |
| Cold | `cold_ts` (HDD/columnar) | PK only | Older than N-5 |

## Files changed

| File | Change |
|---|---|
| `swh/tiering.py` | New — tier assessment logic |
| `swh/cli.py` | New `tier-status` subcommand |
| `orchestration/sensors.py` | New `tier_advancement_monitor` sensor |
| `docs/production-operations.md` | Section 5 update |

## Test plan

- [ ] `swh tier-status --help` shows usage
- [ ] `swh tier-status` against a DB with partitioned tables shows tier classifications
- [ ] `swh tier-status --json` produces valid JSON
- [ ] `tier_advancement_monitor` sensor runs and logs recommendations
- [ ] Partitions before N-5 classified as cold, N-2 through N-5 as warm