### PR TITLE
feat(#330): hub-and-spoke spawn reference configs

### DIFF
--- a/docs/production-operations.md
+++ b/docs/production-operations.md
@@ -277,7 +277,24 @@ Install hydra_columnar when your warehouse exceeds 5 TB or 5 redistricting cycle
 
 **Default-safe recommendation:** Start with a streaming read replica for Django and API traffic (`DATABASES['readonly']`). For non-PostgreSQL consumers (search, graph, BI), read from Delta Lake directly — the data is already there in a format optimized for analytical access. Logical replication and CDC are powerful but operationally expensive; defer until you have a concrete freshness requirement that batch can't meet.
 
-**Implementation pointer:** Read replica setup is part of your HA topology (see §1). Django database routing is a settings change (`DATABASE_ROUTERS`). Delta Lake access is already built into SW's architecture.
+**Implementation:** SW ships reference configurations for four spawn types in `k8s/spawns/`:
+
+| Spawn type | File | Mechanism | Refresh |
+|---|---|---|---|
+| Web OLTP | `logical-replication.sql` | Logical replication publications | Near-real-time |
+| Analytical DB | `pg-dump-partition.sh` | Per-partition pg_dump/restore | Nightly/on-demand |
+| OpenSearch | `debezium-connector.json` | Debezium CDC via Kafka | Real-time |
+| Neo4j | `neo4j-import.cypher` | APOC JDBC import | Nightly/on-demand |
+
+**Web OLTP spawn (logical replication):** Run `logical-replication.sql` on the primary to create publications. Dimension tables (`sw_dim_*`) are published by default; add fact tables if your web app needs them. Create a subscription on the downstream instance pointing to the publication.
+
+**Analytical spawn (pg_dump by partition):** `pg-dump-partition.sh` dumps specific partitions (leveraging §4 partitioning) and restores to a target DB. Includes row-count parity verification. Use for per-engagement or per-cycle snapshots.
+
+**OpenSearch spawn (Debezium CDC):** Register `debezium-connector.json` with Kafka Connect. The connector captures changes from specified tables and publishes to Kafka topics. Pair with the OpenSearch Sink Connector for indexing.
+
+**Neo4j spawn (graph import):** `neo4j-import.cypher` imports persons, geographies, and vote relationships via APOC JDBC. Run nightly or after materialization. Includes parity verification queries.
+
+**Parity monitoring:** All spawn types should verify row counts against the hub. Use the `ParityCheck` model from §11 to record and alert on mismatches. The `pg-dump-partition.sh` script includes built-in parity checks; for other spawns, schedule periodic count comparisons.
 
 ---
 

--- a/k8s/spawns/debezium-connector.json
+++ b/k8s/spawns/debezium-connector.json
@@ -1,0 +1,35 @@
+{
+  "name": "sw-opensearch-cdc",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "primary-host",
+    "database.port": "5432",
+    "database.user": "debezium",
+    "database.password": "${DEBEZIUM_DB_PASSWORD}",
+    "database.dbname": "socialwarehouse",
+    "database.server.name": "socialwarehouse",
+    "plugin.name": "pgoutput",
+    "publication.name": "sw_full",
+    "slot.name": "sw_debezium_opensearch",
+
+    "table.include.list": "public.sw_dim_person,public.sw_dim_geography,public.sw_fact_vote_history,public.sw_fact_person_score",
+
+    "transforms": "route",
+    "transforms.route.type": "org.apache.kafka.connect.transforms.RegexRouter",
+    "transforms.route.regex": "socialwarehouse\\.public\\.(.*)",
+    "transforms.route.replacement": "sw-$1",
+
+    "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "key.converter.schemas.enable": false,
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": false,
+
+    "topic.prefix": "sw-cdc",
+    "heartbeat.interval.ms": 10000,
+    "snapshot.mode": "initial",
+
+    "_comment_setup": "Register via: curl -X POST http://kafka-connect:8083/connectors -H 'Content-Type: application/json' -d @debezium-connector.json",
+    "_comment_opensearch": "Use OpenSearch Sink Connector to consume topics: sw-cdc.public.sw_dim_person, etc.",
+    "_comment_monitoring": "Monitor connector lag via Kafka Connect REST API: GET /connectors/sw-opensearch-cdc/status"
+  }
+}

--- a/k8s/spawns/logical-replication.sql
+++ b/k8s/spawns/logical-replication.sql
@@ -1,0 +1,53 @@
+-- Logical replication publications for hub-to-downstream distribution.
+--
+-- Run on the PRIMARY PostGIS instance. Each publication defines a
+-- filtered subset of hub tables that a downstream subscriber receives.
+--
+-- Prerequisites:
+--   wal_level = logical  (set in postgresql.conf or CNPG cluster.yaml)
+--   max_replication_slots >= number of subscribers + WAL archiving slots
+--   max_wal_senders >= max_replication_slots
+
+-- Publication: Django OLTP web app
+-- All sw_dim_* and sw_geo_* tables (dimensions + geography).
+-- Fact tables excluded by default — web app reads facts via API,
+-- not direct DB queries. Add specific fact tables if your web app
+-- needs them.
+CREATE PUBLICATION sw_web_oltp FOR TABLE
+    sw_dim_geography,
+    sw_dim_person,
+    sw_dim_redistricting_cycle,
+    sw_dim_survey,
+    sw_dim_census_variable,
+    sw_dim_time
+WITH (publish = 'insert, update, delete, truncate');
+
+-- Publication: monitoring tables (for a dedicated observability DB)
+CREATE PUBLICATION sw_monitoring FOR TABLE
+    sw_monitoring_materialization,
+    sw_monitoring_replication_lag,
+    sw_monitoring_parity_check
+WITH (publish = 'insert, update, delete, truncate');
+
+-- Publication: full warehouse (all sw_* tables)
+-- Use with caution — this replicates everything including fact tables.
+-- Suitable for a full read replica, not for selective spawns.
+CREATE PUBLICATION sw_full FOR ALL TABLES IN SCHEMA public;
+
+-- Subscriber setup (run on the DOWNSTREAM instance):
+--
+-- CREATE SUBSCRIPTION sw_web_oltp_sub
+--     CONNECTION 'host=primary-host port=5432 dbname=socialwarehouse user=replication_user password=...'
+--     PUBLICATION sw_web_oltp
+--     WITH (
+--         copy_data = true,          -- initial data sync
+--         create_slot = true,        -- auto-create replication slot
+--         slot_name = 'sw_web_oltp'  -- named slot for monitoring
+--     );
+--
+-- Verify replication status:
+--   SELECT * FROM pg_stat_subscription;
+--
+-- Parity monitoring:
+--   Compare row counts between hub and spawn using sw_monitoring_parity_check
+--   (see docs/production-operations.md section 11).

--- a/k8s/spawns/neo4j-import.cypher
+++ b/k8s/spawns/neo4j-import.cypher
@@ -1,0 +1,84 @@
+// Neo4j graph import template for SocialWarehouse.
+//
+// Imports person-geography-vote relationships from PostGIS hub
+// into a Neo4j graph database for relationship queries.
+//
+// Prerequisites:
+//   - Neo4j APOC plugin installed
+//   - JDBC driver for PostgreSQL available to Neo4j
+//   - Network access from Neo4j to PostGIS hub (direct connection)
+//
+// Usage:
+//   neo4j-admin database import cypher --from=neo4j-import.cypher
+//   OR run queries individually via Neo4j Browser / cypher-shell.
+//
+// Refresh cadence: nightly or on-demand after materialization.
+
+// --- Constraints (run once) ---
+
+CREATE CONSTRAINT person_id IF NOT EXISTS
+FOR (p:Person) REQUIRE p.person_id IS UNIQUE;
+
+CREATE CONSTRAINT geography_geoid IF NOT EXISTS
+FOR (g:Geography) REQUIRE g.geoid IS UNIQUE;
+
+CREATE CONSTRAINT cycle_id IF NOT EXISTS
+FOR (c:RedistrictingCycle) REQUIRE c.cycle_id IS UNIQUE;
+
+// --- Node import: Persons ---
+// Uses APOC JDBC to stream from PostGIS.
+// Replace jdbc-url with your PostGIS direct connection.
+
+CALL apoc.load.jdbc(
+  'jdbc:postgresql://primary-host:5432/socialwarehouse?user=socialwarehouse&password=...',
+  'SELECT id, first_name, last_name, state_voter_id, registration_status FROM sw_dim_person'
+) YIELD row
+MERGE (p:Person {person_id: row.id})
+SET p.first_name = row.first_name,
+    p.last_name = row.last_name,
+    p.state_voter_id = row.state_voter_id,
+    p.registration_status = row.registration_status;
+
+// --- Node import: Geographies ---
+
+CALL apoc.load.jdbc(
+  'jdbc:postgresql://primary-host:5432/socialwarehouse?user=socialwarehouse&password=...',
+  'SELECT id, geoid, name, geo_level FROM sw_dim_geography'
+) YIELD row
+MERGE (g:Geography {geoid: row.geoid})
+SET g.geography_id = row.id,
+    g.name = row.name,
+    g.geo_level = row.geo_level;
+
+// --- Node import: Redistricting Cycles ---
+
+CALL apoc.load.jdbc(
+  'jdbc:postgresql://primary-host:5432/socialwarehouse?user=socialwarehouse&password=...',
+  'SELECT id, cycle_year FROM sw_dim_redistricting_cycle'
+) YIELD row
+MERGE (c:RedistrictingCycle {cycle_id: row.id})
+SET c.cycle_year = row.cycle_year;
+
+// --- Relationship import: VOTED_IN ---
+
+CALL apoc.load.jdbc(
+  'jdbc:postgresql://primary-host:5432/socialwarehouse?user=socialwarehouse&password=...',
+  'SELECT person_id, election_date, election_type, voted_method FROM sw_fact_vote_history'
+) YIELD row
+MATCH (p:Person {person_id: row.person_id})
+MERGE (p)-[:VOTED_IN {
+  election_date: row.election_date,
+  election_type: row.election_type,
+  voted_method: row.voted_method
+}]->(e:Election {date: row.election_date, type: row.election_type})
+ON CREATE SET e.election_date = row.election_date,
+              e.election_type = row.election_type;
+
+// --- Parity verification ---
+// After import, compare counts:
+//
+//   MATCH (p:Person) RETURN count(p) AS neo4j_person_count;
+//   -- Compare with: SELECT count(*) FROM sw_dim_person;
+//
+//   MATCH ()-[v:VOTED_IN]->() RETURN count(v) AS neo4j_vote_count;
+//   -- Compare with: SELECT count(*) FROM sw_fact_vote_history;

--- a/k8s/spawns/pg-dump-partition.sh
+++ b/k8s/spawns/pg-dump-partition.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Per-partition pg_dump template for analytical DB spawns.
+#
+# Dumps a single partition (or set of partitions) from the hub and
+# restores to a target analytical database. Designed for per-engagement
+# or per-cycle snapshots.
+#
+# Usage:
+#   ./pg-dump-partition.sh \
+#     --source-host primary-host \
+#     --source-db socialwarehouse \
+#     --target-host analytical-host \
+#     --target-db engagement_tx_2024 \
+#     --tables "sw_fact_vote_history_2024,sw_fact_person_score_2024"
+#
+# Prerequisites:
+#   - pg_dump and pg_restore installed (same major version as source)
+#   - Network access from dump host to both source and target
+#   - PGPASSWORD or .pgpass configured for both connections
+
+set -euo pipefail
+
+SOURCE_HOST=""
+SOURCE_PORT="5432"
+SOURCE_DB="socialwarehouse"
+SOURCE_USER="socialwarehouse"
+TARGET_HOST=""
+TARGET_PORT="5432"
+TARGET_DB=""
+TARGET_USER="socialwarehouse"
+TABLES=""
+DUMP_DIR="/tmp/sw-partition-dump"
+PARALLEL_JOBS=4
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --source-host) SOURCE_HOST="$2"; shift 2 ;;
+        --source-port) SOURCE_PORT="$2"; shift 2 ;;
+        --source-db)   SOURCE_DB="$2";   shift 2 ;;
+        --source-user) SOURCE_USER="$2"; shift 2 ;;
+        --target-host) TARGET_HOST="$2"; shift 2 ;;
+        --target-port) TARGET_PORT="$2"; shift 2 ;;
+        --target-db)   TARGET_DB="$2";   shift 2 ;;
+        --target-user) TARGET_USER="$2"; shift 2 ;;
+        --tables)      TABLES="$2";      shift 2 ;;
+        --dump-dir)    DUMP_DIR="$2";    shift 2 ;;
+        --jobs)        PARALLEL_JOBS="$2"; shift 2 ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [[ -z "$SOURCE_HOST" || -z "$TARGET_HOST" || -z "$TARGET_DB" || -z "$TABLES" ]]; then
+    echo "Required: --source-host, --target-host, --target-db, --tables" >&2
+    exit 1
+fi
+
+mkdir -p "$DUMP_DIR"
+
+IFS=',' read -ra TABLE_ARRAY <<< "$TABLES"
+TABLE_FLAGS=""
+for t in "${TABLE_ARRAY[@]}"; do
+    TABLE_FLAGS="$TABLE_FLAGS --table=$t"
+done
+
+echo "[$(date -Iseconds)] Dumping ${#TABLE_ARRAY[@]} table(s) from $SOURCE_HOST:$SOURCE_PORT/$SOURCE_DB..."
+
+pg_dump \
+    --host="$SOURCE_HOST" \
+    --port="$SOURCE_PORT" \
+    --username="$SOURCE_USER" \
+    --dbname="$SOURCE_DB" \
+    --format=directory \
+    --jobs="$PARALLEL_JOBS" \
+    --no-owner \
+    --no-privileges \
+    $TABLE_FLAGS \
+    --file="$DUMP_DIR"
+
+echo "[$(date -Iseconds)] Dump complete. Restoring to $TARGET_HOST:$TARGET_PORT/$TARGET_DB..."
+
+# Dimension tables (required for FK references) should already exist
+# on the target. If not, dump and restore them first.
+
+pg_restore \
+    --host="$TARGET_HOST" \
+    --port="$TARGET_PORT" \
+    --username="$TARGET_USER" \
+    --dbname="$TARGET_DB" \
+    --jobs="$PARALLEL_JOBS" \
+    --no-owner \
+    --no-privileges \
+    --clean \
+    --if-exists \
+    "$DUMP_DIR"
+
+echo "[$(date -Iseconds)] Restore complete."
+
+# Row count verification
+echo "[$(date -Iseconds)] Verifying row counts..."
+for t in "${TABLE_ARRAY[@]}"; do
+    SOURCE_COUNT=$(psql -h "$SOURCE_HOST" -p "$SOURCE_PORT" -U "$SOURCE_USER" -d "$SOURCE_DB" -tAc "SELECT count(*) FROM $t")
+    TARGET_COUNT=$(psql -h "$TARGET_HOST" -p "$TARGET_PORT" -U "$TARGET_USER" -d "$TARGET_DB" -tAc "SELECT count(*) FROM $t")
+    if [[ "$SOURCE_COUNT" == "$TARGET_COUNT" ]]; then
+        echo "  [PARITY] $t: $SOURCE_COUNT rows"
+    else
+        echo "  [MISMATCH] $t: source=$SOURCE_COUNT target=$TARGET_COUNT" >&2
+    fi
+done
+
+rm -rf "$DUMP_DIR"
+echo "[$(date -Iseconds)] Done."


### PR DESCRIPTION
Closes #330

## Summary

- New `k8s/spawns/` directory with four spawn reference configurations
- `logical-replication.sql`: publications for Django OLTP spawn
- `pg-dump-partition.sh`: per-partition dump/restore with parity verification
- `debezium-connector.json`: Debezium CDC for OpenSearch
- `neo4j-import.cypher`: APOC JDBC graph import template
- Updated `docs/production-operations.md` section 6 with implementation details

## Test plan

- [ ] SQL publications create successfully on a PostGIS instance with `wal_level=logical`
- [ ] `pg-dump-partition.sh --help` shows usage
- [ ] Debezium connector JSON validates with Kafka Connect dry-run
- [ ] Neo4j Cypher import runs against a test PostGIS + Neo4j pair