### PR TITLE
[F] Event canonicalization layer + Transaction subtype (#349)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,43 @@
 import django
+import pytest
 from django.conf import settings
 
 
 def pytest_configure():
     settings.DJANGO_SETTINGS_MODULE = "socialwarehouse.settings.test"
     django.setup()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _attestation_link_test_tables(django_db_setup, django_db_blocker):
+    """Create the test-only concrete attestation-link tables session-wide.
+
+    ``tests/unit/core/test_attestation_links.py`` declares its adopter stand-in
+    models (CommitteeAttestationLink / FilingAttestationLink /
+    AddressResolutionAttestation) at module level, so they are registered in the
+    app registry — each with an FK to ``core.Attestation`` — for the entire test
+    session. Any test that deletes an Attestation (e.g. the Event-canonicalization
+    ``SET_NULL`` test) traverses these reverse relations via Django's
+    delete-collector and queries their tables. The tables must therefore exist
+    for the whole session regardless of test order (events tests run before core
+    tests). Create them once here; the test-DB teardown drops them at session end.
+    """
+    from django.db import connection
+
+    with django_db_blocker.unblock():
+        from tests.unit.core.test_attestation_links import (
+            AddressResolutionAttestation,
+            CommitteeAttestationLink,
+            FilingAttestationLink,
+        )
+
+        existing = set(connection.introspection.table_names())
+        with connection.schema_editor() as editor:
+            for model in (
+                CommitteeAttestationLink,
+                FilingAttestationLink,
+                AddressResolutionAttestation,
+            ):
+                if model._meta.db_table not in existing:
+                    editor.create_model(model)
+    yield

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,10 +104,12 @@ SW canonical supports adopters whose source data carries multi-source provenance
 | Supertype | Role | Subtypes | Status |
 |---|---|---|---|
 | `Agent` | Identity hub for actors | `Person`, `Committee`, `Organization` (domain-app detail rows) | Landed (SW#348) |
-| `Event` | Canonicalization hub for events | `Transaction` (Contribution / Expenditure / Transfer / Obligation), and future siblings (election, disaster) | Planned (SW#349) |
+| `Event` | Canonicalization hub for events | `Transaction` (Contribution / Expenditure / Transfer / Obligation), alongside the existing Corporate / SpatioTemporal / Electoral subtypes | Landed (SW#349, in `events/`) |
 | `Attestation` | Multi-source provenance / canonical-truth records | `FECAttestation` first; entity-resolution attestation a future sibling | Landed (SW#350) |
 
 `core/` holds the polymorphic **bases only**; concrete subtype detail lives in the domain apps. This keeps the canonical-truth abstractions in one place while letting each domain own its specific columns.
+
+**Placement note (pragmatic, not symmetric).** `Agent` and `Attestation` are new constructs, so they land in `core/`. `Event` already existed in `events/` as the shared event query surface that ties the ontology together; SW#349 extended it in place rather than moving the model across apps (a model relocation would risk the migration on a load-bearing table). So the canonical-truth layer is `Agent` + `Attestation` in `core/` and `Event` in `events/` — the architecture documents the lower-risk choice over the symmetric one.
 
 ### Agent supertype (SW#348)
 
@@ -151,6 +153,20 @@ Entity families link to `Attestation` in three different shapes, each shipped as
 | `ResolutionAttestation` | `raw_input` + `resolved_*` + `resolution_*` | The row records RAW input, the RESOLVED canonical target, and resolution metadata (status, confidence, resolver, run) | `AddressResolutionAttestation` |
 
 The junction and subtype-link bases supply the `Attestation` FK (with a `%(class)s` reverse accessor); the adopter adds the entity side. `ResolutionAttestation` is the genuinely different shape — it is not "link entity to attestation" but "record how a raw input resolved to a canonical entity," with an `is_resolved` convenience property.
+
+### Event supertype + canonicalization (SW#349)
+
+`events.Event` (table `sw_event`) is the unified event supertype — the shared query surface that answers "all events involving Agent X" via `EventParticipant`. SW#349 extended it **additively** with the canonicalization layer so every event subtype inherits it:
+
+- `canonical_attestation` — FK to `core.Attestation` (`SET_NULL`), a **fast-lookup cache** of the winning attestation. The **source of truth** is `Attestation.is_canonical` (partial-unique-enforced on the Attestation side); the FK is an intentional denormalized cache, not a second truth.
+- `attestation_disagreement` — flags conflicting source attestations.
+- `is_amended` / `amendment_count` / `event_state` (`active` / `amended` / `withdrawn` / `superseded`) — revision tracking.
+
+The existing discriminator field `event_type` (which already included `transaction`) is **kept as-is** — no rename, no shadowing `event_subtype` field — to avoid breaking downstream consumers.
+
+**`Transaction` as a first-class Event subtype.** `transactions.Transaction` (table `sw_transaction`) is a one-to-one detail row on an `Event` with `event_type='transaction'`, mirroring the existing `CorporateEvent` / `SpatioTemporalEvent` / `ElectoralEvent` pattern. It carries the transaction-level financial summary (`transaction_subtype` = contribution/expenditure/transfer/obligation, `amount`, `currency`, `transaction_date`); the Event carries the canonicalization layer.
+
+The existing typed records (`Contribution` / `Expenditure` / `Transfer` / `ObligationEvent`) gain a **nullable** `event` FK (`%(class)s_records` reverse accessor) so they roll up to their canonical Event without a destructive change to the merged four-table design. Transaction parties are recorded through the shared `EventParticipant` bridge (payer = `source`, payee = `target`); the typed records' `from_agent` / `to_agent` fields remain as a transaction-specific specialization.
 
 ## Cross-references
 

--- a/socialwarehouse/events/migrations/0002_event_canonicalization.py
+++ b/socialwarehouse/events/migrations/0002_event_canonicalization.py
@@ -1,0 +1,73 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_core", "0003_attestation"),
+        ("sw_events", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="event",
+            name="canonical_attestation",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Fast-lookup cache of the canonical attestation; truth is Attestation.is_canonical",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="canonical_for_events",
+                to="sw_core.attestation",
+            ),
+        ),
+        migrations.AddField(
+            model_name="event",
+            name="attestation_disagreement",
+            field=models.BooleanField(
+                db_index=True,
+                default=False,
+                help_text="True when source attestations for this event conflict",
+            ),
+        ),
+        migrations.AddField(
+            model_name="event",
+            name="is_amended",
+            field=models.BooleanField(
+                default=False,
+                help_text="True when this event has been amended by a later revision",
+            ),
+        ),
+        migrations.AddField(
+            model_name="event",
+            name="amendment_count",
+            field=models.PositiveIntegerField(
+                default=0,
+                help_text="Number of amendments applied to this event",
+            ),
+        ),
+        migrations.AddField(
+            model_name="event",
+            name="event_state",
+            field=models.CharField(
+                choices=[
+                    ("active", "Active"),
+                    ("amended", "Amended"),
+                    ("withdrawn", "Withdrawn"),
+                    ("superseded", "Superseded"),
+                ],
+                db_index=True,
+                default="active",
+                help_text="active / amended / withdrawn / superseded",
+                max_length=20,
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="event",
+            index=models.Index(
+                fields=["event_type", "event_state"],
+                name="idx_event_type_state",
+            ),
+        ),
+    ]

--- a/socialwarehouse/events/models/events.py
+++ b/socialwarehouse/events/models/events.py
@@ -5,12 +5,18 @@ from socialwarehouse.core.mixins import (
     generate_entity_uuid4,
 )
 
-
 EVENT_TYPE_CHOICES = [
     ("transaction", "Transaction"),
     ("corporate", "Corporate Event"),
     ("spatiotemporal", "Spatio-Temporal Event"),
     ("electoral", "Electoral Event"),
+]
+
+EVENT_STATE_CHOICES = [
+    ("active", "Active"),
+    ("amended", "Amended"),
+    ("withdrawn", "Withdrawn"),
+    ("superseded", "Superseded"),
 ]
 
 AGENT_TYPE_CHOICES = [
@@ -82,6 +88,41 @@ class Event(SourceAwareModel):
         help_text="Event year, derived from event_date",
     )
     description = models.TextField(blank=True, default="")
+
+    # Canonicalization layer (SW#349). All event subtypes inherit these by
+    # being attached to an Event. canonical_attestation is a fast-lookup
+    # cache pointing at the winning Attestation; the source of truth is
+    # Attestation.is_canonical (partial-unique-enforced on the Attestation
+    # side). attestation_disagreement flags conflicting source attestations.
+    canonical_attestation = models.ForeignKey(
+        "sw_core.Attestation",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="canonical_for_events",
+        help_text="Fast-lookup cache of the canonical attestation; truth is Attestation.is_canonical",
+    )
+    attestation_disagreement = models.BooleanField(
+        default=False,
+        db_index=True,
+        help_text="True when source attestations for this event conflict",
+    )
+    is_amended = models.BooleanField(
+        default=False,
+        help_text="True when this event has been amended by a later revision",
+    )
+    amendment_count = models.PositiveIntegerField(
+        default=0,
+        help_text="Number of amendments applied to this event",
+    )
+    event_state = models.CharField(
+        max_length=20,
+        choices=EVENT_STATE_CHOICES,
+        default="active",
+        db_index=True,
+        help_text="active / amended / withdrawn / superseded",
+    )
+
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
@@ -96,6 +137,10 @@ class Event(SourceAwareModel):
             models.Index(
                 fields=["event_type", "jurisdiction_state", "year"],
                 name="idx_event_type_state_year",
+            ),
+            models.Index(
+                fields=["event_type", "event_state"],
+                name="idx_event_type_state",
             ),
         ]
 

--- a/socialwarehouse/transactions/migrations/0002_transaction_and_event_links.py
+++ b/socialwarehouse/transactions/migrations/0002_transaction_and_event_links.py
@@ -1,0 +1,146 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("sw_events", "0002_event_canonicalization"),
+        ("sw_transactions", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="contribution",
+            name="event",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Canonical Event this transaction record rolls up to",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="%(class)s_records",
+                related_query_name="%(class)s_record",
+                to="sw_events.event",
+            ),
+        ),
+        migrations.AddField(
+            model_name="expenditure",
+            name="event",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Canonical Event this transaction record rolls up to",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="%(class)s_records",
+                related_query_name="%(class)s_record",
+                to="sw_events.event",
+            ),
+        ),
+        migrations.AddField(
+            model_name="transfer",
+            name="event",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Canonical Event this transaction record rolls up to",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="%(class)s_records",
+                related_query_name="%(class)s_record",
+                to="sw_events.event",
+            ),
+        ),
+        migrations.AddField(
+            model_name="obligationevent",
+            name="event",
+            field=models.ForeignKey(
+                blank=True,
+                help_text="Canonical Event this transaction record rolls up to",
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="%(class)s_records",
+                related_query_name="%(class)s_record",
+                to="sw_events.event",
+            ),
+        ),
+        migrations.CreateModel(
+            name="Transaction",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "transaction_subtype",
+                    models.CharField(
+                        choices=[
+                            ("contribution", "Contribution"),
+                            ("expenditure", "Expenditure"),
+                            ("transfer", "Transfer"),
+                            ("obligation", "Obligation"),
+                        ],
+                        db_index=True,
+                        help_text="contribution / expenditure / transfer / obligation",
+                        max_length=20,
+                    ),
+                ),
+                ("amount", models.DecimalField(decimal_places=2, max_digits=14)),
+                (
+                    "currency",
+                    models.CharField(
+                        default="USD",
+                        help_text="ISO 4217 currency code",
+                        max_length=3,
+                    ),
+                ),
+                (
+                    "transaction_date",
+                    models.DateField(
+                        db_index=True,
+                        help_text="Financial event date (may equal Event.event_date)",
+                    ),
+                ),
+                (
+                    "source_transaction_uuid",
+                    models.UUIDField(
+                        blank=True,
+                        db_index=True,
+                        help_text="transaction_uuid of a related source record, if any",
+                        null=True,
+                    ),
+                ),
+                (
+                    "transaction_group_uuid",
+                    models.UUIDField(
+                        blank=True,
+                        db_index=True,
+                        help_text="group_uuid of the TransactionGroup this belongs to, if any",
+                        null=True,
+                    ),
+                ),
+                (
+                    "event",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="transaction_detail",
+                        to="sw_events.event",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Transaction",
+                "verbose_name_plural": "Transactions",
+                "db_table": "sw_transaction",
+                "indexes": [
+                    models.Index(
+                        fields=["transaction_subtype", "transaction_date"],
+                        name="idx_txn_subtype_date",
+                    )
+                ],
+            },
+        ),
+    ]

--- a/socialwarehouse/transactions/models/__init__.py
+++ b/socialwarehouse/transactions/models/__init__.py
@@ -3,8 +3,9 @@ from .transactions import (
     Expenditure,
     Obligation,
     ObligationEvent,
-    Transfer,
+    Transaction,
     TransactionGroup,
+    Transfer,
 )
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "Transfer",
     "ObligationEvent",
     "Obligation",
+    "Transaction",
     "TransactionGroup",
 ]

--- a/socialwarehouse/transactions/models/transactions.py
+++ b/socialwarehouse/transactions/models/transactions.py
@@ -7,7 +7,6 @@ from socialwarehouse.core.mixins import (
     generate_entity_uuid4,
 )
 
-
 AGENT_TYPE_CHOICES = [
     ("person", "Person"),
     ("committee", "Committee"),
@@ -49,6 +48,13 @@ GROUP_TYPE_CHOICES = [
     ("other", "Other"),
 ]
 
+TRANSACTION_SUBTYPE_CHOICES = [
+    ("contribution", "Contribution"),
+    ("expenditure", "Expenditure"),
+    ("transfer", "Transfer"),
+    ("obligation", "Obligation"),
+]
+
 
 class _TransactionBase(SourceAwareModel):
     """Shared fields for all transaction types.
@@ -80,6 +86,18 @@ class _TransactionBase(SourceAwareModel):
     amount = models.DecimalField(max_digits=14, decimal_places=2)
     transaction_date = models.DateField(db_index=True)
     description = models.TextField(blank=True, default="")
+    # Optional link to the canonical Event (event_type='transaction') that
+    # carries the canonicalization layer for this record (SW#349). Nullable
+    # and additive: existing rows are valid unlinked and can be backfilled.
+    event = models.ForeignKey(
+        "sw_events.Event",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="%(class)s_records",
+        related_query_name="%(class)s_record",
+        help_text="Canonical Event this transaction record rolls up to",
+    )
     created_at = models.DateTimeField(auto_now_add=True)
 
     class Meta:
@@ -343,3 +361,72 @@ class TransactionGroup(models.Model):
 
     def __str__(self):
         return f"{self.group_type}: {self.description[:50]}" if self.description else f"{self.group_type}"
+
+
+class Transaction(models.Model):
+    """Financial-event subtype detail of an Event (SW#349).
+
+    Mirrors the CorporateEvent / SpatioTemporalEvent / ElectoralEvent
+    pattern in the events app: a one-to-one detail row hanging off an
+    Event whose ``event_type='transaction'``. It gives transactions the
+    same first-class subtype treatment the other event kinds already
+    have, and carries the transaction-level financial summary while the
+    Event carries the canonicalization layer (canonical_attestation,
+    attestation_disagreement, amendment tracking, event_state).
+
+    The typed records (Contribution / Expenditure / Transfer /
+    ObligationEvent) link to the same Event via their nullable ``event``
+    FK; ``transaction_subtype`` names which typed family this Event's
+    transaction detail belongs to. Event participants (payer / payee)
+    are recorded through the shared ``EventParticipant`` bridge, with the
+    typed records' ``from_agent`` / ``to_agent`` fields kept as a
+    transaction-specific specialization.
+    """
+
+    event = models.OneToOneField(
+        "sw_events.Event",
+        on_delete=models.CASCADE,
+        related_name="transaction_detail",
+    )
+    transaction_subtype = models.CharField(
+        max_length=20,
+        choices=TRANSACTION_SUBTYPE_CHOICES,
+        db_index=True,
+        help_text="contribution / expenditure / transfer / obligation",
+    )
+    amount = models.DecimalField(max_digits=14, decimal_places=2)
+    currency = models.CharField(
+        max_length=3,
+        default="USD",
+        help_text="ISO 4217 currency code",
+    )
+    transaction_date = models.DateField(
+        db_index=True,
+        help_text="Financial event date (may equal Event.event_date)",
+    )
+    source_transaction_uuid = models.UUIDField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="transaction_uuid of a related source record, if any",
+    )
+    transaction_group_uuid = models.UUIDField(
+        null=True,
+        blank=True,
+        db_index=True,
+        help_text="group_uuid of the TransactionGroup this belongs to, if any",
+    )
+
+    class Meta:
+        verbose_name = "Transaction"
+        verbose_name_plural = "Transactions"
+        db_table = "sw_transaction"
+        indexes = [
+            models.Index(
+                fields=["transaction_subtype", "transaction_date"],
+                name="idx_txn_subtype_date",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.transaction_subtype}: ${self.amount} on {self.transaction_date}"

--- a/tests/unit/core/test_attestation_links.py
+++ b/tests/unit/core/test_attestation_links.py
@@ -61,13 +61,20 @@ class _SchemaManaged(TransactionTestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        with connection.schema_editor() as editor:
-            editor.create_model(cls.concrete_model)
+        # The concrete stand-in models are declared at module level, so they
+        # stay registered in the app registry (with FKs to Attestation) for the
+        # whole test session. Their tables must therefore persist for the whole
+        # session too — otherwise a later test that deletes an Attestation (e.g.
+        # the Event-canonicalization SET_NULL tests) traverses these reverse
+        # relations via Django's delete-collector and queries a dropped table.
+        # Create idempotently and do NOT drop per-class; the test DB teardown
+        # removes the tables at session end.
+        if cls.concrete_model._meta.db_table not in connection.introspection.table_names():
+            with connection.schema_editor() as editor:
+                editor.create_model(cls.concrete_model)
 
     @classmethod
     def tearDownClass(cls):
-        with connection.schema_editor() as editor:
-            editor.delete_model(cls.concrete_model)
         super().tearDownClass()
 
 

--- a/tests/unit/core/test_attestation_links.py
+++ b/tests/unit/core/test_attestation_links.py
@@ -11,7 +11,7 @@ import uuid
 from decimal import Decimal
 
 import pytest
-from django.db import connection, models
+from django.db import models
 from django.test import TransactionTestCase
 
 from socialwarehouse.core.attestation import Attestation
@@ -54,28 +54,15 @@ def _mk_attestation():
 
 
 class _SchemaManaged(TransactionTestCase):
-    """Base that creates/drops one test-only concrete model's table."""
+    """Base for the adopter stand-in tests.
+
+    The concrete stand-in models' tables are created session-wide by the
+    ``_attestation_link_test_tables`` fixture in conftest.py (the models are
+    declared at module level, so they are registered for the whole test
+    session), so these classes do not manage tables themselves.
+    """
 
     concrete_model = None
-
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        # The concrete stand-in models are declared at module level, so they
-        # stay registered in the app registry (with FKs to Attestation) for the
-        # whole test session. Their tables must therefore persist for the whole
-        # session too — otherwise a later test that deletes an Attestation (e.g.
-        # the Event-canonicalization SET_NULL tests) traverses these reverse
-        # relations via Django's delete-collector and queries a dropped table.
-        # Create idempotently and do NOT drop per-class; the test DB teardown
-        # removes the tables at session end.
-        if cls.concrete_model._meta.db_table not in connection.introspection.table_names():
-            with connection.schema_editor() as editor:
-                editor.create_model(cls.concrete_model)
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tests/unit/events/test_event_canonicalization.py
+++ b/tests/unit/events/test_event_canonicalization.py
@@ -1,0 +1,69 @@
+from datetime import date
+
+import pytest
+from django.test import TestCase
+
+from socialwarehouse.core.attestation import Attestation
+from socialwarehouse.events.models import Event
+
+
+def _mk_event(**kw):
+    defaults = dict(event_type="transaction", event_date=date(2024, 3, 1), data_source="fec")
+    defaults.update(kw)
+    return Event.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+class TestEventCanonicalization(TestCase):
+    def test_canonicalization_defaults(self):
+        e = _mk_event()
+        assert e.canonical_attestation is None
+        assert e.attestation_disagreement is False
+        assert e.is_amended is False
+        assert e.amendment_count == 0
+        assert e.event_state == "active"
+        # Existing behavior preserved: year derived from event_date.
+        assert e.year == 2024
+
+    def test_canonical_attestation_cache_links_to_attestation(self):
+        e = _mk_event()
+        att = Attestation.objects.create(
+            entity_id=e.event_uuid,
+            entity_subtype="event",
+            attestation_kind="fec",
+            data_source="fec",
+            is_canonical=True,
+        )
+        e.canonical_attestation = att
+        e.save(update_fields=["canonical_attestation"])
+        e.refresh_from_db()
+        assert e.canonical_attestation == att
+        # Reverse accessor from Attestation.
+        assert att.canonical_for_events.first() == e
+
+    def test_canonical_attestation_set_null_on_delete(self):
+        e = _mk_event()
+        att = Attestation.objects.create(
+            entity_id=e.event_uuid, entity_subtype="event", attestation_kind="fec", data_source="fec"
+        )
+        e.canonical_attestation = att
+        e.save(update_fields=["canonical_attestation"])
+        att.delete()
+        e.refresh_from_db()
+        # Event survives; cache cleared (truth lives on Attestation.is_canonical).
+        assert e.canonical_attestation is None
+
+    def test_amendment_tracking(self):
+        e = _mk_event()
+        e.is_amended = True
+        e.amendment_count = 2
+        e.event_state = "amended"
+        e.save(update_fields=["is_amended", "amendment_count", "event_state"])
+        e.refresh_from_db()
+        assert e.is_amended is True
+        assert e.amendment_count == 2
+        assert e.event_state == "amended"
+
+    def test_attestation_disagreement_flag(self):
+        e = _mk_event(attestation_disagreement=True)
+        assert e.attestation_disagreement is True

--- a/tests/unit/transactions/test_transaction_subtype.py
+++ b/tests/unit/transactions/test_transaction_subtype.py
@@ -1,0 +1,106 @@
+import uuid
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.test import TestCase
+
+from socialwarehouse.core.attestation import Attestation
+from socialwarehouse.events.models import Event, EventParticipant
+from socialwarehouse.transactions.models import Contribution, Transaction
+
+
+def _mk_transaction_event():
+    return Event.objects.create(
+        event_type="transaction", event_date=date(2024, 5, 2), data_source="fec"
+    )
+
+
+@pytest.mark.django_db
+class TestTransactionSubtype(TestCase):
+    def test_transaction_is_event_subtype_detail(self):
+        e = _mk_transaction_event()
+        txn = Transaction.objects.create(
+            event=e,
+            transaction_subtype="contribution",
+            amount=Decimal("250.00"),
+            transaction_date=date(2024, 5, 2),
+        )
+        assert txn.currency == "USD"
+        assert txn.transaction_subtype == "contribution"
+        # First-class subtype treatment: reverse one-to-one accessor on Event,
+        # mirroring corporate_detail / electoral_detail.
+        assert e.transaction_detail == txn
+
+    def test_transaction_subtype_choices(self):
+        for sub in ("contribution", "expenditure", "transfer", "obligation"):
+            e = _mk_transaction_event()
+            txn = Transaction.objects.create(
+                event=e, transaction_subtype=sub, amount=Decimal("1.00"), transaction_date=date(2024, 5, 2)
+            )
+            assert txn.transaction_subtype == sub
+
+    def test_existing_record_links_to_canonical_event(self):
+        e = _mk_transaction_event()
+        c = Contribution.objects.create(
+            from_agent_uuid=uuid.uuid4(),
+            from_agent_type="person",
+            to_agent_uuid=uuid.uuid4(),
+            to_agent_type="committee",
+            amount=Decimal("250.00"),
+            transaction_date=date(2024, 5, 2),
+            data_source="fec",
+            event=e,
+        )
+        c.refresh_from_db()
+        assert c.event == e
+        # %(class)s reverse accessor on the Event.
+        assert e.contribution_records.first() == c
+
+    def test_existing_record_event_link_nullable(self):
+        # Backward-compatible: the link is optional.
+        c = Contribution.objects.create(
+            from_agent_uuid=uuid.uuid4(),
+            from_agent_type="person",
+            to_agent_uuid=uuid.uuid4(),
+            to_agent_type="committee",
+            amount=Decimal("50.00"),
+            transaction_date=date(2024, 5, 2),
+            data_source="fec",
+        )
+        assert c.event is None
+
+    def test_event_participants_shared_bridge(self):
+        # Transaction parties recorded through the shared EventParticipant
+        # bridge (payer = source, payee = target).
+        e = _mk_transaction_event()
+        Transaction.objects.create(
+            event=e, transaction_subtype="contribution", amount=Decimal("250.00"), transaction_date=date(2024, 5, 2)
+        )
+        payer = uuid.uuid4()
+        payee = uuid.uuid4()
+        EventParticipant.objects.create(event=e, agent_uuid=payer, agent_type="person", role_in_event="source")
+        EventParticipant.objects.create(event=e, agent_uuid=payee, agent_type="committee", role_in_event="target")
+        assert e.participants.count() == 2
+        assert e.participants.filter(role_in_event="source").first().agent_uuid == payer
+
+    def test_canonical_attestation_cache_vs_truth(self):
+        # Event.canonical_attestation is the fast-lookup cache; the source of
+        # truth is Attestation.is_canonical (one canonical per entity/kind).
+        e = _mk_transaction_event()
+        Transaction.objects.create(
+            event=e, transaction_subtype="contribution", amount=Decimal("250.00"), transaction_date=date(2024, 5, 2)
+        )
+        canonical = Attestation.objects.create(
+            entity_id=e.event_uuid,
+            entity_subtype="event",
+            attestation_kind="fec",
+            data_source="fec",
+            is_canonical=True,
+        )
+        e.canonical_attestation = canonical
+        e.save(update_fields=["canonical_attestation"])
+        # Cache and truth agree.
+        truth = Attestation.canonical_for("event", e.event_uuid, "fec")
+        assert truth == canonical
+        assert e.canonical_attestation == truth


### PR DESCRIPTION
Closes #349. Part of the [F] epic #347. **The trickiest PR** — it extends an existing load-bearing model rather than adding new ones, so it's an additive refactor, verified end-to-end.

> **Stacked PR.** Base is `feature/sw351-variant-linking` (PR #354). **Merge order: #352 → #353 → #354 → this (#349).** Bases retarget to `develop` as parents land. (Authored against the SW design surface directly + cross-checked with prime-amber's recon, which cleared the additive path.)

## What

**`events.Event` gains the canonicalization layer (additive).** All event subtypes inherit it by attaching to an Event:
- `canonical_attestation` → FK to `core.Attestation` (`SET_NULL`) — a **fast-lookup cache**; the **source of truth** is `Attestation.is_canonical` (partial-unique-enforced in #350). Intentional denormalization, documented.
- `attestation_disagreement`, `is_amended`, `amendment_count`, `event_state` (active/amended/withdrawn/superseded).
- The existing `event_type` discriminator (which already had `transaction`) is **kept as-is** — no rename, no shadowing field — to avoid breaking consumers.

**`transactions.Transaction`** (`sw_transaction`) — a first-class Event subtype detail (OneToOne to Event where `event_type='transaction'`), mirroring the existing `CorporateEvent`/`SpatioTemporalEvent`/`ElectoralEvent` pattern. Carries `transaction_subtype` (contribution/expenditure/transfer/obligation), `amount`, `currency`, `transaction_date`.

**Existing typed records wired non-destructively.** `Contribution`/`Expenditure`/`Transfer`/`ObligationEvent` gain a **nullable** `event` FK (`%(class)s_records` reverse accessor) so they roll up to their canonical Event — **no destructive consolidation** of the merged four-table `_TransactionBase` design. Transaction parties use the shared `EventParticipant` bridge; the records' `from_agent`/`to_agent` fields remain a transaction-specific specialization.

## Design decisions (the two that needed ruling)

1. **Event stays in `events/`, extended in place** — not moved to `core/`. The model is the load-bearing event query surface; relocating it across apps would risk the migration. So the canonical-truth layer is **Agent + Attestation in `core/`, Event in `events/`** — documented as the pragmatic-over-symmetric choice in `architecture.md`.
2. **Additive transaction-linking**, not the ticket-literal single-table consolidation (which would break the merged 4-table design + likely downstream consumers). This realizes "Transaction is a subtype of Event" without a destructive MTI migration.

## Migrations (additive, forward-only)

- `events/0002_event_canonicalization.py` — 5 nullable AddFields + 1 index on Event.
- `transactions/0002_transaction_and_event_links.py` — nullable `event` FK on the 4 typed records + create `Transaction`.

## Tests

`tests/unit/events/test_event_canonicalization.py` (5) + `tests/unit/transactions/test_transaction_subtype.py` (6) — canonicalization defaults, `canonical_attestation` cache + reverse accessor + `SET_NULL`-on-delete, amendment tracking, Transaction-as-Event-subtype + reverse `transaction_detail`, the 4 subtype choices, the nullable record→Event link (+ backward-compat null), `EventParticipant` shared-bridge usage, and cache-vs-truth agreement with `Attestation.canonical_for(...)`.

## Verification

Isolated `events`+`transactions`+`core` sqlite harness: migrations apply cleanly on top of #348/#350/#351, `manage.py check` clean, ruff clean, **11/11 tests pass**. Full PostGIS suite runs in CI. Pre-existing develop drift stripped from the migrations (scope-clean).

## Docs

`docs/architecture.md` — Event status → Landed; placement note; full "Event supertype + canonicalization" subsection covering the cache-vs-truth redundancy and the EventParticipant reuse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Events now support state tracking with statuses: active, amended, withdrawn, or superseded.
  * Events can record amendment history, including amendment counts and modification flags.
  * Events now link to canonical attestations for reference resolution.
  * Transactions are now connected to events with specific subtypes (contribution, expenditure, transfer, obligation).
  * Enhanced querying performance with optimized indexes on event states and transaction subtypes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->