### PR TITLE
[F] Attestation variant-linking abstract base classes (#351)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,6 +140,18 @@ Lookup helpers — `Attestation.for_entity(...)`, `Attestation.canonical_for(...
 
 **`FECAttestation`** is the first concrete kind, a Django **multi-table-inheritance** child (table `sw_fec_attestation`) adding FEC-form provenance (`source_artifact_hash`, `source_artifact_id`, `parser_version`, `fec_form_type`, `fec_form_version`) and defaulting `attestation_kind` to `fec`. Future kinds (e.g. `EntityResolutionAttestation`) attach to the same superclass and may relocate to domain apps as the taxonomy grows.
 
+### Attestation variant-linking shapes (SW#351)
+
+Entity families link to `Attestation` in three different shapes, each shipped as an **abstract base class** in `core/`. SW ships no concrete subclass — adopters subclass per entity type in their own app, so there are no template-side tables or migrations.
+
+| Base | Shape | When to use | Adopter example |
+|---|---|---|---|
+| `AttestationSubtypeLink` | `(attestation, entity_subtype, source_type)` | A polymorphic Attestation indexes a typed subtype detail row | `CommitteeAttestationLink` |
+| `AttestationJunction` | `(entity_fk [adopter], attestation)` | Plain many-to-many: an entity has many attestations and vice versa | `FilingAttestationLink` |
+| `ResolutionAttestation` | `raw_input` + `resolved_*` + `resolution_*` | The row records RAW input, the RESOLVED canonical target, and resolution metadata (status, confidence, resolver, run) | `AddressResolutionAttestation` |
+
+The junction and subtype-link bases supply the `Attestation` FK (with a `%(class)s` reverse accessor); the adopter adds the entity side. `ResolutionAttestation` is the genuinely different shape — it is not "link entity to attestation" but "record how a raw input resolved to a canonical entity," with an `is_resolved` convenience property.
+
 ## Cross-references
 
 - Initiative SW#284 (General Civic Ontology) — design doc: [`docs/designs/ontology.md`](designs/ontology.md).

--- a/socialwarehouse/core/attestation_links.py
+++ b/socialwarehouse/core/attestation_links.py
@@ -1,0 +1,165 @@
+"""Abstract base classes for the three attestation variant-linking shapes.
+
+Not every entity family links to the central :class:`Attestation` the
+same way. The electinfo data shows three distinct shapes:
+
+- **thin subtype-link** (``committee_attestations``, ``person_attestations``):
+  a polymorphic Attestation points at a subtype detail through a thin
+  index row that records the subtype and source.
+- **junction** (``filing_attestations``): a plain many-to-many between an
+  entity and its attestations.
+- **full resolution** (``address_attestations``): the row records the RAW
+  input, the RESOLVED canonical target, and resolution metadata — not a
+  simple "link entity to attestation" shape.
+
+Each ships here as a Django **abstract base class**. Adopters subclass
+per entity type in their own app (e.g.
+``class CommitteeAttestationLink(AttestationSubtypeLink)``); SW ships no
+concrete subclass, so there are no tables and no migration on the
+template side.
+"""
+
+from django.db import models
+
+
+class AttestationSubtypeLink(models.Model):
+    """Thin link from an Attestation to a typed subtype detail row.
+
+    Preserves the Attestation FK while letting the linked subtype be
+    specific. Adopters subclass per entity type and add whatever subtype
+    FK they need alongside this base's fields.
+
+    Shape: ``(attestation, entity_subtype, source_type)``.
+    """
+
+    attestation = models.ForeignKey(
+        "sw_core.Attestation",
+        on_delete=models.CASCADE,
+        related_name="%(class)s_links",
+        related_query_name="%(class)s_link",
+        help_text="The attestation this link indexes",
+    )
+    entity_subtype = models.CharField(
+        max_length=40,
+        db_index=True,
+        help_text="Kind of subtype detail this link points at",
+    )
+    source_type = models.CharField(
+        max_length=40,
+        blank=True,
+        default="",
+        db_index=True,
+        help_text="Source-system type that produced the link",
+    )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+
+class AttestationJunction(models.Model):
+    """Many-to-many junction between an entity and its attestations.
+
+    A single entity can carry many attestations; an attestation can
+    describe many entities. This base supplies the Attestation side;
+    adopters add the entity FK on their concrete subclass and declare a
+    ``unique_together`` over the pair.
+
+    Shape: ``(entity_fk [adopter-supplied], attestation)``.
+    """
+
+    attestation = models.ForeignKey(
+        "sw_core.Attestation",
+        on_delete=models.CASCADE,
+        related_name="%(class)s_junctions",
+        related_query_name="%(class)s_junction",
+        help_text="The attestation linked to the adopter's entity",
+    )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        abstract = True
+
+
+RESOLUTION_PENDING = "pending"
+RESOLUTION_RESOLVED = "resolved"
+RESOLUTION_AMBIGUOUS = "ambiguous"
+RESOLUTION_UNRESOLVED = "unresolved"
+
+RESOLUTION_STATUS_CHOICES = [
+    (RESOLUTION_PENDING, "Pending"),
+    (RESOLUTION_RESOLVED, "Resolved"),
+    (RESOLUTION_AMBIGUOUS, "Ambiguous"),
+    (RESOLUTION_UNRESOLVED, "Unresolved"),
+]
+
+
+class ResolutionAttestation(models.Model):
+    """Full-resolution shape: raw input, resolved target, and metadata.
+
+    Unlike the link/junction shapes, a resolution attestation records the
+    RAW input that was resolved, the RESOLVED canonical target, and how
+    the resolution was reached. Address resolution is the canonical case
+    (``address_attestations``). Adopters subclass per resolved entity
+    type and typically add a concrete FK to the resolved target
+    alongside the ``resolved_entity_id`` / ``resolved_entity_subtype``
+    pair kept here for uniform polymorphic access.
+
+    Shape: ``raw_input`` + ``resolved_*`` + ``resolution_*`` metadata.
+    """
+
+    raw_input = models.JSONField(
+        default=dict,
+        blank=True,
+        help_text="The raw, unresolved input that was submitted for resolution",
+    )
+    resolved_entity_id = models.UUIDField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="entity_uuid of the resolved canonical target (NULL until resolved)",
+    )
+    resolved_entity_subtype = models.CharField(
+        max_length=40,
+        blank=True,
+        default="",
+        help_text="Kind of the resolved canonical target",
+    )
+    resolution_status = models.CharField(
+        max_length=20,
+        choices=RESOLUTION_STATUS_CHOICES,
+        default=RESOLUTION_PENDING,
+        db_index=True,
+        help_text="Outcome of the resolution attempt",
+    )
+    resolution_confidence = models.DecimalField(
+        max_digits=5,
+        decimal_places=4,
+        null=True,
+        blank=True,
+        help_text="Resolution confidence in [0, 1]; NULL if not scored",
+    )
+    resolver_source = models.CharField(
+        max_length=60,
+        blank=True,
+        default="",
+        help_text="Resolver / pipeline that produced this resolution",
+    )
+    run_id = models.UUIDField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="Resolution run that produced this row, for lineage",
+    )
+
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+
+    @property
+    def is_resolved(self):
+        return self.resolution_status == RESOLUTION_RESOLVED and self.resolved_entity_id is not None

--- a/socialwarehouse/core/models.py
+++ b/socialwarehouse/core/models.py
@@ -8,6 +8,11 @@ from socialwarehouse.core.attestation import (  # noqa: F401
     Attestation,
     FECAttestation,
 )
+from socialwarehouse.core.attestation_links import (  # noqa: F401
+    AttestationJunction,
+    AttestationSubtypeLink,
+    ResolutionAttestation,
+)
 
 
 class EntityIdentifier(models.Model):

--- a/tests/unit/core/test_attestation_links.py
+++ b/tests/unit/core/test_attestation_links.py
@@ -1,0 +1,135 @@
+"""Tests for the three attestation variant-linking abstract base classes.
+
+The bases ship abstract (no template-side tables). These tests stand in
+as the adopter: each declares a concrete subclass, materializes its
+table with the schema editor in setUpClass, and exercises real DB
+behavior against the central Attestation. The concrete models are
+test-only (no migration), so they do not affect the template schema.
+"""
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from django.db import connection, models
+from django.test import TransactionTestCase
+
+from socialwarehouse.core.attestation import Attestation
+from socialwarehouse.core.attestation_links import (
+    RESOLUTION_RESOLVED,
+    AttestationJunction,
+    AttestationSubtypeLink,
+    ResolutionAttestation,
+)
+
+
+# Test-only concrete subclasses standing in for adopter models. Defined
+# under the sw_core label; they carry no migration, so setUpClass builds
+# their tables with the schema editor and tearDownClass drops them.
+class CommitteeAttestationLink(AttestationSubtypeLink):
+    class Meta:
+        app_label = "sw_core"
+
+
+class FilingAttestationLink(AttestationJunction):
+    filing_id = models.UUIDField()
+
+    class Meta:
+        app_label = "sw_core"
+        unique_together = [("filing_id", "attestation")]
+
+
+class AddressResolutionAttestation(ResolutionAttestation):
+    class Meta:
+        app_label = "sw_core"
+
+
+def _mk_attestation():
+    return Attestation.objects.create(
+        entity_id=uuid.uuid4(),
+        entity_subtype="committee",
+        attestation_kind="fec",
+        data_source="fec",
+    )
+
+
+class _SchemaManaged(TransactionTestCase):
+    """Base that creates/drops one test-only concrete model's table."""
+
+    concrete_model = None
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        with connection.schema_editor() as editor:
+            editor.create_model(cls.concrete_model)
+
+    @classmethod
+    def tearDownClass(cls):
+        with connection.schema_editor() as editor:
+            editor.delete_model(cls.concrete_model)
+        super().tearDownClass()
+
+
+@pytest.mark.django_db(transaction=True)
+class TestAttestationSubtypeLink(_SchemaManaged):
+    concrete_model = CommitteeAttestationLink
+
+    def test_abstract(self):
+        assert AttestationSubtypeLink._meta.abstract is True
+
+    def test_adopter_subclass_links_to_attestation(self):
+        att = _mk_attestation()
+        link = CommitteeAttestationLink.objects.create(
+            attestation=att, entity_subtype="committee", source_type="fec_bulk"
+        )
+        assert link.attestation == att
+        assert link.entity_subtype == "committee"
+        # Reverse accessor uses the %(class)s pattern on the base FK.
+        assert att.committeeattestationlink_links.count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+class TestAttestationJunction(_SchemaManaged):
+    concrete_model = FilingAttestationLink
+
+    def test_abstract(self):
+        assert AttestationJunction._meta.abstract is True
+
+    def test_adopter_junction_many_to_many(self):
+        filing_id = uuid.uuid4()
+        a1 = _mk_attestation()
+        a2 = _mk_attestation()
+        FilingAttestationLink.objects.create(filing_id=filing_id, attestation=a1)
+        FilingAttestationLink.objects.create(filing_id=filing_id, attestation=a2)
+        # One filing, two attestations.
+        assert FilingAttestationLink.objects.filter(filing_id=filing_id).count() == 2
+        assert a1.filingattestationlink_junctions.count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+class TestResolutionAttestation(_SchemaManaged):
+    concrete_model = AddressResolutionAttestation
+
+    def test_abstract(self):
+        assert ResolutionAttestation._meta.abstract is True
+
+    def test_adopter_resolution_records_raw_and_resolved(self):
+        resolved_id = uuid.uuid4()
+        row = AddressResolutionAttestation.objects.create(
+            raw_input={"line1": "123 Main St", "zip": "78701"},
+            resolved_entity_id=resolved_id,
+            resolved_entity_subtype="address",
+            resolution_status=RESOLUTION_RESOLVED,
+            resolution_confidence=Decimal("0.9900"),
+            resolver_source="census_geocoder",
+            run_id=uuid.uuid4(),
+        )
+        assert row.is_resolved is True
+        assert row.raw_input["zip"] == "78701"
+        assert row.resolved_entity_id == resolved_id
+
+    def test_unresolved_default_is_not_resolved(self):
+        pending = AddressResolutionAttestation.objects.create(raw_input={"line1": "garbled"})
+        # Default status is pending; not resolved without a target.
+        assert pending.is_resolved is False


### PR DESCRIPTION
Closes #351. Part of the [F] epic #347.

> **Stacked PR.** Base is `feature/sw350-attestation` (PR #353). **Merge order: #352 (#348) → #353 (#350) → this (#351).** Bases retarget to `develop` as parents land.

## What

Adds the three attestation variant-linking shapes as **abstract base classes** in `core/`. SW ships no concrete subclass — adopters subclass per entity type in their own app, so there are **no template-side tables and no migration**.

| Base | Shape | Use |
|---|---|---|
| `AttestationSubtypeLink` | `(attestation, entity_subtype, source_type)` | Thin index from a polymorphic Attestation to a typed subtype detail |
| `AttestationJunction` | `(entity_fk [adopter], attestation)` | Plain many-to-many entity↔attestation |
| `ResolutionAttestation` | `raw_input` + `resolved_*` + `resolution_*` | Records RAW input, RESOLVED canonical target, and resolution metadata (status, confidence, resolver, run); `is_resolved` property |

The link/junction bases supply the `Attestation` FK with a `%(class)s` reverse accessor; the adopter adds the entity side. `ResolutionAttestation` is the genuinely different shape (e.g. `address_attestations`): not "link entity→attestation" but "record how a raw input resolved."

## Design notes

- Placed in `core/` alongside `Attestation`, **not** in a separate `attestations/` app. (The #351 ticket body mentioned `socialwarehouse/attestations/`, but the F(c) ruling on #350 closed that app out — everything lands in `core/`. Flagging this reconciliation explicitly.)
- Abstract by ratification (Dheeraj 2026-06-18): enforceable shapes adopters subclass.

## Tests

`tests/unit/core/test_attestation_links.py` (7) — each base is asserted abstract, then an adopter-style concrete subclass is materialized with the schema editor and exercised against the real `Attestation` table: subtype-link FK + reverse accessor, junction many-to-many (one filing → two attestations), and resolution raw→resolved + `is_resolved` (resolved vs pending). Uses `TransactionTestCase` so the on-the-fly DDL works on both sqlite and the PostGIS CI DB.

## Verification

Isolated harness: `manage.py check` clean, **abstract bases generate no migration** (confirmed via `makemigrations --dry-run`), **7/7 tests pass**.

## Docs

`docs/architecture.md` — "Attestation variant-linking shapes" subsection (the three shapes, when each applies, the ABC-subclass pattern).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recording attestations from multiple sources, including provenance, source authority, payload tracking, and canonical values.
  - Added FEC-specific attestations with source and parser metadata.
  - Added reusable links for associating attestations with entities and relationships.
  - Added entity-resolution records with statuses, confidence, raw input, and resolved targets.
  - Enforced a single canonical attestation per entity and attestation type.
- **Database**
  - Added tables, indexes, and constraints required for attestation storage and lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->