### PR TITLE
fix(warehouse): correct migration dependency app label (unblocks CI) (#356)

### DIFF
--- a/socialwarehouse/warehouse/migrations/0006_partition_fact_tables.py
+++ b/socialwarehouse/warehouse/migrations/0006_partition_fact_tables.py
@@ -218,7 +218,7 @@ ALTER TABLE sw_fact_person_score ADD PRIMARY KEY (id);
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("warehouse", "0005_fact_electoral_contest_fk"),
+        ("sw_warehouse", "0005_fact_electoral_contest_fk"),
     ]
 
     operations = [

--- a/socialwarehouse/warehouse/migrations/0007_monitoring_models.py
+++ b/socialwarehouse/warehouse/migrations/0007_monitoring_models.py
@@ -12,7 +12,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("warehouse", "0006_partition_fact_tables"),
+        ("sw_warehouse", "0006_partition_fact_tables"),
     ]
 
     operations = [


### PR DESCRIPTION
Closes #356.

## The bug

`warehouse` migrations `0006_partition_fact_tables` and `0007_monitoring_models` declare their parent dependency with the literal `("warehouse", ...)` instead of the app's registered label `("sw_warehouse", ...)` (`warehouse/apps.py` sets `label = "sw_warehouse"`). The migration loader resolves the mismatched app name to a `DummyNode`, so `manage.py migrate` aborts the whole graph with:

```
NodeNotFoundError: Migration sw_warehouse.0006_partition_fact_tables dependencies
reference nonexistent parent node ('warehouse', '0005_fact_electoral_contest_fk')
```

## Why this matters now

**CI on `develop` has been red since these migrations landed.** The `ci.yml` "Test suite" job runs `manage.py migrate`, which fails at this step for *every* PR — so nothing can reach CI-green. Confirmed via `gh run list --branch develop`: pushes #341–#345 all failed with this exact error. This is the sole reason the F-epic PRs (#352–#355) show CI-blocked despite passing local verification.

## The fix

Two one-line changes: `("warehouse", ...)` → `("sw_warehouse", ...)` in the two migrations' `dependencies`.

## Verification

- `grep` repo-wide: **zero** remaining `("warehouse", ...)` dependencies.
- Graph-consistency check: every `sw_warehouse` intra-app dependency now resolves to an existing migration node (0001–0007 all present).
- The full `migrate` runs under PostGIS in CI (no GIS locally) — this PR's own CI run is the end-to-end test; it should now pass the migrate step that every other PR currently dies on.

Scope-clean: touches only the two broken dependency lines, nothing else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal database migration dependencies for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->