### PR TITLE
ci(notify): Slack alert on CI failure for develop/main pushes (#358)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,3 +131,28 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose down -v
+
+  notify-failure:
+    name: Notify on CI failure
+    runs-on: ubuntu-latest
+    needs: [test]
+    # Alert only when a push to a protected branch fails. This is the
+    # silent-red-on-develop case (#358): PRs merged for ~10 days while
+    # develop's CI was red and nobody was told. Scoped to push events on
+    # develop/main so PR runs don't spam the channel.
+    if: ${{ failure() && github.event_name == 'push' && (github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main') }}
+
+    steps:
+      - name: Post failure alert to Slack
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL secret not set; skipping Slack alert."
+            echo "Configure the repo secret SLACK_WEBHOOK_URL to enable red-CI alerting (#358)."
+            exit 0
+          fi
+          text=":red_circle: socialwarehouse CI failed on ${{ github.ref_name }} (by ${{ github.actor }}) -- ${RUN_URL}"
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --data "{\"text\": \"${text}\"}" "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
Part of #358 (repo-health remediation — the **alerting** item).

## Why

develop's CI was silently red for ~10 days (#356/#357 + the upstream siege-utilities wheel bug) while PRs #341–#345 merged anyway. Nobody was alerted. This adds failure alerting so a red protected branch is visible immediately.

## What

A `notify-failure` job in `ci.yml` that:
- runs only on **push** events to **`develop` or `main`** (`if: failure() && github.event_name == 'push' && ref in (develop, main)`) — so PR runs don't spam the channel;
- posts a one-line failure summary (branch, actor, run URL) to Slack via an incoming webhook;
- is **gated on the `SLACK_WEBHOOK_URL` repo secret**: if the secret is unset, the step logs a hint and `exit 0`s. So this change is **inert until the secret is configured** — it cannot itself break CI, and merging it early is safe.

## Action needed (Dheeraj / repo admin)

Add a repo secret **`SLACK_WEBHOOK_URL`** (an incoming-webhook URL for the electinfo CI channel). Until then the job no-ops.

## Scope / sequencing

- YAML validated locally (`yaml.safe_load` parses; 3 jobs: test, docker-build, notify-failure).
- This PR's **own CI will be red** for now — it inherits the same two pre-existing blockers (#357 warehouse fix + the unpublished siege-utilities 3.22.1). It should merge as part of the remediation batch **after** develop is genuinely green, per #358 sequencing.
- Pairs with the other two #358 items: **required status checks** on develop (admin) and the **blind-window audit** (after green).